### PR TITLE
Allow range for year match in tests

### DIFF
--- a/spec/exchanges/allcoin/integration/market_spec.rb
+++ b/spec/exchanges/allcoin/integration/market_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Allcoin integration specs' do
     expect(ticker.bid).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 

--- a/spec/exchanges/anx/integration/market_spec.rb
+++ b/spec/exchanges/anx/integration/market_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'ANX integration specs' do
     expect(ticker.bid).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/bit_z/integration/market_spec.rb
+++ b/spec/exchanges/bit_z/integration/market_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'BitZ integration specs' do
     expect(ticker.low).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/bitbay/integration/market_spec.rb
+++ b/spec/exchanges/bitbay/integration/market_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Bitbay integration specs' do
     expect(ticker.low).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/bitcoin_indonesia/integration/market_spec.rb
+++ b/spec/exchanges/bitcoin_indonesia/integration/market_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'BitcoinIndonesia integration specs' do
     expect(ticker.low).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/bitfinex/integration/market_spec.rb
+++ b/spec/exchanges/bitfinex/integration/market_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Bitfinex integration specs' do
     expect(ticker.high).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/bitflyer/integration/market_spec.rb
+++ b/spec/exchanges/bitflyer/integration/market_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Bitflyer integration specs' do
     expect(ticker.bid).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/bithumb/integration/market_spec.rb
+++ b/spec/exchanges/bithumb/integration/market_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Bithumb integration specs' do
     expect(ticker.low).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/bitkonan/integration/market_spec.rb
+++ b/spec/exchanges/bitkonan/integration/market_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Bitkonan integration specs' do
     expect(ticker.low).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/bitso/integration/market_spec.rb
+++ b/spec/exchanges/bitso/integration/market_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Bitso integration specs' do
     expect(ticker.high).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/bitstamp/integration/market_spec.rb
+++ b/spec/exchanges/bitstamp/integration/market_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Bitstamp integration specs' do
     expect(ticker.low).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/bittrex/integration/market_spec.rb
+++ b/spec/exchanges/bittrex/integration/market_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'Bittrex integration specs' do
     expect(ticker.low).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/bleutrade/integration/market_spec.rb
+++ b/spec/exchanges/bleutrade/integration/market_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Bleutrade integration specs' do
     expect(ticker.high).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/btcc/integration/market_spec.rb
+++ b/spec/exchanges/btcc/integration/market_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Btcc integration specs' do
     expect(ticker.bid).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/bter/integration/market_spec.rb
+++ b/spec/exchanges/bter/integration/market_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Bter integration specs' do
     expect(ticker.bid).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/ccex/integration/market_spec.rb
+++ b/spec/exchanges/ccex/integration/market_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Ccex integration specs' do
     expect(ticker.high).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/chbtc/integration/market_spec.rb
+++ b/spec/exchanges/chbtc/integration/market_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Chbtc integration specs' do
     expect(ticker.high).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/coin_exchange/integration/market_spec.rb
+++ b/spec/exchanges/coin_exchange/integration/market_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'CoinExchange integration specs' do
     expect(ticker.high).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/coincheck/integration/market_spec.rb
+++ b/spec/exchanges/coincheck/integration/market_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Coincheck integration specs' do
     expect(ticker.bid).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/coinmate/integration/market_spec.rb
+++ b/spec/exchanges/coinmate/integration/market_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'CoinMate integration specs' do
     expect(ticker.low).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 

--- a/spec/exchanges/coinone/integration/market_spec.rb
+++ b/spec/exchanges/coinone/integration/market_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Coinone integration specs' do
     expect(ticker.low).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/cryptopia/integration/market_spec.rb
+++ b/spec/exchanges/cryptopia/integration/market_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Cryptopia integration specs' do
     expect(ticker.volume).to be_a Numeric
     expect(ticker.change).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/ether_delta/integration/market_spec.rb
+++ b/spec/exchanges/ether_delta/integration/market_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'EtherDelta integration specs' do
     expect(ticker.ask).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/gatecoin/integration/market_spec.rb
+++ b/spec/exchanges/gatecoin/integration/market_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Gatecoin integration specs' do
     expect(ticker.high).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/gdax/integration/market_spec.rb
+++ b/spec/exchanges/gdax/integration/market_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Gdax integration specs' do
     expect(ticker.ask).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/gemini/integration/market_spec.rb
+++ b/spec/exchanges/gemini/integration/market_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Gemini integration specs' do
     expect(ticker.ask).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 

