### PR TITLE
Feature/btc24

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+.idea
 
 # rspec failure tracking
 .rspec_status

--- a/lib/cryptoexchange/exchanges/btc24/btc24.yml
+++ b/lib/cryptoexchange/exchanges/btc24/btc24.yml
@@ -1,0 +1,45 @@
+:pairs:
+  - :base: BTC
+    :target: USD
+  - :base: BCH
+    :target: USD
+  - :base: BCH
+    :target: BTC
+  - :base: DSH
+    :target: BTC
+  - :base: DSH
+    :target: USD
+  - :base: ETH
+    :target: BTC
+  - :base: ETH
+    :target: USD
+  - :base: LTC
+    :target: BTC
+  - :base: LTC
+    :target: USD
+  - :base: XMR
+    :target: BTC
+  - :base: PZM
+    :target: BTC
+  - :base: BCH
+    :target: ECH
+  - :base: ETH
+    :target: LTC
+  - :base: PGU
+    :target: BTC
+  - :base: PGU
+    :target: DSH
+  - :base: PGU
+    :target: ETH
+  - :base: PGU
+    :target: LTC
+  - :base: PGU
+    :target: USD
+  - :base: PGU
+    :target: XMR
+  - :base: PZM
+    :target: RUB
+  - :base: PZM
+    :target: USD
+  - :base: XMR
+    :target: USD

--- a/lib/cryptoexchange/exchanges/btc24/market.rb
+++ b/lib/cryptoexchange/exchanges/btc24/market.rb
@@ -1,0 +1,8 @@
+module Cryptoexchange::Exchanges
+  module Btc24
+    class Market
+      NAME = 'btc24'
+      API_URL = 'https://cryptottlivewebapi.btc24.io:8443/api/v1/public'
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/btc24/services/market.rb
+++ b/lib/cryptoexchange/exchanges/btc24/services/market.rb
@@ -1,0 +1,38 @@
+module Cryptoexchange::Exchanges
+  module Btc24
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output,market_pair)
+        end
+
+        def ticker_url(market_pair)
+          "#{Cryptoexchange::Exchanges::Btc24::Market::API_URL}/quotehistory/#{market_pair.base.downcase}#{market_pair.target.downcase}/1440/bars/bid?timestamp=#{Time.now.to_i - 86400 * 7}&count=1"
+        end
+
+        def adapt(output,market_pair)
+          ticker           = Cryptoexchange::Models::Ticker.new
+
+          bid              = output['Bars'].first
+          ticker.base      = market_pair.base
+          ticker.target    = market_pair.target
+          ticker.market    = Bitbank::Market::NAME
+          ticker.last      = NumericHelper.to_d(bid['Close'])
+          ticker.high      = NumericHelper.to_d(bid['High'])
+          ticker.low       = NumericHelper.to_d(bid['Low'])
+          ticker.volume    = NumericHelper.to_d(bid['Volume'])
+          ticker.timestamp = bid['Timestamp'] / 1000
+          ticker.payload   = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/btc24/services/market.rb
+++ b/lib/cryptoexchange/exchanges/btc24/services/market.rb
@@ -14,7 +14,7 @@ module Cryptoexchange::Exchanges
         end
 
         def ticker_url(market_pair)
-          "#{Cryptoexchange::Exchanges::Btc24::Market::API_URL}/quotehistory/#{market_pair.base.downcase}#{market_pair.target.downcase}/1440/bars/bid?timestamp=#{Time.now.to_i - 86400 * 7}&count=1"
+          "#{Cryptoexchange::Exchanges::Btc24::Market::API_URL}/quotehistory/#{market_pair.base.upcase}#{market_pair.target.upcase}/1440/bars/bid?timestamp=#{Time.now.to_i - 86400 * 7}&count=1"
         end
 
         def adapt(output,market_pair)

--- a/lib/cryptoexchange/exchanges/btc24/services/market.rb
+++ b/lib/cryptoexchange/exchanges/btc24/services/market.rb
@@ -14,7 +14,7 @@ module Cryptoexchange::Exchanges
         end
 
         def ticker_url(market_pair)
-          "#{Cryptoexchange::Exchanges::Btc24::Market::API_URL}/quotehistory/#{market_pair.base.upcase}#{market_pair.target.upcase}/1440/bars/bid?timestamp=#{Time.now.to_i - 86400 * 7}&count=1"
+          "#{Cryptoexchange::Exchanges::Btc24::Market::API_URL}/quotehistory/#{market_pair.base.upcase}#{market_pair.target.upcase}/d1/bars/bid?timestamp=#{(Time.now.to_i - 86400 * 7)*1000}&count=1"
         end
 
         def adapt(output,market_pair)

--- a/lib/cryptoexchange/exchanges/btc24/services/market.rb
+++ b/lib/cryptoexchange/exchanges/btc24/services/market.rb
@@ -11,31 +11,7 @@ module Cryptoexchange::Exchanges
         end
 
         def fetch(market_pair)
-          endpoint = ticker_url(market_pair)
-          output = ''
-          LruTtlCache.ticker_cache.getset(endpoint) do
-            begin
-              response = http_get(endpoint)
-              if response.code == 200
-                io = StringIO.new(response.body, 'rb')
-                gz = Zlib::GzipReader.new(io)
-                data = gz.read
-                output = JSON.parse(data)
-              elsif response.code == 400
-                raise Cryptoexchange::HttpBadRequestError, { response: response }
-              else
-                raise Cryptoexchange::HttpResponseError, { response: response }
-              end
-            rescue HTTP::ConnectionError => e
-              raise Cryptoexchange::HttpConnectionError, { error: e, response: response }
-            rescue HTTP::TimeoutError => e
-              raise Cryptoexchange::HttpTimeoutError, { error: e, response: response }
-            rescue JSON::ParserError => e
-              raise Cryptoexchange::JsonParseError, { error: e, response: response }
-            rescue TypeError => e
-              raise Cryptoexchange::TypeFormatError, { error: e, response: response }
-            end
-          end
+          output = super(ticker_url(market_pair))
           adapt(output,market_pair)
         end
 

