### PR TITLE
Implement Btcsquare ticker, order book and trades

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Or install it yourself as:
 | BTC38             |         |            |         |         |             |
 | BTCC              | Y       |            |         |         | User-Defined|
 | BTCChina          |         |            |         |         |             |
+| Btcsquare         | Y       | Y          | Unstable|         | Y           |
 | BTER              | Y       |            |         |         | Y           |
 | Buyucoin          | Y       | N          | N       |         | Y           |
 | BX Thailand       | Y       |            |         |         | Y           |

--- a/lib/cryptoexchange/exchanges/btcsquare/market.rb
+++ b/lib/cryptoexchange/exchanges/btcsquare/market.rb
@@ -1,0 +1,8 @@
+module Cryptoexchange::Exchanges
+  module Btcsquare
+    class Market
+      NAME = 'btcsquare'
+      API_URL = 'https://www.btcsquare.net/api/v1'
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/btcsquare/services/market.rb
+++ b/lib/cryptoexchange/exchanges/btcsquare/services/market.rb
@@ -1,0 +1,50 @@
+module Cryptoexchange::Exchanges
+  module Btcsquare
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            false
+          end
+        end
+
+        def fetch
+          output = super(ticker_url)
+          adapt_all(output)
+        end
+
+        def ticker_url
+          "#{Cryptoexchange::Exchanges::Btcsquare::Market::API_URL}/markets"
+        end
+
+        def adapt_all(output)
+          output.map do |pair|
+            target, base = pair.keys.first.split('-')
+            market_pair = Cryptoexchange::Models::MarketPair.new(
+              base: base,
+              target: target,
+              market: Btcsquare::Market::NAME
+            )
+            adapt(pair.values.first, market_pair)
+          end
+        end
+
+        def adapt(output, market_pair)
+          ticker           = Cryptoexchange::Models::Ticker.new
+          ticker.base      = market_pair.base
+          ticker.target    = market_pair.target
+          ticker.market    = Btcsquare::Market::NAME
+          ticker.ask       = NumericHelper.to_d(output['ask'])
+          ticker.bid       = NumericHelper.to_d(output['bid'])
+          ticker.high      = NumericHelper.to_d(output['high'])
+          ticker.low       = NumericHelper.to_d(output['low'])
+          ticker.last      = NumericHelper.to_d(output['price'])
+          ticker.volume    = NumericHelper.divide(NumericHelper.to_d(output['volume']), ticker.last)
+          ticker.timestamp = Time.now.to_i
+          ticker.payload   = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/btcsquare/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/btcsquare/services/order_book.rb
@@ -1,0 +1,45 @@
+module Cryptoexchange::Exchanges
+  module Btcsquare
+    module Services
+      class OrderBook < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          base   = market_pair.base
+          target = market_pair.target
+          "#{Cryptoexchange::Exchanges::Btcsquare::Market::API_URL}/orders/#{target}-#{base}"
+        end
+
+        def adapt(output, market_pair)
+          order_book = Cryptoexchange::Models::OrderBook.new
+
+          order_book.base      = market_pair.base
+          order_book.target    = market_pair.target
+          order_book.market    = Btcsquare::Market::NAME
+          order_book.asks      = adapt_orders output['sell']
+          order_book.bids      = adapt_orders output['buy']
+          order_book.timestamp = Time.now.to_i
+          order_book.payload   = output
+          order_book
+        end
+
+        def adapt_orders(orders)
+          orders.collect do |price, amount|
+            Cryptoexchange::Models::Order.new(price: price,
+                                              amount: amount,
+                                              timestamp: nil)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/btcsquare/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/btcsquare/services/pairs.rb
@@ -1,0 +1,26 @@
+module Cryptoexchange::Exchanges
+  module Btcsquare
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Btcsquare::Market::API_URL}/markets"
+
+        def fetch
+          output = super
+          adapt(output)
+        end
+
+        def adapt(output)
+          output.map do |pair|
+            target, base = pair.keys.first.split('-')
+
+            Cryptoexchange::Models::MarketPair.new(
+              base:   base,
+              target: target,
+              market: Btcsquare::Market::NAME
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/btcsquare/services/trades.rb
+++ b/lib/cryptoexchange/exchanges/btcsquare/services/trades.rb
@@ -1,0 +1,33 @@
+module Cryptoexchange::Exchanges
+  module Btcsquare
+    module Services
+      class Trades < Cryptoexchange::Services::Market
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          base   = market_pair.base
+          target = market_pair.target
+          "#{Cryptoexchange::Exchanges::Btcsquare::Market::API_URL}/history/#{target}-#{base}"
+        end
+
+        def adapt(output, market_pair)
+          puts output
+          output.map do |trade|
+            tr = Cryptoexchange::Models::Trade.new
+            tr.base      = market_pair.base
+            tr.target    = market_pair.target
+            tr.market    = Btcsquare::Market::NAME
+            tr.type      = trade['type']
+            tr.price     = trade['price']
+            tr.amount    = trade['quantity']
+            tr.timestamp = trade['date'].to_i
+            tr.payload   = trade
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/Btcsquare/integration_specs_fetch_order_book.yml
+++ b/spec/cassettes/vcr_cassettes/Btcsquare/integration_specs_fetch_order_book.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://www.btcsquare.net/api/v1/orders/BTC-LTC
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - www.btcsquare.net
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 26 Apr 2018 09:31:17 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=df8147c04b9076c7440368e8dafa556bb1524735076; expires=Fri, 26-Apr-19
+        09:31:16 GMT; path=/; domain=.btcsquare.net; HttpOnly; Secure
+      Expires:
+      - '0'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 41180914f9dfa2ba-HKG
+    body:
+      encoding: ASCII-8BIT
+      string: '{"buy":{"0.01377080":"0.01000000","0.01377081":"0.50000000","0.01377082":"0.70000000","0.01377083":"0.60000000","0.01377084":"0.05000000","0.01377085":"0.10000000","0.01377086":"1.00000000","0.01377087":"0.15000000","0.01377088":"0.15000000","0.01377089":"0.12000000","0.01377090":"0.15000000"},"sell":{"0.01577080":"0.04897763"}}'
+    http_version: 
+  recorded_at: Thu, 26 Apr 2018 09:31:17 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Btcsquare/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/Btcsquare/integration_specs_fetch_pairs.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://www.btcsquare.net/api/v1/markets
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - www.btcsquare.net
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 26 Apr 2018 09:31:16 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d5412313c3b6051af01de448942fb66351524735075; expires=Fri, 26-Apr-19
+        09:31:15 GMT; path=/; domain=.btcsquare.net; HttpOnly; Secure
+      Expires:
+      - '0'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4118090d8ffda35c-HKG
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"BTC-LTC":{"initialprice":"0.00000000","price":"0.00000000","high":"0.00000000","low":"0.00000000","volume":"0.000","bid":"0.01377090","ask":"0.01577080"}},{"BTC-BCH":{"initialprice":"0.14980900","price":"0.14980900","high":"0.14980900","low":"0.14980900","volume":"0.010","bid":"0.08132228","ask":"0.09432220"}},{"BTC-XVG":{"initialprice":"0.00000730","price":"0.00000730","high":"0.00000730","low":"0.00000730","volume":"0.020","bid":"0.00001530","ask":"0.00001550"}},{"BTC-ZEC":{"initialprice":"0.00000000","price":"0.00000000","high":"0.00000000","low":"0.00000000","volume":"0.000","bid":"0.01830009","ask":"0.02830000"}},{"BTC-BTG":{"initialprice":"0.00811742","price":"0.00811742","high":"0.00811742","low":"0.00811742","volume":"0.010","bid":"0.00496190","ask":"0.00596178"}},{"BTC-DASH":{"initialprice":"0.05284770","price":"0.05284770","high":"0.05284770","low":"0.05284770","volume":"0.040","bid":"0.03935620","ask":"0.04735610"}},{"BTC-NMC":{"initialprice":"0.00000000","price":"0.00000000","high":"0.00000000","low":"0.00000000","volume":"0.000","bid":"0.00017712","ask":"0.00023207"}},{"BTC-PPC":{"initialprice":"0.00000000","price":"0.00000000","high":"0.00000000","low":"0.00000000","volume":"0.000","bid":"0.00025476","ask":"0.00025485"}}]'
+    http_version: 
+  recorded_at: Thu, 26 Apr 2018 09:31:16 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Btcsquare/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/Btcsquare/integration_specs_fetch_ticker.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://www.btcsquare.net/api/v1/markets
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - www.btcsquare.net
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 26 Apr 2018 09:31:16 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=dc960b60bb7f74448b213bb55f9737b611524735076; expires=Fri, 26-Apr-19
+        09:31:16 GMT; path=/; domain=.btcsquare.net; HttpOnly; Secure
+      Expires:
+      - '0'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 411809135922a2de-HKG
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"BTC-LTC":{"initialprice":"0.00000000","price":"0.00000000","high":"0.00000000","low":"0.00000000","volume":"0.000","bid":"0.01377090","ask":"0.01577080"}},{"BTC-BCH":{"initialprice":"0.14980900","price":"0.14980900","high":"0.14980900","low":"0.14980900","volume":"0.010","bid":"0.08132228","ask":"0.09432220"}},{"BTC-XVG":{"initialprice":"0.00000730","price":"0.00000730","high":"0.00000730","low":"0.00000730","volume":"0.020","bid":"0.00001530","ask":"0.00001550"}},{"BTC-ZEC":{"initialprice":"0.00000000","price":"0.00000000","high":"0.00000000","low":"0.00000000","volume":"0.000","bid":"0.01830009","ask":"0.02830000"}},{"BTC-BTG":{"initialprice":"0.00811742","price":"0.00811742","high":"0.00811742","low":"0.00811742","volume":"0.010","bid":"0.00496190","ask":"0.00596178"}},{"BTC-DASH":{"initialprice":"0.05284770","price":"0.05284770","high":"0.05284770","low":"0.05284770","volume":"0.040","bid":"0.03935620","ask":"0.04735610"}},{"BTC-NMC":{"initialprice":"0.00000000","price":"0.00000000","high":"0.00000000","low":"0.00000000","volume":"0.000","bid":"0.00017712","ask":"0.00023207"}},{"BTC-PPC":{"initialprice":"0.00000000","price":"0.00000000","high":"0.00000000","low":"0.00000000","volume":"0.000","bid":"0.00025476","ask":"0.00025485"}}]'
+    http_version: 
+  recorded_at: Thu, 26 Apr 2018 09:31:16 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Btcsquare/integration_specs_fetch_trade.yml
+++ b/spec/cassettes/vcr_cassettes/Btcsquare/integration_specs_fetch_trade.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://www.btcsquare.net/api/v1/history/BTC-LTC
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - www.btcsquare.net
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 26 Apr 2018 09:33:11 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=dad11dfb7bef3c24d8fb57d69484892391524735190; expires=Fri, 26-Apr-19
+        09:33:10 GMT; path=/; domain=.btcsquare.net; HttpOnly; Secure
+      Expires:
+      - '0'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 41180bdbbc20a33e-HKG
+    body:
+      encoding: ASCII-8BIT
+      string: 'null'
+    http_version: 
+  recorded_at: Thu, 26 Apr 2018 09:33:11 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/btcsquare/integration/market_spec.rb
+++ b/spec/exchanges/btcsquare/integration/market_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+RSpec.describe 'Btcsquare integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:ltc_btc_pair) { Cryptoexchange::Models::MarketPair.new(base: 'LTC', target: 'BTC', market: 'btcsquare') }
+
+  it 'fetch pairs' do
+    pairs = client.pairs('btcsquare')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.market).to eq 'btcsquare'
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(ltc_btc_pair)
+
+    expect(ticker.base).to eq 'LTC'
+    expect(ticker.target).to eq 'BTC'
+    expect(ticker.market).to eq 'btcsquare'
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.ask).to be_a Numeric
+    expect(ticker.bid).to be_a Numeric
+    expect(ticker.high).to be_a Numeric
+    expect(ticker.low).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+    expect(ticker.timestamp).to be_a Numeric
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
+    expect(ticker.payload).to_not be nil
+  end
+
+  it 'fetch order book' do
+    order_book = client.order_book(ltc_btc_pair)
+
+    expect(order_book.base).to eq 'LTC'
+    expect(order_book.target).to eq 'BTC'
+    expect(order_book.market).to eq 'btcsquare'
+    expect(order_book.asks).to_not be_empty
+    expect(order_book.bids).to_not be_empty
+    expect(order_book.asks.first.price).to_not be_nil
+    expect(order_book.bids.first.amount).to_not be_nil
+    expect(order_book.bids.first.timestamp).to be_nil
+    expect(order_book.asks.count).to be > 0
+    expect(order_book.bids.count).to be > 0
+    expect(order_book.timestamp).to be_a Numeric
+    expect(order_book.payload).to_not be nil
+  end
+
+  pending 'fetch trade' do
+    trades = client.trades(ltc_btc_pair)
+    trade = trades.sample
+
+    expect(trades).to_not be_empty
+    expect(trade.trade_id).to be_nil
+    expect(trade.base).to eq 'LTC'
+    expect(trade.target).to eq 'BTC'
+    expect(['buy', 'sell']).to include trade.type
+    expect(trade.price).to_not be_nil
+    expect(trade.amount).to_not be_nil
+    expect(trade.timestamp).to be_a Numeric
+    expect(trade.payload).to_not be nil
+    expect(trade.market).to eq 'btcsquare'
+  end
+end

