### PR TITLE
implement Quoine(ready)

### DIFF
--- a/lib/cryptoexchange/exchanges/quoine/market.rb
+++ b/lib/cryptoexchange/exchanges/quoine/market.rb
@@ -1,0 +1,8 @@
+module Cryptoexchange::Exchanges
+  module Quoine
+    class Market
+      NAME = 'quoine'
+      API_URL = 'https://api.quoine.com'
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/quoine/models/market_pair.rb
+++ b/lib/cryptoexchange/exchanges/quoine/models/market_pair.rb
@@ -1,0 +1,8 @@
+module Cryptoexchange::Exchanges
+  module Quoine
+    module Models
+      class MarketPair < Cryptoexchange::Models::MarketPair
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/quoine/models/ticker.rb
+++ b/lib/cryptoexchange/exchanges/quoine/models/ticker.rb
@@ -1,0 +1,8 @@
+module Cryptoexchange::Exchanges
+  module Quoine
+    module Models
+      class Ticker < Cryptoexchange::Models::Ticker
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/quoine/services/market.rb
+++ b/lib/cryptoexchange/exchanges/quoine/services/market.rb
@@ -1,0 +1,50 @@
+module Cryptoexchange::Exchanges
+  module Quoine
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            false
+          end
+        end
+
+        def fetch
+          output = super(self.ticker_url)
+          adapt_all(output)
+        end
+
+        def ticker_url
+          "#{Cryptoexchange::Exchanges::Quoine::Market::API_URL}/products"
+        end
+
+        def adapt_all(output)
+          output.map do |pair|
+            market_pair = Cryptoexchange::Exchanges::Quoine::Models::MarketPair.new(
+                            base: pair['base_currency'],
+                            target: pair['quoted_currency'],
+                            market: Quoine::Market::NAME
+                          )
+            adapt(pair, market_pair)
+          end
+        end
+
+        def adapt(output, market_pair)
+          ticker           = Quoine::Models::Ticker.new
+          ticker.base      = market_pair.base
+          ticker.target    = market_pair.target
+          ticker.market    = Quoine::Market::NAME
+          #use last price 24h
+          ticker.last      = NumericHelper.to_d(output['last_price_24h'])
+          ticker.bid       = NumericHelper.to_d(output['market_bid'])
+          ticker.ask       = NumericHelper.to_d(output['market_ask'])
+          ticker.high      = NumericHelper.to_d(output['high_market_ask'])
+          ticker.low       = NumericHelper.to_d(output['low_market_bid'])
+          ticker.volume    = NumericHelper.to_d(output['volume_24h'])
+          ticker.timestamp = DateTime.now.to_time.to_i
+          ticker.payload   = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/quoine/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/quoine/services/pairs.rb
@@ -1,0 +1,26 @@
+module Cryptoexchange::Exchanges
+  module Quoine
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Quoine::Market::API_URL}/products"
+
+        def fetch
+          output = super
+          adapt(output)
+        end
+
+        def adapt(output)
+          market_pairs = []
+          output.each do |pair|
+            market_pairs << Quoine::Models::MarketPair.new(
+                              base: pair['base_currency'],
+                              target: pair['quoted_currency'],
+                              market: Quoine::Market::NAME
+                            )
+          end
+          market_pairs
+        end
+      end
+    end
+  end
+end

--- a/spec/exchanges/quoine/integration/market_spec.rb
+++ b/spec/exchanges/quoine/integration/market_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+RSpec.describe 'Quoine integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+
+  it 'fetch pairs' do
+    pairs = client.pairs('quoine')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.market).to eq 'quoine'
+  end
+
+  it 'fetch ticker' do
+    btc_usd_pair = Cryptoexchange::Models::MarketPair.new(base: 'btc', target: 'usd', market: 'quoine')
+    ticker = client.ticker(btc_usd_pair)
+
+    expect(ticker.base).to eq 'BTC'
+    expect(ticker.target).to eq 'USD'
+    expect(ticker.market).to eq 'quoine'
+    expect(ticker.last).to_not be nil
+    expect(ticker.high).to_not be nil
+    expect(ticker.low).to_not be nil
+    expect(ticker.volume).to_not be nil
+    expect(ticker.timestamp).to be_a Numeric
+    expect(ticker.payload).to_not be nil
+  end
+end

--- a/spec/exchanges/quoine/market_spec.rb
+++ b/spec/exchanges/quoine/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Quoine::Market do
+  it { expect(described_class::NAME).to eq 'quoine' }
+  it { expect(described_class::API_URL).to eq 'https://api.quoine.com' }
+end


### PR DESCRIPTION
Something need to ask, according to Quoine's api doc, there is another api `product/:id` [link](https://developers.quoine.com/?ruby#get-a-product) which has single currency's market data.

But it uses `:id` to show it, since we don't have another columns can save on models `market_pair`, so we just list all market ticker? 