--- a/lib/cryptoexchange/exchanges/btc24/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/btc24/services/order_book.rb
@@ -9,32 +9,8 @@ module Cryptoexchange::Exchanges
         end
 
         def fetch(market_pair)
-          endpoint = ticker_url(market_pair)
-          output = ''
-          LruTtlCache.ticker_cache.getset(endpoint) do
-            begin
-              response = http_get(endpoint)
-              if response.code == 200
-                io = StringIO.new(response.body, 'rb')
-                gz = Zlib::GzipReader.new(io)
-                data = gz.read
-                output = JSON.parse(data)
-              elsif response.code == 400
-                raise Cryptoexchange::HttpBadRequestError, { response: response }
-              else
-                raise Cryptoexchange::HttpResponseError, { response: response }
-              end
-            rescue HTTP::ConnectionError => e
-              raise Cryptoexchange::HttpConnectionError, { error: e, response: response }
-            rescue HTTP::TimeoutError => e
-              raise Cryptoexchange::HttpTimeoutError, { error: e, response: response }
-            rescue JSON::ParserError => e
-              raise Cryptoexchange::JsonParseError, { error: e, response: response }
-            rescue TypeError => e
-              raise Cryptoexchange::TypeFormatError, { error: e, response: response }
-            end
-          end
-          adapt(output, market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output,market_pair)
         end
 
         def ticker_url(market_pair)

--- a/lib/cryptoexchange/exchanges/btc24/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/btc24/services/order_book.rb
@@ -9,7 +9,31 @@ module Cryptoexchange::Exchanges
         end
 
         def fetch(market_pair)
-          output = super(ticker_url(market_pair))
+          endpoint = ticker_url(market_pair)
+          output = ''
+          LruTtlCache.ticker_cache.getset(endpoint) do
+            begin
+              response = http_get(endpoint)
+              if response.code == 200
+                io = StringIO.new(response.body, 'rb')
+                gz = Zlib::GzipReader.new(io)
+                data = gz.read
+                output = JSON.parse(data)
+              elsif response.code == 400
+                raise Cryptoexchange::HttpBadRequestError, { response: response }
+              else
+                raise Cryptoexchange::HttpResponseError, { response: response }
+              end
+            rescue HTTP::ConnectionError => e
+              raise Cryptoexchange::HttpConnectionError, { error: e, response: response }
+            rescue HTTP::TimeoutError => e
+              raise Cryptoexchange::HttpTimeoutError, { error: e, response: response }
+            rescue JSON::ParserError => e
+              raise Cryptoexchange::JsonParseError, { error: e, response: response }
+            rescue TypeError => e
+              raise Cryptoexchange::TypeFormatError, { error: e, response: response }
+            end
+          end
           adapt(output, market_pair)
         end
 
@@ -24,8 +48,8 @@ module Cryptoexchange::Exchanges
           order_book.base = market_pair.base
           order_book.target = market_pair.target
           order_book.market = Btc24::Market::NAME
-          order_book.asks = adapt_orders(market['Asks'], market['timestamp'])
-          order_book.bids = adapt_orders(market['Bids'], market['timestamp'])
+          order_book.asks = adapt_orders(market['Asks'], market['Timestamp'])
+          order_book.bids = adapt_orders(market['Bids'], market['Timestamp'])
           order_book.timestamp = Time.now.to_i
           order_book.payload = output
           order_book
@@ -39,6 +63,16 @@ module Cryptoexchange::Exchanges
                                               amount: amount,
                                               timestamp: timestamp)
           end
+        end
+
+        def http_get(endpoint)
+          fetch_response = HTTP.timeout(:write => 2, :connect => 15, :read => 18)
+                               .follow.get(endpoint, {
+              headers: {
+                  "Accept-Encoding" => "gzip"
+              }
+          }
+          )
         end
       end
     end

--- a/lib/cryptoexchange/exchanges/btc24/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/btc24/services/order_book.rb
@@ -14,7 +14,7 @@ module Cryptoexchange::Exchanges
         end
 
         def ticker_url(market_pair)
-          "#{Cryptoexchange::Exchanges::Btc24::Market::API_URL}/level2/#{market_pair.base.downcase}#{market_pair.target.downcase}"
+          "#{Cryptoexchange::Exchanges::Btc24::Market::API_URL}/level2/#{market_pair.base.upcase}#{market_pair.target.upcase}"
         end
 
         def adapt(output, market_pair)