--- a/spec/exchanges/btcsquare/market_spec.rb
+++ b/spec/exchanges/btcsquare/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Btcsquare::Market do
+  it { expect(described_class::NAME).to eq 'btcsquare' }
+  it { expect(described_class::API_URL).to eq 'https://www.btcsquare.net/api/v1' }
+end


### PR DESCRIPTION
- What is the purpose of this Pull Request? as title 
- What is the related issue for this Pull Request? #448
- [x] I have added Specs
- [x] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [x] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
ticker on base `LTC` target `BTC`
```ruby
{
  "initialprice": "0.00000000",
  "price": "0.00000000",
  "high": "0.00000000",
  "low": "0.00000000",
  "volume": "0.000",
  "bid": "0.01377090",
  "ask": "0.01577080"
}
```
took price as `last` and divide volume to be a base volume
order book
```
{
  "buy": {
    "0.01377080": "0.01000000",
    "0.01377081": "0.50000000",
    "0.01377082": "0.70000000",
    "0.01377083": "0.60000000",
    "0.01377084": "0.05000000",
    "0.01377085": "0.10000000",
    "0.01377086": "1.00000000",
    "0.01377087": "0.15000000",
    "0.01377088": "0.15000000",
    "0.01377089": "0.12000000",
    "0.01377090": "0.15000000"
  },
  "sell": {
    "0.01577080": "0.04897763"
  }
}
```
and now the trades will send `null` ....