### PR TITLE
available exchanges should have alphabetical order

### DIFF
--- a/lib/cryptoexchange/client.rb
+++ b/lib/cryptoexchange/client.rb
@@ -2,7 +2,7 @@ module Cryptoexchange
   class Client
     class << self
       def available_exchanges
-        Dir.entries("./lib/cryptoexchange/exchanges")[2..-1].freeze
+        Dir.entries("./lib/cryptoexchange/exchanges")[2..-1].sort.freeze
       end
     end
 


### PR DESCRIPTION
I screw up this method when adding new client but it couldn't automatically have alphabetical order, so I need to add `sort` on it, otherwise this test will never pass