--- a/spec/exchanges/hitbtc/integration/market_spec.rb
+++ b/spec/exchanges/hitbtc/integration/market_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Hitbtc integration specs' do
     expect(ticker.high).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/huobi/integration/market_spec.rb
+++ b/spec/exchanges/huobi/integration/market_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Huobi integration specs' do
     expect(ticker.high).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/itbit/integration/market_spec.rb
+++ b/spec/exchanges/itbit/integration/market_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Itbit integration specs' do
     expect(ticker.high).to be_a Numeric
     expect(ticker.low).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/jubi/integration/market_spec.rb
+++ b/spec/exchanges/jubi/integration/market_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Jubi integration specs' do
     expect(ticker.high).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/korbit/integration/market_spec.rb
+++ b/spec/exchanges/korbit/integration/market_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Korbit integration specs' do
     expect(ticker.high).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/kraken/integration/market_spec.rb
+++ b/spec/exchanges/kraken/integration/market_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Kraken integration specs' do
     expect(ticker.high).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/lakebtc/integration/market_spec.rb
+++ b/spec/exchanges/lakebtc/integration/market_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Lakebtc integration specs' do
     expect(ticker.bid).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/liqui/integration/market_spec.rb
+++ b/spec/exchanges/liqui/integration/market_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Liqui integration specs' do
     expect(ticker.high).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/litebiteu/integration/market_spec.rb
+++ b/spec/exchanges/litebiteu/integration/market_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Litebiteu integration specs' do
     expect(ticker.volume).to be_a Numeric
     expect(ticker.last).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/livecoin/integration/market_spec.rb
+++ b/spec/exchanges/livecoin/integration/market_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Livecoin integration specs' do
     expect(ticker.high).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/novaexchange/integration/market_spec.rb
+++ b/spec/exchanges/novaexchange/integration/market_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Novaexchange integration specs' do
     expect(ticker.high).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 

--- a/spec/exchanges/okcoin/integration/market_spec.rb
+++ b/spec/exchanges/okcoin/integration/market_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Okcoin integration specs' do
     expect(ticker.high).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 
@@ -43,7 +43,7 @@ RSpec.describe 'Okcoin integration specs' do
     expect(ticker.high).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/poloniex/integration/market_spec.rb
+++ b/spec/exchanges/poloniex/integration/market_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Poloniex integration specs' do
     expect(ticker.high).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/qryptos/integration/market_spec.rb
+++ b/spec/exchanges/qryptos/integration/market_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Qryptos integration specs' do
     expect(ticker.low).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/quadrigacx/integration/market_spec.rb
+++ b/spec/exchanges/quadrigacx/integration/market_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Quadrigacx integration specs' do
     expect(ticker.bid).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to be <= Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/quoine/integration/market_spec.rb
+++ b/spec/exchanges/quoine/integration/market_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Quoine integration specs' do
     expect(ticker.low).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/therocktrading/integration/market_spec.rb
+++ b/spec/exchanges/therocktrading/integration/market_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Therocktrading integration specs' do
     expect(ticker.high).to be_a Numeric
     expect(ticker.low).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 
@@ -47,7 +47,7 @@ RSpec.describe 'Therocktrading integration specs' do
     expect(ticker.high).to be_a Numeric
     expect(ticker.low).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 

--- a/spec/exchanges/tidex/integration/market_spec.rb
+++ b/spec/exchanges/tidex/integration/market_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Tidex integration specs' do
     expect(ticker.high).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/tux_exchange/intergration/market_spec.rb
+++ b/spec/exchanges/tux_exchange/intergration/market_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'TuxExchange integration specs' do
     expect(ticker.high).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/viabtc/integration/market_spec.rb
+++ b/spec/exchanges/viabtc/integration/market_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Viabtc integration specs' do
     expect(ticker.high).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/yobit/integration/market_spec.rb
+++ b/spec/exchanges/yobit/integration/market_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Yobit integration specs' do
     expect(ticker.high).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/yunbi/integration/market_spec.rb
+++ b/spec/exchanges/yunbi/integration/market_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Yunbi integration specs' do
     expect(ticker.high).to_not be nil
     expect(ticker.volume).to_not be nil
     expect(ticker.timestamp).to be_a Numeric
-    expect(DateTime.strptime(ticker.timestamp.to_s, '%s').year).to eq Date.today.year
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
 end


### PR DESCRIPTION
- What is the purpose of this Pull Request?
This resolves an issue with the test suite where the current year was being used as the reference in checking a timestamp. This would have caused test failures when the calendar year rolled over (in 2018).

- What is the related issue for this Pull Request?
https://github.com/coingecko/cryptoexchange/issues/174