--- a/lib/cryptoexchange/exchanges/btc24/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/btc24/services/order_book.rb
@@ -1,0 +1,46 @@
+module Cryptoexchange::Exchanges
+  module Btc24
+    module Services
+      class OrderBook < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          "#{Cryptoexchange::Exchanges::Btc24::Market::API_URL}/level2/#{market_pair.base.downcase}#{market_pair.target.downcase}"
+        end
+
+        def adapt(output, market_pair)
+          order_book = Cryptoexchange::Models::OrderBook.new
+
+          market = output.first
+          order_book.base = market_pair.base
+          order_book.target = market_pair.target
+          order_book.market = Btc24::Market::NAME
+          order_book.asks = adapt_orders(market['Asks'], market['timestamp'])
+          order_book.bids = adapt_orders(market['Bids'], market['timestamp'])
+          order_book.timestamp = Time.now.to_i
+          order_book.payload = output
+          order_book
+        end
+
+        def adapt_orders(orders, timestamp)
+          orders.collect do |order_entry|
+            price = order_entry['Price']
+            amount = order_entry['Volume']
+            Cryptoexchange::Models::Order.new(price: price,
+                                              amount: amount,
+                                              timestamp: timestamp)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/btc24/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/btc24/services/pairs.rb
@@ -1,0 +1,26 @@
+module Cryptoexchange::Exchanges
+  module Btc24
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+
+        def fetch
+          output = super
+          adapt(output)
+        end
+
+        def adapt(output)
+          market_pairs = []
+          output.each do |pair|
+            market_pairs << Cryptoexchange::Models::MarketPair.new(
+                base: pair[:base],
+                target: pair[:target],
+                market: Btc24::Market::NAME
+            )
+          end
+
+          market_pairs
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/Btc24/integration_specs_fetch_order_book.yml
+++ b/spec/cassettes/vcr_cassettes/Btc24/integration_specs_fetch_order_book.yml
@@ -1,0 +1,34 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://cryptottlivewebapi.btc24.io:8443/api/v1/public/level2/btcusd
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Host:
+      - cryptottlivewebapi.btc24.io
+      User-Agent:
+      - http.rb/1.0.4
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - 'gzip'
+      Content-Length:
+      - '478'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 26 Apr 2018 11:40:30 GMT
+      Server:
+      - Microsoft-HTTPAPI/2.0
+    body:
+      encoding: UTF-8
+      string: '[{"Timestamp":1524742822281,"BestBid":{"Volume":0.02,"Price":8806.9,"Type":"Bid"},"BestAsk":{"Volume":1.48,"Price":8874.637,"Type":"Ask"},"Bids":[{"Volume":0.02,"Price":8806.9,"Type":"Bid"},{"Volume":1.94,"Price":8799.515,"Type":"Bid"},{"Volume":1.67,"Price":8796.171,"Type":"Bid"},{"Volume":2.5,"Price":8796.134,"Type":"Bid"},{"Volume":0.57,"Price":8795.594,"Type":"Bid"},{"Volume":0.16,"Price":8794.9,"Type":"Bid"},{"Volume":0.1,"Price":8790.981,"Type":"Bid"},{"Volume":0.05,"Price":8788.586,"Type":"Bid"},{"Volume":1,"Price":8785.3,"Type":"Bid"},{"Volume":0.11,"Price":8785.142,"Type":"Bid"},{"Volume":3.16,"Price":8781.221,"Type":"Bid"},{"Volume":6,"Price":8777.1,"Type":"Bid"},{"Volume":2.64,"Price":8776.074,"Type":"Bid"},{"Volume":0.02,"Price":8775.482,"Type":"Bid"},{"Volume":0.05,"Price":8774.985,"Type":"Bid"},{"Volume":8.05,"Price":8774.9,"Type":"Bid"},{"Volume":0.01,"Price":8773.9,"Type":"Bid"},{"Volume":5.32,"Price":8772.9,"Type":"Bid"},{"Volume":4.5,"Price":8770.848,"Type":"Bid"},{"Volume":0.3,"Price":8767.047,"Type":"Bid"}],"Asks":[{"Volume":1.48,"Price":8874.637,"Type":"Ask"},{"Volume":1.87,"Price":8889.302,"Type":"Ask"},{"Volume":2.12,"Price":8889.324,"Type":"Ask"},{"Volume":1.75,"Price":8889.346,"Type":"Ask"},{"Volume":2.37,"Price":8890.808,"Type":"Ask"},{"Volume":0.3,"Price":8893.757,"Type":"Ask"},{"Volume":2.5,"Price":8896.007,"Type":"Ask"},{"Volume":2.4,"Price":8901.462,"Type":"Ask"},{"Volume":2.65,"Price":8906.547,"Type":"Ask"},{"Volume":3.2,"Price":8912.276,"Type":"Ask"},{"Volume":0.22,"Price":8913.385,"Type":"Ask"},{"Volume":0.02,"Price":8914.763,"Type":"Ask"},{"Volume":2.5,"Price":8921.343,"Type":"Ask"},{"Volume":8.96,"Price":8925.1,"Type":"Ask"},{"Volume":5.29,"Price":8926.069,"Type":"Ask"},{"Volume":6.38,"Price":8926.456,"Type":"Ask"},{"Volume":4.05,"Price":8928.946,"Type":"Ask"},{"Volume":0.19,"Price":8932.088,"Type":"Ask"},{"Volume":0.4,"Price":8943.1,"Type":"Ask"},{"Volume":0.05,"Price":8946.078,"Type":"Ask"}],"Symbol":"BTCUSD"}]'
+    http_version: 
+  recorded_at: Thu, 26 Apr 2018 11:40:30 GMT
+recorded_with: VCR 3.0.3

--- a/spec/cassettes/vcr_cassettes/Btc24/integration_specs_fetch_order_book.yml
+++ b/spec/cassettes/vcr_cassettes/Btc24/integration_specs_fetch_order_book.yml
@@ -2,33 +2,40 @@
 http_interactions:
 - request:
     method: get
-    uri: https://cryptottlivewebapi.btc24.io:8443/api/v1/public/level2/btcusd
+    uri: https://cryptottlivewebapi.btc24.io:8443/api/v1/public/level2/BTCUSD
     body:
-      encoding: US-ASCII
+      encoding: UTF-8
       string: ''
     headers:
+      Accept-Encoding:
+      - gzip
+      Connection:
+      - close
       Host:
-      - cryptottlivewebapi.btc24.io
+      - cryptottlivewebapi.btc24.io:8443
       User-Agent:
-      - http.rb/1.0.4
+      - http.rb/3.0.0
   response:
     status:
       code: 200
       message: OK
     headers:
