### PR TITLE
[#hotfix] use D to log the latest 24h volume

### DIFF
--- a/lib/cryptoexchange/exchanges/btc_alpha/services/market.rb
+++ b/lib/cryptoexchange/exchanges/btc_alpha/services/market.rb
@@ -16,7 +16,7 @@ module Cryptoexchange::Exchanges
         def ticker_url(market_pair)
           base = market_pair.base
           target = market_pair.target
-          "#{Cryptoexchange::Exchanges::BtcAlpha::Market::TICKER_URL}/charts/#{base}_#{target}/1/chart?limit=1"
+          "#{Cryptoexchange::Exchanges::BtcAlpha::Market::TICKER_URL}/charts/#{base}_#{target}/D/chart?limit=1"
         end
 
         def adapt(output, market_pair)

--- a/spec/cassettes/vcr_cassettes/BtcAlpha/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/BtcAlpha/integration_specs_fetch_ticker.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://btc-alpha.com/api/charts/BTC_USD/1/chart?limit=1
+    uri: https://btc-alpha.com/api/charts/BTC_USD/D/chart?limit=1
     body:
       encoding: UTF-8
       string: ''
@@ -19,7 +19,7 @@ http_interactions:
       message: Moved Permanently
     headers:
       Date:
-      - Thu, 08 Mar 2018 02:30:25 GMT
+      - Thu, 22 Mar 2018 15:35:59 GMT
       Content-Type:
       - text/html; charset=utf-8
       Transfer-Encoding:
@@ -27,10 +27,10 @@ http_interactions:
       Connection:
       - close
       Set-Cookie:
-      - __cfduid=d4f35dc711554ad6a9169a9cb4f9cb5831520476224; expires=Fri, 08-Mar-19
-        02:30:24 GMT; path=/; domain=.btc-alpha.com; HttpOnly; Secure
+      - __cfduid=d9918c7ea91c3016202c722b32183863d1521732958; expires=Fri, 22-Mar-19
+        15:35:58 GMT; path=/; domain=.btc-alpha.com; HttpOnly; Secure
       Location:
-      - "/api/charts/BTC_USD/1/chart/?limit=1"
+      - "/api/charts/BTC_USD/D/chart/?limit=1"
       Vary:
       - Accept-Language
       Content-Language:
@@ -48,15 +48,15 @@ http_interactions:
       Server:
       - cloudflare
       Cf-Ray:
-      - 3f81e1346a6a7014-SIN
+      - 3ff9bb30de3878f8-LAX
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 08 Mar 2018 02:30:25 GMT
+  recorded_at: Thu, 22 Mar 2018 15:35:59 GMT
 - request:
     method: get
-    uri: https://btc-alpha.com/api/charts/BTC_USD/1/chart/?limit=1
+    uri: https://btc-alpha.com/api/charts/BTC_USD/D/chart/?limit=1
     body:
       encoding: UTF-8
       string: ''
@@ -73,7 +73,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 08 Mar 2018 02:30:26 GMT
+      - Thu, 22 Mar 2018 15:35:59 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -81,14 +81,14 @@ http_interactions:
       Connection:
       - close
       Set-Cookie:
-      - __cfduid=d73320ebcf3cfbc35e4f04187cea403dc1520476225; expires=Fri, 08-Mar-19
-        02:30:25 GMT; path=/; domain=.btc-alpha.com; HttpOnly; Secure
+      - __cfduid=d44559d27798b00061c7337cd24153eab1521732959; expires=Fri, 22-Mar-19
+        15:35:59 GMT; path=/; domain=.btc-alpha.com; HttpOnly; Secure
       Vary:
       - Accept, Accept-Language
       Allow:
       - GET, HEAD, OPTIONS
       Etag:
-      - '"813b234ed2f7d239446c9a143a3b7a6c"'
+      - '"12a45bb503af27a0648e071b07bd8663"'
       Content-Language:
       - en
       Strict-Transport-Security:
@@ -104,10 +104,10 @@ http_interactions:
       Server:
       - cloudflare
       Cf-Ray:
-      - 3f81e1381eac1117-SIN
+      - 3ff9bb356e3377a8-LAX
     body:
       encoding: UTF-8
-      string: '[{"time":1520476200,"open":9934.664,"close":9936.719,"low":9934.664,"high":9936.719,"volume":0.098484}]'
+      string: '[{"time":1521676800,"open":9167.0,"close":8850.79,"low":8707.208,"high":9367.85,"volume":76.03202}]'
     http_version: 
-  recorded_at: Thu, 08 Mar 2018 02:30:26 GMT
+  recorded_at: Thu, 22 Mar 2018 15:35:59 GMT
 recorded_with: VCR 4.0.0


### PR DESCRIPTION
- What is the purpose of this Pull Request? fix btc alpha's volume always return in one minute, not 24 hrs
- What is the related issue for this Pull Request? #377 
- [x] I have added Specs
- [x] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [x] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly


