### PR TITLE
implemented cobinhood pairs, markets, orderbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Or install it yourself as:
 | Cex               | Y       | Y          | Y       |         | Y           |
 | CCex              | Y       |            |         |         | Y           |
 | CHBTC             | Y       |            |         |         | User-Defined|
+| Cobinhood         | Y       | Y          |         |         | Y           |
 | Coincheck         | Y       |            |         |         | User-Defined|
 | CoinExchange      | Y       |            |         |         | Y           |
 | Coinmate          | Y       | Y          |         |         | User-Defined|

--- a/lib/cryptoexchange/exchanges/cobinhood/market.rb
+++ b/lib/cryptoexchange/exchanges/cobinhood/market.rb
@@ -1,0 +1,8 @@
+module Cryptoexchange::Exchanges
+  module Cobinhood
+    class Market
+      NAME = 'cobinhood'
+      API_URL = 'https://api.cobinhood.com/v1'
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/cobinhood/services/market.rb
+++ b/lib/cryptoexchange/exchanges/cobinhood/services/market.rb
@@ -1,0 +1,49 @@
+module Cryptoexchange::Exchanges
+  module Cobinhood
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          trading_pair_id = "#{market_pair.base}-#{market_pair.target}"
+          "#{Cryptoexchange::Exchanges::Cobinhood::Market::API_URL}/market/tickers/#{trading_pair_id}"
+        end
+
+        def adapt(output, market_pair)
+          ticker = Cryptoexchange::Models::Ticker.new
+          market = output['result']["ticker"]
+
+          ticker.base      = market_pair.base
+          ticker.target    = market_pair.target
+          ticker.market    = Cobinhood::Market::NAME
+          ticker.last      = NumericHelper.to_d(market['last_trade_price'])
+          ticker.high      = NumericHelper.to_d(market['24h_high'])
+          ticker.low       = NumericHelper.to_d(market['24h_low'])
+          ticker.ask       = NumericHelper.to_d(market['lowest_ask'])
+          ticker.bid       = NumericHelper.to_d(market['highest_bid'])
+          ticker.volume    = NumericHelper.to_d(market['24h_volume'])
+          ticker.timestamp = DateTime.now.to_time.to_i
+          ticker.payload   = market
+          ticker
+        end
+
+        private
+
+        def http_get(endpoint)
+          ctx = OpenSSL::SSL::SSLContext.new
+          ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
+          fetch_response = HTTP.timeout(:write => 2, :connect => 5, :read => 8).get(endpoint, ssl_context: ctx)
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/cobinhood/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/cobinhood/services/order_book.rb
@@ -1,0 +1,53 @@
+module Cryptoexchange::Exchanges
+  module Cobinhood
+    module Services
+      class OrderBook < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          trading_pair_id = "#{market_pair.base}-#{market_pair.target}"
+          "#{Cryptoexchange::Exchanges::Cobinhood::Market::API_URL}/market/orderbooks/#{trading_pair_id}"
+        end
+
+        def adapt(output, market_pair)
+          order_book = Cryptoexchange::Models::OrderBook.new
+          order_book.base      = market_pair.base
+          order_book.target    = market_pair.target
+          order_book.market    = Cobinhood::Market::NAME
+          order_book.asks      = adapt_orders output["result"]["orderbook"]['asks']
+          order_book.bids      = adapt_orders output["result"]["orderbook"]['bids']
+          order_book.timestamp = DateTime.now.to_time.to_i
+          order_book.payload   = output
+          order_book
+        end
+
+        def adapt_orders(orders)
+          orders.collect do |price, amount, count|
+            Cryptoexchange::Models::Order.new \
+              price: price,
+              amount: amount,
+              timestamp: DateTime.now.to_time.to_i
+          end
+        end
+
+        private
+
+        def http_get(endpoint)
+          ctx = OpenSSL::SSL::SSLContext.new
+          ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
+          fetch_response = HTTP.timeout(:write => 2, :connect => 5, :read => 8).get(endpoint, ssl_context: ctx)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/cobinhood/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/cobinhood/services/pairs.rb
@@ -1,0 +1,31 @@
+module Cryptoexchange::Exchanges
+  module Cobinhood
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Cobinhood::Market::API_URL}/market/trading_pairs"
+
+        def fetch_via_api(endpoint = self.class::PAIRS_URL)
+          ctx = OpenSSL::SSL::SSLContext.new
+          ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
+          fetch_response = HTTP.timeout(:write => 2, :connect => 5, :read => 8).get(endpoint, ssl_context: ctx)
+          JSON.parse(fetch_response.to_s)
+        end
+
+        def fetch
+          output = super
+          adapt(output)
+        end
+
+        def adapt(output)
+          pairs = output['result']["trading_pairs"]
+          pairs.map do |pair|
+            Cryptoexchange::Models::MarketPair.new \
+              base: pair['base_currency_id'],
+              target: pair['quote_currency_id'],
+              market: Cobinhood::Market::NAME
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/Cobinhood/integration_specs_fetch_order_book.yml
+++ b/spec/cassettes/vcr_cassettes/Cobinhood/integration_specs_fetch_order_book.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.cobinhood.com/v1/market/orderbooks/BTC-USD
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.cobinhood.com
+      User-Agent:
+      - http.rb/1.0.4
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - https://cobinhood.com
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sat, 06 Jan 2018 10:12:03 GMT
+      Content-Length:
+      - '827'
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - clear
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"result":{"orderbook":{"sequence":0,"bids":[["13001.1","1","0.01"],["13001","1","0.04804863"],["13000","1","0.004"],["10005","1","0.05"],["10000.1","1","0.03"],["10000","1","0.00265705"],["958.3","1","0.76"],["958.2","1","0.08"],["958.1","1","0.4"],["56","1","1"],["11","1","9"],["10","1","5"],["5.6","1","5"]],"asks":[["17999.8","1","0.05313375"],["17999.9","1","0.2033"],["18000","1","0.01"],["18199.9","1","0.01919825"],["18200","1","0.0199576"],["18497.6","1","0.1"],["18499.3","1","0.0069417"],["18499.8","1","0.002"],["18990","1","0.05"],["19000","1","0.05"],["19128","1","0.3"],["19129","1","0.00358099"],["19400","1","0.01"],["24780","2","0.39793939"],["24789","1","0.0205"],["24895","1","0.51712562"],["26000","1","0.03"],["175000","2","0.0597289"],["400000","1","0.03"],["999999999.9","1","0.002"]]}}}'
+    http_version: 
+  recorded_at: Sat, 06 Jan 2018 10:12:03 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/vcr_cassettes/Cobinhood/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/Cobinhood/integration_specs_fetch_pairs.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.cobinhood.com/v1/market/trading_pairs
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.cobinhood.com
+      User-Agent:
+      - http.rb/1.0.4
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - https://cobinhood.com
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 06 Jan 2018 10:01:46 GMT
+      Content-Length:
+      - '1192'
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - clear
+      Connection:
+      - close
+    body:
+      encoding: ASCII-8BIT
+      string: '{"success":true,"result":{"trading_pairs":[{"id":"BTC-USD","base_currency_id":"BTC","quote_currency_id":"USD","base_max_size":"10000","base_min_size":"0.002","quote_increment":"0.1"},{"id":"ETH-USD","base_currency_id":"ETH","quote_currency_id":"USD","base_max_size":"100000","base_min_size":"0.04","quote_increment":"0.01"},{"id":"ETH-BTC","base_currency_id":"ETH","quote_currency_id":"BTC","base_max_size":"100000","base_min_size":"0.04","quote_increment":"0.000001"},{"id":"COB-USD","base_currency_id":"COB","quote_currency_id":"USD","base_max_size":"100000","base_min_size":"100","quote_increment":"0.001"},{"id":"COB-BTC","base_currency_id":"COB","quote_currency_id":"BTC","base_max_size":"100000","base_min_size":"100","quote_increment":"0.00000001"},{"id":"CMT-BTC","base_currency_id":"CMT","quote_currency_id":"BTC","base_max_size":"100000","base_min_size":"150","quote_increment":"0.00000001"},{"id":"COB-ETH","base_currency_id":"COB","quote_currency_id":"ETH","base_max_size":"100000","base_min_size":"100","quote_increment":"0.000001"},{"id":"CMT-ETH","base_currency_id":"CMT","quote_currency_id":"ETH","base_max_size":"100000","base_min_size":"150","quote_increment":"0.000001"}]}}'
+    http_version: 
+  recorded_at: Sat, 06 Jan 2018 10:01:46 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/vcr_cassettes/Cobinhood/integration_specs_fetch_pairs_and_assign_the_correct_base/target.yml
+++ b/spec/cassettes/vcr_cassettes/Cobinhood/integration_specs_fetch_pairs_and_assign_the_correct_base/target.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.cobinhood.com/v1/market/trading_pairs
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.cobinhood.com
+      User-Agent:
+      - http.rb/1.0.4
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - https://cobinhood.com
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 06 Jan 2018 10:01:46 GMT
+      Content-Length:
+      - '1192'
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - clear
+      Connection:
+      - close
+    body:
+      encoding: ASCII-8BIT
+      string: '{"success":true,"result":{"trading_pairs":[{"id":"BTC-USD","base_currency_id":"BTC","quote_currency_id":"USD","base_max_size":"10000","base_min_size":"0.002","quote_increment":"0.1"},{"id":"ETH-USD","base_currency_id":"ETH","quote_currency_id":"USD","base_max_size":"100000","base_min_size":"0.04","quote_increment":"0.01"},{"id":"ETH-BTC","base_currency_id":"ETH","quote_currency_id":"BTC","base_max_size":"100000","base_min_size":"0.04","quote_increment":"0.000001"},{"id":"COB-USD","base_currency_id":"COB","quote_currency_id":"USD","base_max_size":"100000","base_min_size":"100","quote_increment":"0.001"},{"id":"COB-BTC","base_currency_id":"COB","quote_currency_id":"BTC","base_max_size":"100000","base_min_size":"100","quote_increment":"0.00000001"},{"id":"CMT-BTC","base_currency_id":"CMT","quote_currency_id":"BTC","base_max_size":"100000","base_min_size":"150","quote_increment":"0.00000001"},{"id":"COB-ETH","base_currency_id":"COB","quote_currency_id":"ETH","base_max_size":"100000","base_min_size":"100","quote_increment":"0.000001"},{"id":"CMT-ETH","base_currency_id":"CMT","quote_currency_id":"ETH","base_max_size":"100000","base_min_size":"150","quote_increment":"0.000001"}]}}'
+    http_version: 
+  recorded_at: Sat, 06 Jan 2018 10:01:46 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/vcr_cassettes/Cobinhood/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/Cobinhood/integration_specs_fetch_ticker.yml
@@ -1,0 +1,40 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.cobinhood.com/v1/market/tickers/BTC-USD
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.cobinhood.com
+      User-Agent:
+      - http.rb/1.0.4
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - https://cobinhood.com
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 06 Jan 2018 10:01:46 GMT
+      Content-Length:
+      - '244'
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - clear
+      Connection:
+      - close
+    body:
+      encoding: ASCII-8BIT
+      string: '{"success":true,"result":{"ticker":{"trading_pair_id":"BTC-USD","timestamp":1515232860000,"24h_high":"16000","24h_low":"10000","24h_open":"14888","24h_volume":"0.29536807","last_trade_price":"13001","highest_bid":"13001","lowest_ask":"13001"}}}'
+    http_version: 
+  recorded_at: Sat, 06 Jan 2018 10:01:47 GMT
+recorded_with: VCR 3.0.3