-      Content-Encoding:
-      - 'gzip'
       Content-Length:
-      - '478'
+      - '449'
       Content-Type:
       - application/json; charset=utf-8
-      Date:
-      - Thu, 26 Apr 2018 11:40:30 GMT
+      Content-Encoding:
+      - gzip
       Server:
       - Microsoft-HTTPAPI/2.0
+      Date:
+      - Fri, 27 Apr 2018 12:07:39 GMT
+      Connection:
+      - close
     body:
       encoding: UTF-8
-      string: '[{"Timestamp":1524742822281,"BestBid":{"Volume":0.02,"Price":8806.9,"Type":"Bid"},"BestAsk":{"Volume":1.48,"Price":8874.637,"Type":"Ask"},"Bids":[{"Volume":0.02,"Price":8806.9,"Type":"Bid"},{"Volume":1.94,"Price":8799.515,"Type":"Bid"},{"Volume":1.67,"Price":8796.171,"Type":"Bid"},{"Volume":2.5,"Price":8796.134,"Type":"Bid"},{"Volume":0.57,"Price":8795.594,"Type":"Bid"},{"Volume":0.16,"Price":8794.9,"Type":"Bid"},{"Volume":0.1,"Price":8790.981,"Type":"Bid"},{"Volume":0.05,"Price":8788.586,"Type":"Bid"},{"Volume":1,"Price":8785.3,"Type":"Bid"},{"Volume":0.11,"Price":8785.142,"Type":"Bid"},{"Volume":3.16,"Price":8781.221,"Type":"Bid"},{"Volume":6,"Price":8777.1,"Type":"Bid"},{"Volume":2.64,"Price":8776.074,"Type":"Bid"},{"Volume":0.02,"Price":8775.482,"Type":"Bid"},{"Volume":0.05,"Price":8774.985,"Type":"Bid"},{"Volume":8.05,"Price":8774.9,"Type":"Bid"},{"Volume":0.01,"Price":8773.9,"Type":"Bid"},{"Volume":5.32,"Price":8772.9,"Type":"Bid"},{"Volume":4.5,"Price":8770.848,"Type":"Bid"},{"Volume":0.3,"Price":8767.047,"Type":"Bid"}],"Asks":[{"Volume":1.48,"Price":8874.637,"Type":"Ask"},{"Volume":1.87,"Price":8889.302,"Type":"Ask"},{"Volume":2.12,"Price":8889.324,"Type":"Ask"},{"Volume":1.75,"Price":8889.346,"Type":"Ask"},{"Volume":2.37,"Price":8890.808,"Type":"Ask"},{"Volume":0.3,"Price":8893.757,"Type":"Ask"},{"Volume":2.5,"Price":8896.007,"Type":"Ask"},{"Volume":2.4,"Price":8901.462,"Type":"Ask"},{"Volume":2.65,"Price":8906.547,"Type":"Ask"},{"Volume":3.2,"Price":8912.276,"Type":"Ask"},{"Volume":0.22,"Price":8913.385,"Type":"Ask"},{"Volume":0.02,"Price":8914.763,"Type":"Ask"},{"Volume":2.5,"Price":8921.343,"Type":"Ask"},{"Volume":8.96,"Price":8925.1,"Type":"Ask"},{"Volume":5.29,"Price":8926.069,"Type":"Ask"},{"Volume":6.38,"Price":8926.456,"Type":"Ask"},{"Volume":4.05,"Price":8928.946,"Type":"Ask"},{"Volume":0.19,"Price":8932.088,"Type":"Ask"},{"Volume":0.4,"Price":8943.1,"Type":"Ask"},{"Volume":0.05,"Price":8946.078,"Type":"Ask"}],"Symbol":"BTCUSD"}]'
+      string: !binary |-
+        H4sIAAAAAAAEAJ2WyW7CQAyG7zxFlDOyxp69t9I+QCVoL4hDFw5RiUClPaCKd68HCVV4EmFxjCefPb+3ZPk7adpF16/336/9rr1r0JNL1iTvHZkpH874aNZ98BG/2rQv281Pv+YnAxSmxfL01b0XQ6YcIJ9Mi8OuWNrCTZrj2c39/nPAjcFLN9ZlwAs3hTu76T72bFrefpcqPlqJenBEOtjkAViJUo1SCBoYJem0Yq1EUwDyygvLRBXWJQ3sAKXaAhttlr2E9YIlacEHVVgEVyULueCqwARW3jnmW+8clb2MEFKNcl8pB0Gy3I/JKgNXar0Y4tHO8HKEAicqKlNl5NwH7gxVYOTEDLAa1EJyNZoGu2pVthYvsMGtpV9914plPd5MykqNk1GgrDqkqIERz/n5pyNCdMrQdoANVseSVFz1pl4xzxMaFUwgWtMm9ue8hnW8VyXM/WpUgglkonnVOlImSw6UTfFsu1biak3blMDpFFM1jTaXEquaa2CQMkFWBUbISbIquSTF8h+H/DiMipXVZdZnldaKdaZsX1Vcw58+CY+MwmltzQ/923ZzWmaLh+f5Yzs5rv4ARh9ZWzEKAAA=
     http_version: 
-  recorded_at: Thu, 26 Apr 2018 11:40:30 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Fri, 27 Apr 2018 12:07:40 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Btc24/integration_specs_fetch_order_book.yml
+++ b/spec/cassettes/vcr_cassettes/Btc24/integration_specs_fetch_order_book.yml
@@ -21,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       Content-Length:
-      - '449'
+      - '457'
       Content-Type:
       - application/json; charset=utf-8
       Content-Encoding:
