### PR TITLE
Append ExtStock: ticker, orderbook, trades

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Or install it yourself as:
 | EtherDelta        | Y       |            |         |         | Y           |
 | Ethfinex          | Y       | Y          | Y       |         | Y           |
 | Exmo              | Y       | Y          | Y       |         | Y           |
+| Extstock          | Y       | Y          | Y       |         | Y           |
 | Gate              | Y       | Y          | Y       |         | Y           |
 | Gatecoin          | Y       |            |         |         | Y           |
 | GDAX              | Y       |            |         |         | Y           |

--- a/lib/cryptoexchange/exchanges/extstock/market.rb
+++ b/lib/cryptoexchange/exchanges/extstock/market.rb
@@ -1,0 +1,8 @@
+module Cryptoexchange::Exchanges
+  module Extstock
+    class Market
+      NAME = 'extstock'
+      API_URL = 'https://extstock.com/api/v1'
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/extstock/services/market.rb
+++ b/lib/cryptoexchange/exchanges/extstock/services/market.rb
@@ -1,0 +1,40 @@
+module Cryptoexchange::Exchanges
+  module Extstock
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          base = market_pair.base.downcase
+          target = market_pair.target.downcase
+          "#{Cryptoexchange::Exchanges::Extstock::Market::API_URL}/tickers/#{base}_#{target}"
+        end
+
+        def adapt(output, market_pair)
+          ticker           = Cryptoexchange::Models::Ticker.new
+          ticker.base      = market_pair.base
+          ticker.target    = market_pair.target
+          ticker.market    = Extstock::Market::NAME
+          ticker.last      = NumericHelper.to_d(HashHelper.dig(output, 'ticker', 'last'))
+          ticker.bid       = NumericHelper.to_d(HashHelper.dig(output, 'ticker', 'buy'))
+          ticker.ask       = NumericHelper.to_d(HashHelper.dig(output, 'ticker', 'sell'))
+          ticker.high      = NumericHelper.to_d(HashHelper.dig(output, 'ticker', 'high'))
+          ticker.low       = NumericHelper.to_d(HashHelper.dig(output, 'ticker', 'low'))
+          ticker.volume    = NumericHelper.to_d(HashHelper.dig(output, 'ticker', 'vol'))
+          ticker.timestamp = NumericHelper.to_d(HashHelper.dig(output, 'at'))
+          ticker.payload   = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/extstock/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/extstock/services/order_book.rb
@@ -1,0 +1,51 @@
+module Cryptoexchange::Exchanges
+  module Extstock
+    module Services
+      class OrderBook < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          base = market_pair.base.downcase
+          target = market_pair.target.downcase
+
+          "#{Cryptoexchange::Exchanges::Extstock::Market::API_URL}/order_book?market=#{base}_#{target}"
+        end
+
+        def adapt(output, market_pair)
+          order_book = Cryptoexchange::Models::OrderBook.new
+
+          order_book.base      = market_pair.base
+          order_book.target    = market_pair.target
+          order_book.market    = Extstock::Market::NAME
+          order_book.asks      = adapt_orders output['asks']
+          order_book.bids      = adapt_orders output['bids']
+          order_book.payload   = output
+          order_book
+        end
+
+        def adapt_orders(orders)
+          orders.collect do |order_entry|
+            price = order_entry['price']
+            amount = order_entry['volume']
+            timestamp = Time.parse(order_entry['created_at']).to_i
+
+            Cryptoexchange::Models::Order.new(
+              price: price,
+              amount: amount,
+              timestamp: timestamp
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/extstock/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/extstock/services/pairs.rb
@@ -1,0 +1,31 @@
+module Cryptoexchange::Exchanges
+  module Extstock
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Extstock::Market::API_URL}/markets"
+
+        def fetch
+          output = super
+          adapt(output)
+        end
+
+        def adapt(output)
+          market_pairs = []
+
+          output.each do |pair|
+            base, target = pair["name"].split("/")
+            market_pair = Cryptoexchange::Models::MarketPair.new(
+              base: base,
+              target: target,
+              market: Extstock::Market::NAME
+            )
+
+            market_pairs << market_pair
+          end
+
+          market_pairs
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/extstock/services/trades.rb
+++ b/lib/cryptoexchange/exchanges/extstock/services/trades.rb
@@ -1,0 +1,34 @@
+module Cryptoexchange::Exchanges
+  module Extstock
+    module Services
+      class Trades < Cryptoexchange::Services::Market
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          base = market_pair.base.downcase
+          target = market_pair.target.downcase
+          "#{Cryptoexchange::Exchanges::Extstock::Market::API_URL}/trades?market=#{base}_#{target}"
+        end
+
+        def adapt(output, market_pair)
+          output.collect do |trade|
+            tr = Cryptoexchange::Models::Trade.new
+            tr.trade_id  = trade['id']
+            tr.base      = market_pair.base
+            tr.target    = market_pair.target
+            tr.market    = Extstock::Market::NAME
+            tr.type      = trade['side']
+            tr.price     = trade['price']
+            tr.amount    = trade['funds']
+            tr.timestamp = Time.parse(trade['created_at']).to_i
+            tr.payload   = trade
+            tr
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/Extstock/integration_specs_fetch_order_book.yml
+++ b/spec/cassettes/vcr_cassettes/Extstock/integration_specs_fetch_order_book.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://extstock.com/api/v1/order_book?market=eth_ltc
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - extstock.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 14 Mar 2018 07:51:31 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '10021'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=dac3c4036fccdf8a69ff567d59dc5a92d1521013890; expires=Thu, 14-Mar-19
+        07:51:30 GMT; path=/; domain=.extstock.com; HttpOnly; Secure
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Id:
+      - a2326b1c-31ca-4c55-b249-37cc872b60a5
+      Etag:
+      - '"b732d54722a020cd086a808ab64c8792"'
+      X-Runtime:
+      - '0.198535'
+      X-Powered-By:
+      - Phusion Passenger 5.2.1
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 3fb527d268ce30cc-SIN
+    body:
+      encoding: ASCII-8BIT
+      string: '{"asks":[{"id":1867209,"side":"sell","ord_type":"limit","price":"3.9840416","avg_price":"3.9840416","state":"wait","market":"eth_ltc","created_at":"2018-03-13T17:58:51-04:00","volume":"0.0704","remaining_volume":"0.01024733","executed_volume":"0.06015267","trades_count":2},{"id":1867799,"side":"sell","ord_type":"limit","price":"3.9840416","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-13T18:05:38-04:00","volume":"0.0188","remaining_volume":"0.0188","executed_volume":"0.0","trades_count":0},{"id":1868092,"side":"sell","ord_type":"limit","price":"3.9840416","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-13T18:08:27-04:00","volume":"0.06898","remaining_volume":"0.06898","executed_volume":"0.0","trades_count":0},{"id":1868633,"side":"sell","ord_type":"limit","price":"3.9840416","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-13T18:15:06-04:00","volume":"0.03","remaining_volume":"0.03","executed_volume":"0.0","trades_count":0},{"id":1868757,"side":"sell","ord_type":"limit","price":"3.9840416","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-13T18:16:42-04:00","volume":"0.04312","remaining_volume":"0.04312","executed_volume":"0.0","trades_count":0},{"id":1869547,"side":"sell","ord_type":"limit","price":"3.9840416","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-13T18:24:25-04:00","volume":"0.09107","remaining_volume":"0.09107","executed_volume":"0.0","trades_count":0},{"id":1869722,"side":"sell","ord_type":"limit","price":"3.9840416","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-13T18:26:03-04:00","volume":"0.08551598","remaining_volume":"0.08551598","executed_volume":"0.0","trades_count":0},{"id":1870255,"side":"sell","ord_type":"limit","price":"3.9840416","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-13T18:34:09-04:00","volume":"0.0557","remaining_volume":"0.0557","executed_volume":"0.0","trades_count":0},{"id":1870546,"side":"sell","ord_type":"limit","price":"3.9840416","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-13T18:38:30-04:00","volume":"0.00069","remaining_volume":"0.00069","executed_volume":"0.0","trades_count":0},{"id":1871263,"side":"sell","ord_type":"limit","price":"3.9840416","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-13T18:46:08-04:00","volume":"0.05776","remaining_volume":"0.05776","executed_volume":"0.0","trades_count":0},{"id":1873138,"side":"sell","ord_type":"limit","price":"3.9840416","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-13T19:14:49-04:00","volume":"0.0654","remaining_volume":"0.0654","executed_volume":"0.0","trades_count":0},{"id":1873548,"side":"sell","ord_type":"limit","price":"3.9840416","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-13T19:19:35-04:00","volume":"0.0618","remaining_volume":"0.0618","executed_volume":"0.0","trades_count":0},{"id":1873779,"side":"sell","ord_type":"limit","price":"3.9840416","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-13T19:22:05-04:00","volume":"0.05404014","remaining_volume":"0.05404014","executed_volume":"0.0","trades_count":0},{"id":1875175,"side":"sell","ord_type":"limit","price":"3.9840416","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-13T19:36:13-04:00","volume":"0.10594397","remaining_volume":"0.10594397","executed_volume":"0.0","trades_count":0},{"id":1875272,"side":"sell","ord_type":"limit","price":"3.9840416","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-13T19:37:18-04:00","volume":"0.01414517","remaining_volume":"0.01414517","executed_volume":"0.0","trades_count":0},{"id":1875754,"side":"sell","ord_type":"limit","price":"3.9840416","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-13T19:45:03-04:00","volume":"0.1272","remaining_volume":"0.1272","executed_volume":"0.0","trades_count":0},{"id":1875782,"side":"sell","ord_type":"limit","price":"3.9840416","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-13T19:46:01-04:00","volume":"0.059","remaining_volume":"0.059","executed_volume":"0.0","trades_count":0},{"id":1876527,"side":"sell","ord_type":"limit","price":"3.9840416","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-13T19:54:16-04:00","volume":"0.01654","remaining_volume":"0.01654","executed_volume":"0.0","trades_count":0},{"id":1848041,"side":"sell","ord_type":"limit","price":"3.9842946","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-13T14:29:23-04:00","volume":"0.04","remaining_volume":"0.04","executed_volume":"0.0","trades_count":0},{"id":1875155,"side":"sell","ord_type":"limit","price":"3.98448688","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-13T19:36:06-04:00","volume":"0.00567382","remaining_volume":"0.00567382","executed_volume":"0.0","trades_count":0}],"bids":[{"id":1895159,"side":"buy","ord_type":"limit","price":"3.98222","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-13T23:20:00-04:00","volume":"0.01","remaining_volume":"0.01","executed_volume":"0.0","trades_count":0},{"id":1899418,"side":"buy","ord_type":"limit","price":"3.98222","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-14T00:04:49-04:00","volume":"0.06373971","remaining_volume":"0.06373971","executed_volume":"0.0","trades_count":0},{"id":1895618,"side":"buy","ord_type":"limit","price":"3.9821188","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-13T23:24:49-04:00","volume":"0.06429655","remaining_volume":"0.06429655","executed_volume":"0.0","trades_count":0},{"id":1896088,"side":"buy","ord_type":"limit","price":"3.9821188","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-13T23:29:45-04:00","volume":"0.1","remaining_volume":"0.1","executed_volume":"0.0","trades_count":0},{"id":1896386,"side":"buy","ord_type":"limit","price":"3.9821188","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-13T23:33:11-04:00","volume":"0.03507836","remaining_volume":"0.03507836","executed_volume":"0.0","trades_count":0},{"id":1896594,"side":"buy","ord_type":"limit","price":"3.9821188","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-13T23:35:59-04:00","volume":"0.07218959","remaining_volume":"0.07218959","executed_volume":"0.0","trades_count":0},{"id":1897448,"side":"buy","ord_type":"limit","price":"3.9821188","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-13T23:45:51-04:00","volume":"0.03057","remaining_volume":"0.03057","executed_volume":"0.0","trades_count":0},{"id":1897695,"side":"buy","ord_type":"limit","price":"3.9821188","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-13T23:47:44-04:00","volume":"0.02822","remaining_volume":"0.02822","executed_volume":"0.0","trades_count":0},{"id":1898406,"side":"buy","ord_type":"limit","price":"3.9821188","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-13T23:54:19-04:00","volume":"0.062","remaining_volume":"0.062","executed_volume":"0.0","trades_count":0},{"id":1898992,"side":"buy","ord_type":"limit","price":"3.9821188","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-14T00:00:28-04:00","volume":"0.01459","remaining_volume":"0.01459","executed_volume":"0.0","trades_count":0},{"id":1899083,"side":"buy","ord_type":"limit","price":"3.9821188","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-14T00:01:11-04:00","volume":"0.0584","remaining_volume":"0.0584","executed_volume":"0.0","trades_count":0},{"id":1899683,"side":"buy","ord_type":"limit","price":"3.9821188","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-14T00:07:46-04:00","volume":"0.0521","remaining_volume":"0.0521","executed_volume":"0.0","trades_count":0},{"id":1902352,"side":"buy","ord_type":"limit","price":"3.981208","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-14T00:42:37-04:00","volume":"0.03156099","remaining_volume":"0.03156099","executed_volume":"0.0","trades_count":0},{"id":1901545,"side":"buy","ord_type":"limit","price":"3.98052996","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-14T00:34:37-04:00","volume":"0.10672","remaining_volume":"0.10672","executed_volume":"0.0","trades_count":0},{"id":1902004,"side":"buy","ord_type":"limit","price":"3.98052996","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-14T00:38:56-04:00","volume":"0.078","remaining_volume":"0.078","executed_volume":"0.0","trades_count":0},{"id":1902187,"side":"buy","ord_type":"limit","price":"3.98052996","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-14T00:40:51-04:00","volume":"0.04425","remaining_volume":"0.04425","executed_volume":"0.0","trades_count":0},{"id":1902856,"side":"buy","ord_type":"limit","price":"3.98052996","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-14T00:48:16-04:00","volume":"0.0458303","remaining_volume":"0.0458303","executed_volume":"0.0","trades_count":0},{"id":1903548,"side":"buy","ord_type":"limit","price":"3.98052996","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-14T00:55:10-04:00","volume":"0.041","remaining_volume":"0.041","executed_volume":"0.0","trades_count":0},{"id":1903962,"side":"buy","ord_type":"limit","price":"3.98052996","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-14T00:59:16-04:00","volume":"0.0044","remaining_volume":"0.0044","executed_volume":"0.0","trades_count":0},{"id":1904520,"side":"buy","ord_type":"limit","price":"3.98052996","avg_price":"0.0","state":"wait","market":"eth_ltc","created_at":"2018-03-14T01:05:21-04:00","volume":"0.1095","remaining_volume":"0.1095","executed_volume":"0.0","trades_count":0}]}'
+    http_version: 
+  recorded_at: Wed, 14 Mar 2018 07:51:30 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Extstock/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/Extstock/integration_specs_fetch_pairs.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://extstock.com/api/v1/markets
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - extstock.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 14 Mar 2018 07:51:29 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '801'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=dba2deaad4b168ae04248f084ff1d9d671521013889; expires=Thu, 14-Mar-19
+        07:51:29 GMT; path=/; domain=.extstock.com; HttpOnly; Secure
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Id:
+      - 1aacfbf4-ca42-49e3-b2e9-a7d4a595d8ac
+      Etag:
+      - '"05588a85459500435c38f848b6153765"'
+      X-Runtime:
+      - '0.007673'
+      X-Powered-By:
+      - Phusion Passenger 5.2.1
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 3fb527c6bf7731b6-SIN
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"id":"btc_usd","name":"BTC/USD"},{"id":"btc_eur","name":"BTC/EUR"},{"id":"ltc_btc","name":"LTC/BTC"},{"id":"ltc_usd","name":"LTC/USD"},{"id":"ltc_eur","name":"LTC/EUR"},{"id":"dash_btc","name":"DASH/BTC"},{"id":"dash_usd","name":"DASH/USD"},{"id":"dash_eur","name":"DASH/EUR"},{"id":"dash_ltc","name":"DASH/LTC"},{"id":"dash_eth","name":"DASH/ETH"},{"id":"eth_btc","name":"ETH/BTC"},{"id":"eth_usd","name":"ETH/USD"},{"id":"eth_eur","name":"ETH/EUR"},{"id":"eth_ltc","name":"ETH/LTC"},{"id":"bch_usd","name":"BCH/USD"},{"id":"bch_btc","name":"BCH/BTC"},{"id":"bch_eur","name":"BCH/EUR"},{"id":"bch_ltc","name":"BCH/LTC"},{"id":"bch_eth","name":"BCH/ETH"},{"id":"bch_dash","name":"BCH/DASH"},{"id":"nebl_eth","name":"NEBL/ETH"},{"id":"xnode_eth","name":"XNODE/ETH"},{"id":"ctr_eth","name":"CTR/ETH"}]'
+    http_version: 
+  recorded_at: Wed, 14 Mar 2018 07:51:28 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Extstock/integration_specs_fetch_pairs_and_assign_the_correct_base/target.yml
+++ b/spec/cassettes/vcr_cassettes/Extstock/integration_specs_fetch_pairs_and_assign_the_correct_base/target.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://extstock.com/api/v1/markets
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - extstock.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 14 Mar 2018 07:51:30 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '801'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=dd22825675b45f268b7ee865bc306691e1521013889; expires=Thu, 14-Mar-19
+        07:51:29 GMT; path=/; domain=.extstock.com; HttpOnly; Secure
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Id:
+      - 4726e28f-f004-47d8-93d1-48d6a6a91645
+      Etag:
+      - '"05588a85459500435c38f848b6153765"'
+      X-Runtime:
+      - '0.006180'
+      X-Powered-By:
+      - Phusion Passenger 5.2.1
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 3fb527caad7531f2-SIN
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"id":"btc_usd","name":"BTC/USD"},{"id":"btc_eur","name":"BTC/EUR"},{"id":"ltc_btc","name":"LTC/BTC"},{"id":"ltc_usd","name":"LTC/USD"},{"id":"ltc_eur","name":"LTC/EUR"},{"id":"dash_btc","name":"DASH/BTC"},{"id":"dash_usd","name":"DASH/USD"},{"id":"dash_eur","name":"DASH/EUR"},{"id":"dash_ltc","name":"DASH/LTC"},{"id":"dash_eth","name":"DASH/ETH"},{"id":"eth_btc","name":"ETH/BTC"},{"id":"eth_usd","name":"ETH/USD"},{"id":"eth_eur","name":"ETH/EUR"},{"id":"eth_ltc","name":"ETH/LTC"},{"id":"bch_usd","name":"BCH/USD"},{"id":"bch_btc","name":"BCH/BTC"},{"id":"bch_eur","name":"BCH/EUR"},{"id":"bch_ltc","name":"BCH/LTC"},{"id":"bch_eth","name":"BCH/ETH"},{"id":"bch_dash","name":"BCH/DASH"},{"id":"nebl_eth","name":"NEBL/ETH"},{"id":"xnode_eth","name":"XNODE/ETH"},{"id":"ctr_eth","name":"CTR/ETH"}]'
+    http_version: 
+  recorded_at: Wed, 14 Mar 2018 07:51:28 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Extstock/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/Extstock/integration_specs_fetch_ticker.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://extstock.com/api/v1/tickers/eth_ltc
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - extstock.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 14 Mar 2018 07:51:30 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '140'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d795d6f6a608f0267a05495574d3c71a51521013890; expires=Thu, 14-Mar-19
+        07:51:30 GMT; path=/; domain=.extstock.com; HttpOnly; Secure
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Id:
+      - f6469f2c-f868-4d16-b7a2-c5d34bcdd7e0
+      Etag:
+      - '"da0b45f2c0041bf973aac85e75023837"'
+      X-Runtime:
+      - '0.287977'
+      X-Powered-By:
+      - Phusion Passenger 5.2.1
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 3fb527cdec8c3096-SIN
+    body:
+      encoding: ASCII-8BIT
+      string: '{"at":1521013890,"ticker":{"buy":"3.98222","sell":"3.9840416","low":"3.93656868","high":"3.9840416","last":"3.9840416","vol":"29.49518585"}}'
+    http_version: 
+  recorded_at: Wed, 14 Mar 2018 07:51:29 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Extstock/integration_specs_fetch_trades.yml
+++ b/spec/cassettes/vcr_cassettes/Extstock/integration_specs_fetch_trades.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://extstock.com/api/v1/trades?market=eth_ltc
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - extstock.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 14 Mar 2018 08:00:22 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '7708'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=deae3b49e312fd0b69ed4a2b1613729941521014421; expires=Thu, 14-Mar-19
+        08:00:21 GMT; path=/; domain=.extstock.com; HttpOnly; Secure
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Id:
+      - 1b3f5a62-df85-4f67-a159-d0977b4f3a44
+      Etag:
+      - '"af82c85a8366a66fcb0b1e95cdbc154c"'
+      X-Runtime:
+      - '0.098430'
+      X-Powered-By:
+      - Phusion Passenger 5.2.1
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 3fb534c7bb0630cc-SIN
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"id":1078227,"price":"3.9840416","volume":"0.01396131","funds":"0.055622439830496","market":"eth_ltc","created_at":"2018-03-14T04:00:02-04:00","side":null},{"id":1078226,"price":"3.9840416","volume":"0.05776","funds":"0.230118242816","market":"eth_ltc","created_at":"2018-03-14T04:00:01-04:00","side":null},{"id":1078225,"price":"3.9840416","volume":"0.00069","funds":"0.002748988704","market":"eth_ltc","created_at":"2018-03-14T04:00:01-04:00","side":null},{"id":1078224,"price":"3.9840416","volume":"0.0557","funds":"0.22191111712","market":"eth_ltc","created_at":"2018-03-14T04:00:01-04:00","side":null},{"id":1078223,"price":"3.9840416","volume":"0.02188869","funds":"0.087205451529504","market":"eth_ltc","created_at":"2018-03-14T04:00:01-04:00","side":null},{"id":1078071,"price":"3.9840416","volume":"0.06362729","funds":"0.253493770255264","market":"eth_ltc","created_at":"2018-03-14T03:55:37-04:00","side":null},{"id":1078070,"price":"3.9840416","volume":"0.09107","funds":"0.362826668512","market":"eth_ltc","created_at":"2018-03-14T03:55:37-04:00","side":null},{"id":1078069,"price":"3.9840416","volume":"0.00370271","funds":"0.014751750672736","market":"eth_ltc","created_at":"2018-03-14T03:55:37-04:00","side":null},{"id":1077973,"price":"3.9840416","volume":"0.03941729","funds":"0.157040123119264","market":"eth_ltc","created_at":"2018-03-14T03:51:49-04:00","side":null},{"id":1077972,"price":"3.9840416","volume":"0.03","funds":"0.119521248","market":"eth_ltc","created_at":"2018-03-14T03:51:49-04:00","side":null},{"id":1077971,"price":"3.9840416","volume":"0.06898","funds":"0.274819189568","market":"eth_ltc","created_at":"2018-03-14T03:51:48-04:00","side":null},{"id":1077970,"price":"3.9840416","volume":"0.0188","funds":"0.07489998208","market":"eth_ltc","created_at":"2018-03-14T03:51:48-04:00","side":null},{"id":1077969,"price":"3.9840416","volume":"0.01024733","funds":"0.040825789008928","market":"eth_ltc","created_at":"2018-03-14T03:51:48-04:00","side":null},{"id":1077945,"price":"3.9840416","volume":"0.04472316","funds":"0.178178929923456","market":"eth_ltc","created_at":"2018-03-14T03:51:03-04:00","side":null},{"id":1077881,"price":"3.9840416","volume":"0.01542951","funds":"0.061471809707616","market":"eth_ltc","created_at":"2018-03-14T03:48:42-04:00","side":null},{"id":1077880,"price":"3.9840416","volume":"0.00957049","funds":"0.038129230292384","market":"eth_ltc","created_at":"2018-03-14T03:48:42-04:00","side":null},{"id":1077834,"price":"3.9840416","volume":"0.02","funds":"0.079680832","market":"eth_ltc","created_at":"2018-03-14T03:47:57-04:00","side":null},{"id":1077789,"price":"3.9840416","volume":"0.03402","funds":"0.135537095232","market":"eth_ltc","created_at":"2018-03-14T03:46:09-04:00","side":null},{"id":1077709,"price":"3.9840416","volume":"0.01060951","funds":"0.042268729195616","market":"eth_ltc","created_at":"2018-03-14T03:43:20-04:00","side":null},{"id":1077708,"price":"3.9840416","volume":"0.01749049","funds":"0.069682839764384","market":"eth_ltc","created_at":"2018-03-14T03:43:20-04:00","side":null},{"id":1077664,"price":"3.9840416","volume":"0.01779989","funds":"0.070915502235424","market":"eth_ltc","created_at":"2018-03-14T03:41:26-04:00","side":null},{"id":1077652,"price":"3.9840416","volume":"0.00510962","funds":"0.020356938640192","market":"eth_ltc","created_at":"2018-03-14T03:40:52-04:00","side":null},{"id":1077651,"price":"3.9840416","volume":"0.02909038","funds":"0.115897284079808","market":"eth_ltc","created_at":"2018-03-14T03:40:52-04:00","side":null},{"id":1077605,"price":"3.9840416","volume":"0.07010413","funds":"0.279297770251808","market":"eth_ltc","created_at":"2018-03-14T03:39:18-04:00","side":null},{"id":1077604,"price":"3.9840416","volume":"0.00811555","funds":"0.03233268880688","market":"eth_ltc","created_at":"2018-03-14T03:39:18-04:00","side":null},{"id":1077602,"price":"3.9840416","volume":"0.01368445","funds":"0.05451941807312","market":"eth_ltc","created_at":"2018-03-14T03:39:03-04:00","side":null},{"id":1077601,"price":"3.9840416","volume":"0.0213","funds":"0.08486008608","market":"eth_ltc","created_at":"2018-03-14T03:39:02-04:00","side":null},{"id":1077600,"price":"3.9840416","volume":"0.02937877","funds":"0.117046241836832","market":"eth_ltc","created_at":"2018-03-14T03:39:02-04:00","side":null},{"id":1077589,"price":"3.9840416","volume":"0.01362123","funds":"0.054267546963168","market":"eth_ltc","created_at":"2018-03-14T03:38:30-04:00","side":null},{"id":1077588,"price":"3.9840416","volume":"0.034","funds":"0.1354574144","market":"eth_ltc","created_at":"2018-03-14T03:38:30-04:00","side":null},{"id":1077587,"price":"3.9840416","volume":"0.03407877","funds":"0.135771237356832","market":"eth_ltc","created_at":"2018-03-14T03:38:30-04:00","side":null},{"id":1077516,"price":"3.9840416","volume":"0.00192123","funds":"0.007654260243168","market":"eth_ltc","created_at":"2018-03-14T03:36:06-04:00","side":null},{"id":1077515,"price":"3.9840416","volume":"0.02477877","funds":"0.098719650476832","market":"eth_ltc","created_at":"2018-03-14T03:36:05-04:00","side":null},{"id":1077443,"price":"3.9840416","volume":"0.059","funds":"0.2350584544","market":"eth_ltc","created_at":"2018-03-14T03:32:49-04:00","side":null},{"id":1077369,"price":"3.9840416","volume":"0.04622123","funds":"0.184147303123168","market":"eth_ltc","created_at":"2018-03-14T03:30:41-04:00","side":null},{"id":1077368,"price":"3.9840416","volume":"0.01041247","funds":"0.041483713638752","market":"eth_ltc","created_at":"2018-03-14T03:30:41-04:00","side":null},{"id":1077363,"price":"3.9840416","volume":"0.02","funds":"0.079680832","market":"eth_ltc","created_at":"2018-03-14T03:30:24-04:00","side":null},{"id":1077135,"price":"3.9840416","volume":"0.03396895","funds":"0.13533370990832","market":"eth_ltc","created_at":"2018-03-14T03:21:23-04:00","side":null},{"id":1077134,"price":"3.9840416","volume":"0.02803105","funds":"0.11167686929168","market":"eth_ltc","created_at":"2018-03-14T03:21:23-04:00","side":null},{"id":1077069,"price":"3.9840416","volume":"0.03266895","funds":"0.13015445582832","market":"eth_ltc","created_at":"2018-03-14T03:18:04-04:00","side":null},{"id":1077068,"price":"3.9840416","volume":"0.00033105","funds":"0.00131891697168","market":"eth_ltc","created_at":"2018-03-14T03:18:03-04:00","side":null},{"id":1077041,"price":"3.9840416","volume":"0.02","funds":"0.079680832","market":"eth_ltc","created_at":"2018-03-14T03:16:43-04:00","side":null},{"id":1077008,"price":"3.9840416","volume":"0.01565459","funds":"0.062368537790944","market":"eth_ltc","created_at":"2018-03-14T03:15:24-04:00","side":null},{"id":1077007,"price":"3.9840416","volume":"0.00434541","funds":"0.017312294209056","market":"eth_ltc","created_at":"2018-03-14T03:15:24-04:00","side":null},{"id":1076921,"price":"3.9840416","volume":"0.0067745","funds":"0.0269898898192","market":"eth_ltc","created_at":"2018-03-14T03:11:51-04:00","side":null},{"id":1076920,"price":"3.9840416","volume":"0.0923588","funds":"0.36796130132608","market":"eth_ltc","created_at":"2018-03-14T03:11:51-04:00","side":null},{"id":1076919,"price":"3.9840416","volume":"0.04727223","funds":"0.188334530844768","market":"eth_ltc","created_at":"2018-03-14T03:11:51-04:00","side":null},{"id":1076794,"price":"3.9840416","volume":"0.00832777","funds":"0.033178182115232","market":"eth_ltc","created_at":"2018-03-14T03:07:33-04:00","side":null},{"id":1076793,"price":"3.9840416","volume":"0.0151","funds":"0.06015902816","market":"eth_ltc","created_at":"2018-03-14T03:07:33-04:00","side":null},{"id":1076792,"price":"3.9840416","volume":"0.0073479","funds":"0.02927433927264","market":"eth_ltc","created_at":"2018-03-14T03:07:33-04:00","side":null}]'
+    http_version: 
+  recorded_at: Wed, 14 Mar 2018 08:00:20 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/extstock/integration/market_spec.rb
+++ b/spec/exchanges/extstock/integration/market_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+require 'pry'
+
+RSpec.describe 'Extstock integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:eth_ltc_pair) { Cryptoexchange::Models::MarketPair.new(base: 'ETH', target: 'LTC', market: 'extstock') }
+
+  it 'fetch pairs' do
+    pairs = client.pairs('extstock')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.market).to eq 'extstock'
+  end
+
+  it 'fetch pairs and assign the correct base/target' do
+    pairs = client.pairs('extstock')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.market).to eq 'extstock'
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(eth_ltc_pair)
+
+    expect(ticker.base).to eq 'ETH'
+    expect(ticker.target).to eq 'LTC'
+    expect(ticker.market).to eq 'extstock'
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.bid).to be_a Numeric
+    expect(ticker.ask).to be_a Numeric
+    expect(ticker.high).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+    expect(ticker.timestamp).to be_a Numeric
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
+    expect(ticker.payload).to_not be nil
+  end
+
+  it 'fetch order_book' do
+    order_book = client.order_book(eth_ltc_pair)
+
+    expect(order_book.base).to eq eth_ltc_pair.base
+    expect(order_book.target).to eq eth_ltc_pair.target
+    expect(order_book.market).to eq eth_ltc_pair.market
+    expect(order_book.asks).to be_a Array
+    expect(order_book.bids).to be_a Array
+    expect(order_book.payload).to_not be nil
+  end
+
+  it 'fetch trades' do
+    trades = client.trades(eth_ltc_pair)
+    first_trade_result = trades.first
+
+    expect(first_trade_result.trade_id).to_not be nil
+    expect(first_trade_result.base).to eq eth_ltc_pair.base
+    expect(first_trade_result.target).to eq eth_ltc_pair.target
+    expect(first_trade_result.market).to eq eth_ltc_pair.market
+    # response['side'] is always returning nil currently seems like a bug from ExtStock
+    # expect(first_trade_result.type).to_not be nil
+    expect(first_trade_result.price).to_not be nil
+  end
+end

--- a/spec/exchanges/extstock/market_spec.rb
+++ b/spec/exchanges/extstock/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Extstock::Market do
+  it { expect(described_class::NAME).to eq 'extstock' }
+  it { expect(described_class::API_URL).to eq 'https://extstock.com/api/v1' }
+end


### PR DESCRIPTION
- What is the purpose of this Pull Request?
append **ExtStock** ticker, order_book, trades

- What is the related issue for this Pull Request?
https://github.com/coingecko/cryptoexchange/issues/348

- [x] I have added Specs
- [x] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [x] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly


