### PR TITLE
Rethrow errors as a Cryptoexchange Error Class

### DIFF
--- a/lib/cryptoexchange/error.rb
+++ b/lib/cryptoexchange/error.rb
@@ -1,0 +1,16 @@
+module Cryptoexchange
+  class Error < StandardError
+  end
+
+  class HttpConnectionError < Error
+  end
+
+  class HttpTimeoutError < Error
+  end
+
+  class JsonParseError < Error
+  end
+
+  class TypeFormatError < Error
+  end
+end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Client do
+  let(:client) { Cryptoexchange::Client.new }
+
+  it 'throws Cryptoexchange::HttpConnectionError' do
+    expect(StringHelper).to receive(:camelize) { "Gdax" }
+    expect_any_instance_of(Cryptoexchange::Exchanges::Gdax::Services::Pairs).to receive(:fetch) { raise HTTP::ConnectionError }
+    expect{ client.pairs('gdax') }.to raise_error(Cryptoexchange::HttpConnectionError)
+  end
+
+  it 'throws Cryptoexchange::HttpTimeoutError' do
+    expect(StringHelper).to receive(:camelize) { "Gdax" }
+    expect_any_instance_of(Cryptoexchange::Exchanges::Gdax::Services::Pairs).to receive(:fetch) { raise HTTP::TimeoutError }
+    expect{ client.pairs('gdax') }.to raise_error(Cryptoexchange::HttpTimeoutError)
+  end
+
+  it 'throws Cryptoexchange::JsonParseError' do
+    expect(StringHelper).to receive(:camelize) { "Gdax" }
+    expect_any_instance_of(Cryptoexchange::Exchanges::Gdax::Services::Pairs).to receive(:fetch) { raise JSON::ParserError }
+    expect{ client.pairs('gdax') }.to raise_error(Cryptoexchange::JsonParseError)
+  end
+
+  it 'throws Cryptoexchange::TypeFormatError' do
+    expect(StringHelper).to receive(:camelize) { "Gdax" }
+    expect_any_instance_of(Cryptoexchange::Exchanges::Gdax::Services::Pairs).to receive(:fetch) { raise TypeError }
+    expect{ client.pairs('gdax') }.to raise_error(Cryptoexchange::TypeFormatError)
+  end
+
+end


### PR DESCRIPTION
- What is the purpose of this Pull Request?
Continuation of https://github.com/coingecko/cryptoexchange/pull/245 to catch and throw it as a Cryptoexchange Error as to be expected how to handle the error

- What is the related issue for this Pull Request?
https://github.com/coingecko/cryptoexchange/issues/244