@@ -29,13 +29,13 @@ http_interactions:
       Server:
       - Microsoft-HTTPAPI/2.0
       Date:
-      - Fri, 27 Apr 2018 12:07:39 GMT
+      - Fri, 27 Apr 2018 12:15:16 GMT
       Connection:
       - close
     body:
       encoding: UTF-8
       string: !binary |-
-        H4sIAAAAAAAEAJ2WyW7CQAyG7zxFlDOyxp69t9I+QCVoL4hDFw5RiUClPaCKd68HCVV4EmFxjCefPb+3ZPk7adpF16/336/9rr1r0JNL1iTvHZkpH874aNZ98BG/2rQv281Pv+YnAxSmxfL01b0XQ6YcIJ9Mi8OuWNrCTZrj2c39/nPAjcFLN9ZlwAs3hTu76T72bFrefpcqPlqJenBEOtjkAViJUo1SCBoYJem0Yq1EUwDyygvLRBXWJQ3sAKXaAhttlr2E9YIlacEHVVgEVyULueCqwARW3jnmW+8clb2MEFKNcl8pB0Gy3I/JKgNXar0Y4tHO8HKEAicqKlNl5NwH7gxVYOTEDLAa1EJyNZoGu2pVthYvsMGtpV9914plPd5MykqNk1GgrDqkqIERz/n5pyNCdMrQdoANVseSVFz1pl4xzxMaFUwgWtMm9ue8hnW8VyXM/WpUgglkonnVOlImSw6UTfFsu1biak3blMDpFFM1jTaXEquaa2CQMkFWBUbISbIquSTF8h+H/DiMipXVZdZnldaKdaZsX1Vcw58+CY+MwmltzQ/923ZzWmaLh+f5Yzs5rv4ARh9ZWzEKAAA=
+        H4sIAAAAAAAEAKWVv24CMQzGd57idDOykjhxkm6lfYBK0C6IoX8YTuUEKu2AKt69zgmGOlfhtiPO/Rz7s/Ox/Jw07aLr1/v3x37XXjU2OJ/QukjJpykfzvho1r3wEX/atA/bzUe/5l8GTJyWyN1b91wCGY0FRDsEF4ddibWFnDTHc6Lr/WuVyEbwJDJRgO95CnjO073sObT8TzlVLxYlbABN1sGCdTlBIKdhnSQJMkUVCZFGYA1qJef/xiU6dX5RIDOCOqNSyCKEijaskk6kVKNGORrAIOCYdUIhOLkSMUBQXWtAdsuoS0qhK1Y5Wg8hC5S42aiCHTgvYX6/WbXHZR4S5qJVz9aCq6pWNjyyk8Rj05Ysx1tYO1rzqlgWu9eIZf3K+KoanPAOjFzDaRAXYdn8AOegg0l6ZVQWbUfuJbBG2bFk+S1br6xZlpw8IKnE8mC8hNn4clYqLSec4jl2Wa0g2QRe13HtXpj57zArpa7mlB3o1sNBdS+BT0pWKs1sED7yA4uQBewNGxOhruFAElY/RDlhbwhM0q4H1rDqXtY5STQCetVOW8gVnGC05MG/5of+absZXG1xcz+/bSfH1Rc0AUpsOgoAAA==
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 12:07:40 GMT
+  recorded_at: Fri, 27 Apr 2018 12:15:18 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Btc24/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/Btc24/integration_specs_fetch_ticker.yml
@@ -1,0 +1,41 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://cryptottlivewebapi.btc24.io:8443/api/v1/public/ticker/BTCUSD
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip
+      Connection:
+      - close
+      Host:
+      - cryptottlivewebapi.btc24.io:8443
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Length:
+      - '203'
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Encoding:
+      - gzip
+      Server:
+      - Microsoft-HTTPAPI/2.0
+      Date:
+      - Fri, 27 Apr 2018 12:05:25 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: !binary |-
+        H4sIAAAAAAAEAG2POw+CMBhFd34FYTZNn5S6WRkdTEAX41ClQ2MJhsdAjP/dFkNSCOs999yvvX2iOMmVsWPZqkpXZdMre23sUOtkH0MA6W5ZKLQN+ArKYdx2pe56b55b81yKnjhtBgJTCBhOPT+pv1Sa2pVU/XYcMYwzChFDGYFhKbxLQjAvc0ggEILNzB1dDVOeCYFSntGgE+6iIN96sP/LoXv5lNAUCEzmVJpq6nIGppFirB+NdVEiy+OlyJPoe/8BxG7iy4sBAAA=
+    http_version: 
+  recorded_at: Fri, 27 Apr 2018 12:05:26 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Btc24/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/Btc24/integration_specs_fetch_ticker.yml
@@ -29,13 +29,13 @@ http_interactions:
       Server:
       - Microsoft-HTTPAPI/2.0
       Date:
-      - Fri, 27 Apr 2018 12:05:25 GMT
+      - Fri, 27 Apr 2018 12:15:16 GMT
       Connection:
       - close
     body:
       encoding: UTF-8
       string: !binary |-
-        H4sIAAAAAAAEAG2POw+CMBhFd34FYTZNn5S6WRkdTEAX41ClQ2MJhsdAjP/dFkNSCOs999yvvX2iOMmVsWPZqkpXZdMre23sUOtkH0MA6W5ZKLQN+ArKYdx2pe56b55b81yKnjhtBgJTCBhOPT+pv1Sa2pVU/XYcMYwzChFDGYFhKbxLQjAvc0ggEILNzB1dDVOeCYFSntGgE+6iIN96sP/LoXv5lNAUCEzmVJpq6nIGppFirB+NdVEiy+OlyJPoe/8BxG7iy4sBAAA=
+        H4sIAAAAAAAEAG2PvQ7CIBhF9z5F09kQKNAWN7Gjg0nRxTigZWiE1PRnaIzvLtSQ0KbrOffeD26fKE5K2ehJdLJWtWgHqa+tHo1K9jEEkOyWgUrpwK8kH6ftLlf94Jrnrnkui87YmhcsJRDQNHP+JP8l0RgbkuZtPaJpWhCIKCowDEPhXRwKv5xDDAFj1Dt7dDVM8oIxlOUFCTLhLgr41oPdXw79y1GcUYA84009M4gAxjOtJvNotYUJF8dLVSbR9/4D9NEtWYsBAAA=
     http_version: 
