### PR TITLE
Implement FEX ticker

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Or install it yourself as:
 | Exmo              | Y       | Y          | Y       |         | Y           |
 | Extstock          | Y       | Y          | Y       |         | Y           |
 | Exx               | Y       | Y          | Y       |         | Y           |
+| Fex               | Y       | N          | N       |         | Y           |
 | Fisco             | Y       | Y          | Y       |         | Y           |
 | Forkdelta         | Y       | N          | N       |         | Y           |
 | Freiexchange      | Y       | Y          |         |         | User-Defined|

--- a/lib/cryptoexchange/exchanges/fex/market.rb
+++ b/lib/cryptoexchange/exchanges/fex/market.rb
@@ -1,0 +1,8 @@
+module Cryptoexchange::Exchanges
+  module Fex
+    class Market
+      NAME = 'fex'
+      API_URL = 'http://api.fexpro.io/api'
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/fex/services/market.rb
+++ b/lib/cryptoexchange/exchanges/fex/services/market.rb
@@ -1,0 +1,52 @@
+module Cryptoexchange::Exchanges
+  module Fex
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            false
+          end
+        end
+
+        def fetch
+          output = super ticker_url
+          adapt_all output
+        end
+
+        def ticker_url
+          "#{Cryptoexchange::Exchanges::Fex::Market::API_URL}/market/ticker"
+        end
+
+        def adapt_all(output)
+          output.map do |ticker|
+            base, target = ticker['symbol'].split("/")
+            market_pair = Cryptoexchange::Models::MarketPair.new(
+              base:   base,
+              target: target,
+              market: Fex::Market::NAME
+            )
+            adapt(ticker, market_pair)
+          end
+        end
+
+        def adapt(output, market_pair)
+          ticker           = Cryptoexchange::Models::Ticker.new
+          ticker.base      = market_pair.base
+          ticker.target    = market_pair.target
+          ticker.market    = Fex::Market::NAME
+          ticker.ask       = NumericHelper.to_d(output['sell'])
+          ticker.bid       = NumericHelper.to_d(output['buy'])
+          # this is their typo
+          ticker.last      = NumericHelper.to_d(output['colse'])
+          ticker.volume    = NumericHelper.to_d(output['volume'])
+          ticker.high      = NumericHelper.to_d(output['high'])
+          ticker.low       = NumericHelper.to_d(output['low'])
+          ticker.change    = NumericHelper.to_d(output['changePercentage'])
+          ticker.timestamp = Time.now.to_i
+          ticker.payload   = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/fex/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/fex/services/pairs.rb
@@ -1,0 +1,25 @@
+module Cryptoexchange::Exchanges
+  module Fex
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Fex::Market::API_URL}/market/ticker"
+
+        def fetch
+          output = super
+          adapt(output)
+        end
+
+        def adapt(output)
+          output.map do |pair|
+            base, target = pair['symbol'].split("/")
+            Cryptoexchange::Models::MarketPair.new(
+              base:   base,
+              target: target,
+              market: Fex::Market::NAME
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/Fex/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/Fex/integration_specs_fetch_pairs.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.fexpro.io/api/market/ticker
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.fexpro.io
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '5776'
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Wed, 25 Apr 2018 06:37:23 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '[{"symbol":"BCH/BTC","buy":0.14222100,"sell":0.14289800,"changePercentage":-10.000000000000000,"colse":0.14244000,"open":0.15826100,"low":0.13629200,"high":0.15945700,"volume":272.11293500,"name":"FEX"},{"symbol":"BCH/USDT","buy":1342.75000000,"sell":1349.69000000,"changePercentage":-9.240000000000000,"colse":1344.63000000,"open":1481.49000000,"low":1255.02000000,"high":1501.19000000,"volume":578.53809500,"name":"FEX"},{"symbol":"BTC/USDT","buy":9414.66000000,"sell":9454.90000000,"changePercentage":1.010000000000000,"colse":9423.48000000,"open":9329.47000000,"low":9182.46000000,"high":9756.68000000,"volume":119.55500000,"name":"FEX"},{"symbol":"DASH/BTC","buy":0.05214300,"sell":0.05251600,"changePercentage":-8.480000000000000,"colse":0.05229500,"open":0.05713900,"low":0.05038200,"high":0.05755400,"volume":721.01722500,"name":"FEX"},{"symbol":"DCR/BTC","buy":0.00917917,"sell":0.00931349,"changePercentage":15.710000000000000,"colse":0.00922670,"open":0.00797385,"low":0.00758230,"high":0.01060114,"volume":8429.57445467,"name":"FEX"},{"symbol":"DGD/ETH","buy":0.42783800,"sell":0.43345800,"changePercentage":2.660000000000000,"colse":0.43040600,"open":0.41924600,"low":0.40990800,"high":0.47164300,"volume":235.90127500,"name":"FEX"},{"symbol":"DOGE/BTC","buy":0.00000055,"sell":0.00000058,"changePercentage":-6.450000000000000,"colse":0.00000058,"open":0.00000062,"low":0.00000054,"high":0.00000064,"volume":3583901301.04214500,"name":"FEX"},{"symbol":"EOS/ETH","buy":0.02195783,"sell":0.02211885,"changePercentage":12.890000000000000,"colse":0.02196236,"open":0.01945425,"low":0.01929560,"high":0.02274515,"volume":31062.40300000,"name":"FEX"},{"symbol":"ETC/BTC","buy":0.00215900,"sell":0.00218500,"changePercentage":-5.620000000000000,"colse":0.00218200,"open":0.00231200,"low":0.00203300,"high":0.00242200,"volume":14577.91221500,"name":"FEX"},{"symbol":"ETC/USDT","buy":20.48000000,"sell":20.49000000,"changePercentage":-5.540000000000000,"colse":20.48000000,"open":21.68000000,"low":18.71000000,"high":32.47000000,"volume":12039.36165000,"name":"FEX"},{"symbol":"ETH/BTC","buy":0.07028100,"sell":0.07061900,"changePercentage":-6.000000000000000,"colse":0.07043500,"open":0.07492800,"low":0.06827200,"high":0.07558800,"volume":407.63227500,"name":"FEX"},{"symbol":"ETH/USDT","buy":662.86000000,"sell":665.67000000,"changePercentage":-5.060000000000000,"colse":663.92000000,"open":699.30000000,"low":426.04000000,"high":711.61000000,"volume":1223.80554500,"name":"FEX"},{"symbol":"FEX/BTC","buy":0.00004729,"sell":0.00005300,"changePercentage":2.910000000000000,"colse":0.00004738,"open":0.00004604,"low":0.00004600,"high":0.00005300,"volume":78434.00000000,"name":"FEX"},{"symbol":"FEX/ETH","buy":0.00067000,"sell":0.00070000,"changePercentage":-0.070000000000000,"colse":0.00067283,"open":0.00067331,"low":0.00067000,"high":0.00067668,"volume":103135.00000000,"name":"FEX"},{"symbol":"IOST/ETH","buy":0.00007386,"sell":0.00007492,"changePercentage":-2.770000000000000,"colse":0.00007467,"open":0.00007680,"low":0.00007029,"high":0.00008078,"volume":3130483.50450000,"name":"FEX"},{"symbol":"LTC/BTC","buy":0.01654100,"sell":0.01660600,"changePercentage":-4.210000000000000,"colse":0.01657500,"open":0.01730400,"low":0.01630000,"high":0.01759400,"volume":1848.28361500,"name":"FEX"},{"symbol":"LTC/USDT","buy":155.90000000,"sell":156.52000000,"changePercentage":-3.240000000000000,"colse":156.65000000,"open":161.90000000,"low":150.00000000,"high":166.60000000,"volume":2744.67773500,"name":"FEX"},{"symbol":"PIVX/BTC","buy":0.00057860,"sell":0.00059242,"changePercentage":-8.150000000000000,"colse":0.00057957,"open":0.00063103,"low":0.00055847,"high":0.00064942,"volume":195498.50676975,"name":"FEX"},{"symbol":"RUFF/ETH","buy":0.00012292,"sell":0.00012459,"changePercentage":-16.150000000000000,"colse":0.00012439,"open":0.00014834,"low":0.00012292,"high":0.00016446,"volume":1432728.34650000,"name":"FEX"},{"symbol":"SC/BTC","buy":0.00000219,"sell":0.00000222,"changePercentage":-5.170000000000000,"colse":0.00000220,"open":0.00000232,"low":0.00000181,"high":0.00000240,"volume":129739178.78212500,"name":"FEX"},{"symbol":"SC/ETH","buy":0.00003108,"sell":0.00003165,"changePercentage":2.460000000000000,"colse":0.00003160,"open":0.00003084,"low":0.00003014,"high":0.00003200,"volume":134904486.87336500,"name":"FEX"},{"symbol":"SC/USDT","buy":0.02063742,"sell":0.02112618,"changePercentage":-3.610000000000000,"colse":0.02103459,"open":0.02182231,"low":0.01962457,"high":0.02276245,"volume":127894876.50366500,"name":"FEX"},{"symbol":"TNB/ETH","buy":0.00007536,"sell":0.00007789,"changePercentage":-6.270000000000000,"colse":0.00007592,"open":0.00008100,"low":0.00007082,"high":0.00008271,"volume":2797338.90000000,"name":"FEX"},{"symbol":"VIA/BTC","buy":0.00026706,"sell":0.00027122,"changePercentage":-1.250000000000000,"colse":0.00027112,"open":0.00027456,"low":0.00024741,"high":0.00028151,"volume":54829.33833476,"name":"FEX"},{"symbol":"XVG/BTC","buy":0.00000683,"sell":0.00000692,"changePercentage":-7.150000000000000,"colse":0.00000688,"open":0.00000741,"low":0.00000648,"high":0.00000745,"volume":19355346.22285585,"name":"FEX"},{"symbol":"XVG/USDT","buy":0.06486836,"sell":0.06545764,"changePercentage":-4.980000000000000,"colse":0.06522025,"open":0.06863561,"low":0.05996367,"high":0.06958407,"volume":5355744.46727120,"name":"FEX"},{"symbol":"ZIL/ETH","buy":0.00013418,"sell":0.00013578,"changePercentage":-2.630000000000000,"colse":0.00013497,"open":0.00013861,"low":0.00012139,"high":0.00014366,"volume":873851.99600000,"name":"FEX"},{"symbol":"ZIL/USDT","buy":0.08915000,"sell":0.08967800,"changePercentage":-7.740000000000000,"colse":0.08947300,"open":0.09697800,"low":0.05611400,"high":0.10016800,"volume":2345290.61300000,"name":"FEX"}]'
+    http_version: 
+  recorded_at: Wed, 25 Apr 2018 06:37:23 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Fex/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/Fex/integration_specs_fetch_ticker.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.fexpro.io/api/market/ticker
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.fexpro.io
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '5776'
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - "-1"
+      Server:
+      - Microsoft-IIS/8.5
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Date:
+      - Wed, 25 Apr 2018 06:37:23 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: '[{"symbol":"BCH/BTC","buy":0.14222100,"sell":0.14289800,"changePercentage":-10.000000000000000,"colse":0.14244000,"open":0.15826100,"low":0.13629200,"high":0.15945700,"volume":272.11293500,"name":"FEX"},{"symbol":"BCH/USDT","buy":1342.75000000,"sell":1349.69000000,"changePercentage":-9.240000000000000,"colse":1344.63000000,"open":1481.49000000,"low":1255.02000000,"high":1501.19000000,"volume":578.53376500,"name":"FEX"},{"symbol":"BTC/USDT","buy":9414.66000000,"sell":9454.90000000,"changePercentage":1.010000000000000,"colse":9423.48000000,"open":9329.47000000,"low":9182.46000000,"high":9756.68000000,"volume":119.55500000,"name":"FEX"},{"symbol":"DASH/BTC","buy":0.05214300,"sell":0.05251600,"changePercentage":-8.480000000000000,"colse":0.05229500,"open":0.05713900,"low":0.05038200,"high":0.05755400,"volume":721.01722500,"name":"FEX"},{"symbol":"DCR/BTC","buy":0.00917917,"sell":0.00931860,"changePercentage":15.710000000000000,"colse":0.00922670,"open":0.00797385,"low":0.00758230,"high":0.01060114,"volume":8429.57445467,"name":"FEX"},{"symbol":"DGD/ETH","buy":0.42783800,"sell":0.43345800,"changePercentage":2.660000000000000,"colse":0.43040600,"open":0.41924600,"low":0.40990800,"high":0.47164300,"volume":235.90127500,"name":"FEX"},{"symbol":"DOGE/BTC","buy":0.00000055,"sell":0.00000058,"changePercentage":-6.450000000000000,"colse":0.00000058,"open":0.00000062,"low":0.00000054,"high":0.00000064,"volume":3583901301.04214500,"name":"FEX"},{"symbol":"EOS/ETH","buy":0.02195783,"sell":0.02211885,"changePercentage":12.890000000000000,"colse":0.02196236,"open":0.01945425,"low":0.01929560,"high":0.02274515,"volume":31062.40300000,"name":"FEX"},{"symbol":"ETC/BTC","buy":0.00215900,"sell":0.00218500,"changePercentage":-6.570000000000000,"colse":0.00216000,"open":0.00231200,"low":0.00203300,"high":0.00242200,"volume":14577.91221500,"name":"FEX"},{"symbol":"ETC/USDT","buy":20.48000000,"sell":20.49000000,"changePercentage":-5.540000000000000,"colse":20.48000000,"open":21.68000000,"low":18.71000000,"high":32.47000000,"volume":12039.36165000,"name":"FEX"},{"symbol":"ETH/BTC","buy":0.07028100,"sell":0.07061900,"changePercentage":-6.000000000000000,"colse":0.07043500,"open":0.07492800,"low":0.06827200,"high":0.07558800,"volume":407.63227500,"name":"FEX"},{"symbol":"ETH/USDT","buy":662.86000000,"sell":665.67000000,"changePercentage":-5.060000000000000,"colse":663.92000000,"open":699.30000000,"low":426.04000000,"high":711.61000000,"volume":1223.80554500,"name":"FEX"},{"symbol":"FEX/BTC","buy":0.00004729,"sell":0.00005300,"changePercentage":2.910000000000000,"colse":0.00004738,"open":0.00004604,"low":0.00004600,"high":0.00005300,"volume":78434.00000000,"name":"FEX"},{"symbol":"FEX/ETH","buy":0.00067000,"sell":0.00070000,"changePercentage":-0.070000000000000,"colse":0.00067283,"open":0.00067331,"low":0.00067000,"high":0.00067668,"volume":103135.00000000,"name":"FEX"},{"symbol":"IOST/ETH","buy":0.00007386,"sell":0.00007492,"changePercentage":-2.770000000000000,"colse":0.00007467,"open":0.00007680,"low":0.00007029,"high":0.00008078,"volume":3131382.82000000,"name":"FEX"},{"symbol":"LTC/BTC","buy":0.01654100,"sell":0.01660600,"changePercentage":-4.210000000000000,"colse":0.01657500,"open":0.01730400,"low":0.01630000,"high":0.01759400,"volume":1848.28361500,"name":"FEX"},{"symbol":"LTC/USDT","buy":155.90000000,"sell":156.52000000,"changePercentage":-3.240000000000000,"colse":156.65000000,"open":161.90000000,"low":150.00000000,"high":166.60000000,"volume":2744.67773500,"name":"FEX"},{"symbol":"PIVX/BTC","buy":0.00057860,"sell":0.00059242,"changePercentage":-8.150000000000000,"colse":0.00057957,"open":0.00063103,"low":0.00055847,"high":0.00064942,"volume":195498.50676975,"name":"FEX"},{"symbol":"RUFF/ETH","buy":0.00012292,"sell":0.00012459,"changePercentage":-16.150000000000000,"colse":0.00012439,"open":0.00014834,"low":0.00012292,"high":0.00016446,"volume":1432728.34650000,"name":"FEX"},{"symbol":"SC/BTC","buy":0.00000219,"sell":0.00000222,"changePercentage":-5.170000000000000,"colse":0.00000220,"open":0.00000232,"low":0.00000181,"high":0.00000240,"volume":129739178.78212500,"name":"FEX"},{"symbol":"SC/ETH","buy":0.00003108,"sell":0.00003165,"changePercentage":2.460000000000000,"colse":0.00003160,"open":0.00003084,"low":0.00003014,"high":0.00003200,"volume":134904486.87336500,"name":"FEX"},{"symbol":"SC/USDT","buy":0.02063742,"sell":0.02112618,"changePercentage":-3.610000000000000,"colse":0.02103459,"open":0.02182231,"low":0.01962457,"high":0.02276245,"volume":127894876.50366500,"name":"FEX"},{"symbol":"TNB/ETH","buy":0.00007536,"sell":0.00007789,"changePercentage":-6.270000000000000,"colse":0.00007592,"open":0.00008100,"low":0.00007082,"high":0.00008271,"volume":2797338.90000000,"name":"FEX"},{"symbol":"VIA/BTC","buy":0.00026706,"sell":0.00027122,"changePercentage":-1.250000000000000,"colse":0.00027112,"open":0.00027456,"low":0.00024741,"high":0.00028151,"volume":54829.33833476,"name":"FEX"},{"symbol":"XVG/BTC","buy":0.00000683,"sell":0.00000695,"changePercentage":-7.150000000000000,"colse":0.00000688,"open":0.00000741,"low":0.00000648,"high":0.00000745,"volume":19355346.22285585,"name":"FEX"},{"symbol":"XVG/USDT","buy":0.06486836,"sell":0.06545764,"changePercentage":-4.980000000000000,"colse":0.06522025,"open":0.06863561,"low":0.05996367,"high":0.06958407,"volume":5355744.46727120,"name":"FEX"},{"symbol":"ZIL/ETH","buy":0.00013418,"sell":0.00013578,"changePercentage":-2.630000000000000,"colse":0.00013497,"open":0.00013861,"low":0.00012139,"high":0.00014366,"volume":873851.99600000,"name":"FEX"},{"symbol":"ZIL/USDT","buy":0.08915000,"sell":0.08967800,"changePercentage":-7.740000000000000,"colse":0.08947300,"open":0.09697800,"low":0.05611400,"high":0.10016800,"volume":2345290.61300000,"name":"FEX"}]'
+    http_version: 
+  recorded_at: Wed, 25 Apr 2018 06:37:23 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/fex/integration/market_spec.rb
+++ b/spec/exchanges/fex/integration/market_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+RSpec.describe 'Fex integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:xvg_btc_pair) { Cryptoexchange::Models::MarketPair.new(base: 'XVG', target: 'BTC', market: 'fex') }
+
+  it 'fetch pairs' do
+    pairs = client.pairs('fex')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.market).to eq 'fex'
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(xvg_btc_pair)
+
+    expect(ticker.base).to eq 'XVG'
+    expect(ticker.target).to eq 'BTC'
+    expect(ticker.market).to eq 'fex'
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.ask).to be_a Numeric
+    expect(ticker.bid).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+    expect(ticker.high).to be_a Numeric
+    expect(ticker.low).to be_a Numeric
+    expect(ticker.change).to be_a Numeric
+    expect(ticker.timestamp).to be_a Numeric
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
+    expect(ticker.payload).to_not be nil
+  end
+end

--- a/spec/exchanges/fex/market_spec.rb
+++ b/spec/exchanges/fex/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Fex::Market do
+  it { expect(described_class::NAME).to eq 'fex' }
+  it { expect(described_class::API_URL).to eq 'http://api.fexpro.io/api' }
+end


### PR DESCRIPTION
- What is the purpose of this Pull Request? as title 
- What is the related issue for this Pull Request? #445
- [x] I have added Specs
- [x] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [x] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly

ticker about base `XVG` target: `BTC`
```ruby
{
  "symbol": "XVG/BTC",
  "buy": 0.00000686,
  "sell": 0.000007,
  "changePercentage": -6.34,
  "colse": 0.00000694,
  "open": 0.00000741,
  "low": 0.00000648,
  "high": 0.00000745,
  "volume": 19420729.15422327,
  "name": "FEX"
}
```
took this volume as base volume