--- a/spec/exchanges/cobinhood/integration/market_spec.rb
+++ b/spec/exchanges/cobinhood/integration/market_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+RSpec.describe 'Cobinhood integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:usd_btc_pair) { Cryptoexchange::Models::MarketPair.new(base: 'BTC', target: 'USD', market: 'cobinhood') }
+
+  it 'fetch pairs' do
+    pairs = client.pairs('cobinhood')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.market).to eq 'cobinhood'
+  end
+
+  it 'fetch pairs and assign the correct base/target' do
+    pairs = client.pairs('cobinhood')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to eq 'BTC'
+    expect(pair.target).to eq 'USD'
+    expect(pair.market).to eq 'cobinhood'
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(usd_btc_pair)
+
+    expect(ticker.base).to eq 'BTC'
+    expect(ticker.target).to eq 'USD'
+    expect(ticker.market).to eq 'cobinhood'
+    expect(ticker.ask).to be_a Numeric
+    expect(ticker.bid).to be_a Numeric
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.high).to be_a Numeric
+    expect(ticker.low).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+    expect(ticker.timestamp).to be_a Numeric
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
+    expect(ticker.payload).to_not be nil
+  end
+
+  it 'fetch order book' do
+    pair = Cryptoexchange::Models::MarketPair.new(base: 'BTC', target: 'USD', market: 'cobinhood')
+    order_book = client.order_book(pair)
+
+    expect(order_book.payload['error']).to_not eq 'Invalid Symbols Pair'
+    expect(order_book.base).to eq 'BTC'
+    expect(order_book.target).to eq 'USD'
+    expect(order_book.market).to eq 'cobinhood'
+    expect(order_book.asks).to_not be_empty
+    expect(order_book.bids).to_not be_empty
+    expect(order_book.asks.first.price).to_not be_nil
+    expect(order_book.bids.first.amount).to_not be_nil
+    expect(order_book.bids.first.timestamp).to_not be_nil
+    expect(order_book.asks.count).to be > 10
+    expect(order_book.bids.count).to be > 10
+    expect(order_book.timestamp).to be_a Numeric
+    expect(order_book.payload).to_not be nil
+  end
+
+end

--- a/spec/exchanges/cobinhood/market_spec.rb
+++ b/spec/exchanges/cobinhood/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Cobinhood::Market do
+  it { expect(described_class::NAME).to eq 'cobinhood' }
+  it { expect(described_class::API_URL).to eq 'https://api.cobinhood.com/v1' }
+end


### PR DESCRIPTION
- Introduces Cobinhood exchange with implementation of Market, Ticker, and Order book.
- [Y] I have added Specs
- [N] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [Y] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly

I am not 100% sure how to confirm volume is indeed expressed in base.  However, I did confirm the Volume matches what's displayed on Cobinhood's exchange website.
  