-  recorded_at: Fri, 27 Apr 2018 12:05:26 GMT
+  recorded_at: Fri, 27 Apr 2018 12:15:18 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Latoken/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/Latoken/integration_specs_fetch_pairs.yml
@@ -12,29 +12,36 @@ http_interactions:
       Host:
       - api.latoken.com
       User-Agent:
-      - http.rb/2.1.0
+      - http.rb/3.0.0
   response:
     status:
       code: 200
       message: OK
     headers:
-      Server:
-      - cloudflare
       Date:
-      - Fri, 16 Mar 2018 09:32:29 GMT
+      - Fri, 04 May 2018 13:00:28 GMT
       Content-Type:
       - application/json; charset=utf-8
-      Connection:
-      - keep-alive
       Transfer-Encoding:
       - chunked
-      Status:
-      - 200 OK
-      Content-Encoding:
-      - gzip
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d00f7d8c86a26f41f0f3179f94f4a21d71525438828; expires=Sat, 04-May-19
+        13:00:28 GMT; path=/; domain=.latoken.com; HttpOnly; Secure
+      X-Powered-By:
+      - Express
+      Etag:
+      - W/"c00-SEexUMF1uZ3g3QauCgvyexyJVOs"
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 415b26833a1f4ed2-DME
     body:
       encoding: UTF-8
-      string: '[{"baseSymbol":"ETH","targetSymbol":"LA"},{"baseSymbol":"LA","targetSymbol":"SALT"},{"baseSymbol":"LA","targetSymbol":"REP"},{"baseSymbol":"LA","targetSymbol":"MANA"},{"baseSymbol":"LA","targetSymbol":"SAN"},{"baseSymbol":"LA","targetSymbol":"BAT"},{"baseSymbol":"LA","targetSymbol":"PAY"},{"baseSymbol":"LA","targetSymbol":"QASH"},{"baseSymbol":"LA","targetSymbol":"POWR"},{"baseSymbol":"LA","targetSymbol":"MCO"},{"baseSymbol":"LA","targetSymbol":"AION"},{"baseSymbol":"LA","targetSymbol":"FUN"},{"baseSymbol":"LA","targetSymbol":"WTC"},{"baseSymbol":"LA","targetSymbol":"GNO"},{"baseSymbol":"LA","targetSymbol":"AE"},{"baseSymbol":"LA","targetSymbol":"RDN"},{"baseSymbol":"LA","targetSymbol":"VERI"},{"baseSymbol":"LA","targetSymbol":"SNT"},{"baseSymbol":"LA","targetSymbol":"BNT"},{"baseSymbol":"LA","targetSymbol":"VEN"},{"baseSymbol":"LA","targetSymbol":"PPT"},{"baseSymbol":"ETH","targetSymbol":"PAY"},{"baseSymbol":"ETH","targetSymbol":"POWR"},{"baseSymbol":"ETH","targetSymbol":"AION"},{"baseSymbol":"ETH","targetSymbol":"FUN"},{"baseSymbol":"ETH","targetSymbol":"WTC"},{"baseSymbol":"ETH","targetSymbol":"GNO"},{"baseSymbol":"ETH","targetSymbol":"RDN"},{"baseSymbol":"ETH","targetSymbol":"VERI"},{"baseSymbol":"ETH","targetSymbol":"SNT"},{"baseSymbol":"ETH","targetSymbol":"BNT"},{"baseSymbol":"ETH","targetSymbol":"VEN"},{"baseSymbol":"ETH","targetSymbol":"PPT"},{"baseSymbol":"BTC","targetSymbol":"PAY"},{"baseSymbol":"BTC","targetSymbol":"POWR"},{"baseSymbol":"BTC","targetSymbol":"AION"},{"baseSymbol":"BTC","targetSymbol":"FUN"},{"baseSymbol":"BTC","targetSymbol":"WTC"},{"baseSymbol":"BTC","targetSymbol":"GNO"},{"baseSymbol":"BTC","targetSymbol":"RDN"},{"baseSymbol":"BTC","targetSymbol":"VERI"},{"baseSymbol":"BTC","targetSymbol":"SNT"},{"baseSymbol":"BTC","targetSymbol":"BNT"},{"baseSymbol":"BTC","targetSymbol":"VEN"},{"baseSymbol":"BTC","targetSymbol":"PPT"},{"baseSymbol":"USDT","targetSymbol":"PAY"},{"baseSymbol":"USDT","targetSymbol":"POWR"},{"baseSymbol":"USDT","targetSymbol":"AION"},{"baseSymbol":"USDT","targetSymbol":"FUN"},{"baseSymbol":"USDT","targetSymbol":"WTC"},{"baseSymbol":"USDT","targetSymbol":"GNO"},{"baseSymbol":"USDT","targetSymbol":"RDN"},{"baseSymbol":"USDT","targetSymbol":"VERI"},{"baseSymbol":"USDT","targetSymbol":"SNT"},{"baseSymbol":"USDT","targetSymbol":"BNT"},{"baseSymbol":"USDT","targetSymbol":"VEN"},{"baseSymbol":"USDT","targetSymbol":"PPT"},{"baseSymbol":"TMT","targetSymbol":"TAT"},{"baseSymbol":"USDT","targetSymbol":"EOS"},{"baseSymbol":"USDT","targetSymbol":"TRX"},{"baseSymbol":"USDT","targetSymbol":"ICX"},{"baseSymbol":"BTC","targetSymbol":"EOS"},{"baseSymbol":"BTC","targetSymbol":"TRX"},{"baseSymbol":"BTC","targetSymbol":"ICX"},{"baseSymbol":"ETH","targetSymbol":"EOS"},{"baseSymbol":"ETH","targetSymbol":"TRX"},{"baseSymbol":"ETH","targetSymbol":"ICX"},{"baseSymbol":"LA","targetSymbol":"EOS"},{"baseSymbol":"LA","targetSymbol":"TRX"},{"baseSymbol":"LA","targetSymbol":"ICX"}]'
+      string: '[{"baseSymbol":"ETH","targetSymbol":"LA"},{"baseSymbol":"LA","targetSymbol":"MTRc"},{"baseSymbol":"LA","targetSymbol":"SALT"},{"baseSymbol":"LA","targetSymbol":"REP"},{"baseSymbol":"LA","targetSymbol":"MANA"},{"baseSymbol":"LA","targetSymbol":"SAN"},{"baseSymbol":"LA","targetSymbol":"BAT"},{"baseSymbol":"LA","targetSymbol":"PAY"},{"baseSymbol":"LA","targetSymbol":"QASH"},{"baseSymbol":"LA","targetSymbol":"POWR"},{"baseSymbol":"LA","targetSymbol":"MCO"},{"baseSymbol":"LA","targetSymbol":"AION"},{"baseSymbol":"LA","targetSymbol":"FUN"},{"baseSymbol":"LA","targetSymbol":"WTC"},{"baseSymbol":"LA","targetSymbol":"GNO"},{"baseSymbol":"LA","targetSymbol":"AE"},{"baseSymbol":"LA","targetSymbol":"RDN"},{"baseSymbol":"LA","targetSymbol":"VERI"},{"baseSymbol":"LA","targetSymbol":"SNT"},{"baseSymbol":"LA","targetSymbol":"BNT"},{"baseSymbol":"LA","targetSymbol":"VEN"},{"baseSymbol":"LA","targetSymbol":"PPT"},{"baseSymbol":"ETH","targetSymbol":"PAY"},{"baseSymbol":"ETH","targetSymbol":"POWR"},{"baseSymbol":"ETH","targetSymbol":"AION"},{"baseSymbol":"ETH","targetSymbol":"FUN"},{"baseSymbol":"ETH","targetSymbol":"WTC"},{"baseSymbol":"ETH","targetSymbol":"GNO"},{"baseSymbol":"ETH","targetSymbol":"RDN"},{"baseSymbol":"ETH","targetSymbol":"VERI"},{"baseSymbol":"ETH","targetSymbol":"SNT"},{"baseSymbol":"ETH","targetSymbol":"BNT"},{"baseSymbol":"ETH","targetSymbol":"VEN"},{"baseSymbol":"ETH","targetSymbol":"PPT"},{"baseSymbol":"BTC","targetSymbol":"PAY"},{"baseSymbol":"BTC","targetSymbol":"POWR"},{"baseSymbol":"BTC","targetSymbol":"AION"},{"baseSymbol":"BTC","targetSymbol":"FUN"},{"baseSymbol":"BTC","targetSymbol":"WTC"},{"baseSymbol":"BTC","targetSymbol":"GNO"},{"baseSymbol":"BTC","targetSymbol":"RDN"},{"baseSymbol":"BTC","targetSymbol":"VERI"},{"baseSymbol":"BTC","targetSymbol":"SNT"},{"baseSymbol":"BTC","targetSymbol":"BNT"},{"baseSymbol":"BTC","targetSymbol":"VEN"},{"baseSymbol":"BTC","targetSymbol":"PPT"},{"baseSymbol":"USDT","targetSymbol":"PAY"},{"baseSymbol":"USDT","targetSymbol":"POWR"},{"baseSymbol":"USDT","targetSymbol":"AION"},{"baseSymbol":"USDT","targetSymbol":"FUN"},{"baseSymbol":"USDT","targetSymbol":"WTC"},{"baseSymbol":"USDT","targetSymbol":"GNO"},{"baseSymbol":"USDT","targetSymbol":"RDN"},{"baseSymbol":"USDT","targetSymbol":"VERI"},{"baseSymbol":"USDT","targetSymbol":"SNT"},{"baseSymbol":"USDT","targetSymbol":"BNT"},{"baseSymbol":"USDT","targetSymbol":"VEN"},{"baseSymbol":"USDT","targetSymbol":"PPT"},{"baseSymbol":"USDT","targetSymbol":"EOS"},{"baseSymbol":"USDT","targetSymbol":"TRX"},{"baseSymbol":"USDT","targetSymbol":"ICX"},{"baseSymbol":"BTC","targetSymbol":"EOS"},{"baseSymbol":"BTC","targetSymbol":"TRX"},{"baseSymbol":"BTC","targetSymbol":"ICX"},{"baseSymbol":"ETH","targetSymbol":"EOS"},{"baseSymbol":"ETH","targetSymbol":"TRX"},{"baseSymbol":"ETH","targetSymbol":"ICX"},{"baseSymbol":"LA","targetSymbol":"EOS"},{"baseSymbol":"LA","targetSymbol":"TRX"},{"baseSymbol":"LA","targetSymbol":"ICX"},{"baseSymbol":"ETH","targetSymbol":"MTRc"},{"baseSymbol":"LA","targetSymbol":"CPT"},{"baseSymbol":"ETH","targetSymbol":"CPT"}]'
     http_version: 
-  recorded_at: Fri, 16 Mar 2018 09:32:29 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Fri, 04 May 2018 13:00:28 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Latoken/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/Latoken/integration_specs_fetch_ticker.yml
@@ -12,29 +12,36 @@ http_interactions:
       Host:
       - api.latoken.com
       User-Agent:
-      - http.rb/2.1.0
+      - http.rb/3.0.0
   response:
     status:
       code: 200
       message: OK
     headers:
-      Server:
-      - cloudflare
       Date:
-      - Fri, 16 Mar 2018 09:33:54 GMT
+      - Fri, 04 May 2018 13:00:28 GMT
       Content-Type:
       - application/json; charset=utf-8
-      Connection:
-      - keep-alive
       Transfer-Encoding:
       - chunked
-      Status:
-      - 200 OK
-      Content-Encoding:
-      - gzip
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=df8f0a5e820d915086a8b3662f54a0b061525438828; expires=Sat, 04-May-19
+        13:00:28 GMT; path=/; domain=.latoken.com; HttpOnly; Secure
+      X-Powered-By:
+      - Express
+      Etag:
+      - W/"8a-NYwYmzDIaxTb5u9VkvD0nVo65UE"
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 415b26849cb24f3e-DME
     body:
       encoding: UTF-8
-      string: '{"ask":0.000338,"bid":0.00031792,"last_price":0.00033694,"high":0.00034331,"low":0.0003194,"volume":238.6178398628,"timestamp":1521192834}'
+      string: '{"ask":0.0003161,"bid":0.0003152,"last_price":0.0003152,"high":0.00034,"low":0.0003163,"volume":345.79267989888734,"timestamp":1525438828}'
     http_version: 
-  recorded_at: Fri, 16 Mar 2018 09:33:54 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Fri, 04 May 2018 13:00:28 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/btc24/integration/market_spec.rb
+++ b/spec/exchanges/btc24/integration/market_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Btc24 integration specs' do
   end
 
   it 'fetch ticker' do
-    pair = Cryptoexchange::Models::MarketPair.new(base: 'BTC', target: 'USD', market: 'bitbank')
+    pair = Cryptoexchange::Models::MarketPair.new(base: 'BTC', target: 'USD', market: 'btc24')
     ticker = client.ticker(pair)
 
     expect(ticker.base).to eq 'BTC'
@@ -22,6 +22,9 @@ RSpec.describe 'Btc24 integration specs' do
     expect(ticker.market).to eq 'btc24'
     expect(ticker.last).to_not be nil
     expect(ticker.high).to_not be nil
+    expect(ticker.low).to_not be nil
+    expect(ticker.ask).to_not be nil
+    expect(ticker.bid).to_not be nil
     expect(ticker.volume).to_not be nil
     expect(ticker.timestamp).to be_a Numeric
     expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)

--- a/spec/exchanges/btc24/integration/market_spec.rb
+++ b/spec/exchanges/btc24/integration/market_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+RSpec.describe 'Btc24 integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+
+  it 'fetch pairs' do
+    pairs = client.pairs('btc24')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be_nil
+    expect(pair.target).to_not be_nil
+    expect(pair.market).to eq 'btc24'
+  end
+
+  it 'fetch ticker' do
+    pair = Cryptoexchange::Models::MarketPair.new(base: 'BTC', target: 'USD', market: 'bitbank')
+    ticker = client.ticker(pair)
+
+    expect(ticker.base).to eq 'BTC'
+    expect(ticker.target).to eq 'USD'
+    expect(ticker.market).to eq 'btc24'
+    expect(ticker.last).to_not be nil
+    expect(ticker.high).to_not be nil
+    expect(ticker.volume).to_not be nil
+    expect(ticker.timestamp).to be_a Numeric
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
+    expect(ticker.payload).to_not be nil
+  end
+
+  it 'fetch order book' do
+    pair = Cryptoexchange::Models::MarketPair.new(base: 'BTC', target: 'USD', market: 'btc24')
+    order_book = client.order_book(pair)
+
+    expect(order_book.base).to eq 'BTC'
+    expect(order_book.target).to eq 'USD'
+    expect(order_book.market).to eq 'btc24'
+    expect(order_book.asks).to_not be_empty
+    expect(order_book.bids).to_not be_empty
+    expect(order_book.asks.first.price).to_not be_nil
+    expect(order_book.bids.first.amount).to_not be_nil
+    expect(order_book.bids.first.timestamp).to_not be_nil
+    expect(order_book.timestamp).to be_a Numeric
+    expect(order_book.payload).to_not be nil
+  end
+
+end

--- a/spec/exchanges/btc24/market_spec.rb
+++ b/spec/exchanges/btc24/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Btc24::Market do
+  it { expect(described_class::NAME).to eq 'btc24' }
+  it { expect(described_class::API_URL).to eq 'https://cryptottlivewebapi.btc24.io:8443/api/v1/public' }
+end


### PR DESCRIPTION
This PR adds BTC24 support, which was requested in [this issue](https://github.com/coingecko/cryptoexchange/issues/437). There's only Ticker and Orderbook atm.
This PR depends on [another one](https://github.com/coingecko/cryptoexchange/pull/479), because BTC24 returns gzipped data. If that PR rejected, you could accept this one until [this commit](https://github.com/coingecko/cryptoexchange/pull/480/commits/453d3e405a6cb92251d1937a2e5f52fe2cb17d0a) (parsing gzip).
- [X] I have added Specs
- [X] I have verified that the `volume` refers to BASE
- [X] I have verified that the `base` and `target` is assigned correctly


