### PR TITLE
Implement Coinnox ticker, order book and trades

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Or install it yourself as:
 | Coinhouse         | Y       |            |         |         | Y           |
 | Coinmate          | Y       | Y          |         |         | User-Defined|
 | Coinnest          | Y       | Y          | Y       |         | User-Defined|
+| Coinnox           | Y       | Y          | Y       |         | Y           |
 | Coinroom          | Y       |            |         |         | Y           |
 | Coinone           | Y       | Y          | Y       |         | Y           |
 | Coinrail          | Y       | Y          | Y       |         | Y           |

--- a/lib/cryptoexchange/exchanges/coinnox/market.rb
+++ b/lib/cryptoexchange/exchanges/coinnox/market.rb
@@ -1,0 +1,8 @@
+module Cryptoexchange::Exchanges
+  module Coinnox
+    class Market
+      NAME = 'coinnox'
+      API_URL = 'https://coinnox.com/api/v2'
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/coinnox/services/market.rb
+++ b/lib/cryptoexchange/exchanges/coinnox/services/market.rb
@@ -1,0 +1,52 @@
+module Cryptoexchange::Exchanges
+  module Coinnox
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            false
+          end
+        end
+
+        def fetch
+          output = super(ticker_url)
+          adapt_all(output)
+        end
+
+        def ticker_url
+          "#{Cryptoexchange::Exchanges::Coinnox::Market::API_URL}/tickers"
+        end
+
+        def adapt_all(output)
+          output.map do |key, value|
+            separator = /(USDT|BTC|BCH|ETH)\z/i =~ key
+            base      = key[0..separator - 1]
+            target    = key[separator..-1]
+            market_pair = Cryptoexchange::Models::MarketPair.new(
+              base: base,
+              target: target,
+              market: Coinnox::Market::NAME
+            )
+            adapt(value, market_pair)
+          end
+        end
+
+        def adapt(output, market_pair)
+          ticker = Cryptoexchange::Models::Ticker.new
+          ticker.base      = market_pair.base
+          ticker.target    = market_pair.target
+          ticker.market    = Coinnox::Market::NAME
+          ticker.ask       = NumericHelper.to_d(HashHelper.dig(output, 'ticker', 'sell'))
+          ticker.bid       = NumericHelper.to_d(HashHelper.dig(output, 'ticker', 'buy'))
+          ticker.last      = NumericHelper.to_d(HashHelper.dig(output, 'ticker', 'last'))
+          ticker.high      = NumericHelper.to_d(HashHelper.dig(output, 'ticker', 'high'))
+          ticker.low       = NumericHelper.to_d(HashHelper.dig(output, 'ticker', 'low'))
+          ticker.volume    = NumericHelper.to_d(HashHelper.dig(output, 'ticker', 'vol'))
+          ticker.timestamp = NumericHelper.to_d(output['at'])
+          ticker.payload   = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/coinnox/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/coinnox/services/order_book.rb
@@ -1,0 +1,44 @@
+module Cryptoexchange::Exchanges
+  module Coinnox
+    module Services
+      class OrderBook < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          base   = market_pair.base.downcase
+          target = market_pair.target.downcase
+          "#{Cryptoexchange::Exchanges::Coinnox::Market::API_URL}/depth?market=#{base}#{target}&limit=300"
+        end
+
+        def adapt(output, market_pair)
+          order_book           = Cryptoexchange::Models::OrderBook.new
+          order_book.base      = market_pair.base
+          order_book.target    = market_pair.target
+          order_book.market    = Coinnox::Market::NAME
+          order_book.asks      = adapt_orders(output['asks'])
+          order_book.bids      = adapt_orders(output['bids'])
+          order_book.timestamp = output['timestamp']
+          order_book.payload   = output
+          order_book
+        end
+
+        def adapt_orders(orders)
+          orders.collect do |order_entry|
+            price, amount = order_entry
+            Cryptoexchange::Models::Order.new(price:  price,
+                                              amount: amount)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/coinnox/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/coinnox/services/pairs.rb
@@ -1,0 +1,25 @@
+module Cryptoexchange::Exchanges
+  module Coinnox
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Coinnox::Market::API_URL}/markets"
+
+        def fetch
+          output = super
+          adapt(output)
+        end
+
+        def adapt(output)
+          output.map do |pair|
+            base, target = pair['name'].split('/')
+            Cryptoexchange::Models::MarketPair.new(
+              base:   base,
+              target: target,
+              market: Coinnox::Market::NAME
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/coinnox/services/trades.rb
+++ b/lib/cryptoexchange/exchanges/coinnox/services/trades.rb
@@ -1,0 +1,33 @@
+module Cryptoexchange::Exchanges
+  module Coinnox
+    module Services
+      class Trades < Cryptoexchange::Services::Market
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          base = market_pair.base.downcase
+          target = market_pair.target.downcase
+          "#{Cryptoexchange::Exchanges::Coinnox::Market::API_URL}/trades?market=#{base}#{target}&limit=50&order_by=desc"
+        end
+
+        def adapt(output, market_pair)
+          output.collect do |trade|
+            tr = Cryptoexchange::Models::Trade.new
+            tr.trade_id  = trade['id']
+            tr.base      = market_pair.base
+            tr.target    = market_pair.target
+            tr.market    = Coinnox::Market::NAME
+            tr.price     = trade['price']
+            tr.amount    = trade['volume']
+            tr.timestamp = Time.parse(trade['created_at']).to_i
+            tr.payload   = trade
+            tr
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/Coinnox/integration_specs_fetch_order_book.yml
+++ b/spec/cassettes/vcr_cassettes/Coinnox/integration_specs_fetch_order_book.yml
@@ -1,0 +1,88 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://coinnox.com/api/v2/depth?limit=300&market=trfbtc
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - coinnox.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 19 May 2018 08:05:44 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1093'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=db15c4c036cad89a58daf2ee781f5d87d1526717143; expires=Sun, 19-May-19
+        08:05:43 GMT; path=/; domain=.coinnox.com; HttpOnly
+      Access-Control-Allow-Origin:
+      - coinnox.com
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept, Authorization
+      Vary:
+      - Origin
+      Version:
+      - HTTP/1.1
+      Host:
+      - coinnox.com
+      X-Real-Ip:
+      - 59.148.173.158
+      X-Forwarded-For:
+      - 59.148.173.158, 59.148.173.158
+      X-Forwarded-Proto:
+      - https
+      X-Forwarded-Ssl:
+      - 'on'
+      X-Forwarded-Port:
+      - '443'
+      Accept-Encoding:
+      - gzip
+      Cf-Ipcountry:
+      - HK
+      Cf-Visitor:
+      - '{"scheme":"https"}'
+      User-Agent:
+      - http.rb/3.0.0
+      Cf-Connecting-Ip:
+      - 59.148.173.158
+      X-Forwarded-Host:
+      - coinnox.com
+      Etag:
+      - W/"0676311be62dbb597c6727bafdab5f07"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - f183ce5a-652b-4e74-b8c7-60607a9ddac4
+      X-Runtime:
+      - '0.003521'
+      Strict-Transport-Security:
+      - max-age=31536000
+      - max-age=31536000
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 41d50f6598e1aa4a-SIN
+    body:
+      encoding: ASCII-8BIT
+      string: '{"timestamp":1526717144,"asks":[["0.00001954","4.0"],["0.00001951","4.0"],["0.00001947","2.0"],["0.00001927","2.0"],["0.00001915","2.0"],["0.00001855","33.0"],["0.00001825","50.0"],["0.00001805","50.0"],["0.00001775","20.0"],["0.00001771","10.0"],["0.00001769","20.0"],["0.00001765","20.0"],["0.00001755","10.0"],["0.00001735","20.0"],["0.00001725","40.0"],["0.00001688","20.0"],["0.00001686","51.0"],["0.00001685","20.0"],["0.00001684","20.0"],["0.00001683","15.0"],["0.00001682","10.0"],["0.00001681","30.0"],["0.00001679","10.0"],["0.00001678","20.0"],["0.00001677","10.0"],["0.00001676","52.47054686"],["0.00001675","10.0"],["0.00001671","18.0"],["0.00001669","89.0"],["0.00001668","98.52016"],["0.00001667","5.08032"],["0.00001666","9.04032"]],"bids":[["0.00001665","1.47984"],["0.00001664","44.95968"],["0.00001663","5.95968"],["0.00001662","31.48002"],["0.0000166","23.84"],["0.00001656","1.312"],["0.00001654","4.28"],["0.00001652","22.64"],["0.0000165","1.08"],["0.0000164","2.32"],["0.0000162","101.56"],["0.00000522","11.12563364"],["0.00000517","0.56281682"],["0.00000509","1.1"]]}'
+    http_version: 
+  recorded_at: Sat, 19 May 2018 08:05:44 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Coinnox/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/Coinnox/integration_specs_fetch_pairs.yml
@@ -1,0 +1,88 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://coinnox.com/api/v2/markets
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - coinnox.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 19 May 2018 08:05:42 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '708'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d292e1c4c68462ebe1e98623f5252d3a31526717142; expires=Sun, 19-May-19
+        08:05:42 GMT; path=/; domain=.coinnox.com; HttpOnly
+      Access-Control-Allow-Origin:
+      - coinnox.com
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept, Authorization
+      Vary:
+      - Origin
+      Version:
+      - HTTP/1.1
+      Host:
+      - coinnox.com
+      X-Real-Ip:
+      - 59.148.173.158
+      X-Forwarded-For:
+      - 59.148.173.158, 59.148.173.158
+      X-Forwarded-Proto:
+      - https
+      X-Forwarded-Ssl:
+      - 'on'
+      X-Forwarded-Port:
+      - '443'
+      Accept-Encoding:
+      - gzip
+      Cf-Ipcountry:
+      - HK
+      Cf-Visitor:
+      - '{"scheme":"https"}'
+      User-Agent:
+      - http.rb/3.0.0
+      Cf-Connecting-Ip:
+      - 59.148.173.158
+      X-Forwarded-Host:
+      - coinnox.com
+      Etag:
+      - W/"8f8e03ed4f004f4aeb2ba5f49bf7c253"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - dd87052f-25a4-4041-9180-9f975d1c724f
+      X-Runtime:
+      - '0.004213'
+      Strict-Transport-Security:
+      - max-age=31536000
+      - max-age=31536000
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 41d50f59dbf67020-SIN
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"id":"trfbtc","name":"TRF/BTC"},{"id":"ltcbtc","name":"LTC/BTC"},{"id":"dashbtc","name":"DASH/BTC"},{"id":"xzcbtc","name":"XZC/BTC"},{"id":"ethbtc","name":"ETH/BTC"},{"id":"dopebtc","name":"DOPE/BTC"},{"id":"bchbtc","name":"BCH/BTC"},{"id":"alqobtc","name":"ALQO/BTC"},{"id":"kmdbtc","name":"KMD/BTC"},{"id":"navbtc","name":"NAV/BTC"},{"id":"pivxbtc","name":"PIVX/BTC"},{"id":"superbtc","name":"SUPER/BTC"},{"id":"thcbtc","name":"THC/BTC"},{"id":"xvgbtc","name":"XVG/BTC"},{"id":"zecbtc","name":"ZEC/BTC"},{"id":"zenbtc","name":"ZEN/BTC"},{"id":"cannbtc","name":"CANN/BTC"},{"id":"qaubtc","name":"QAU/BTC"},{"id":"jcbtc","name":"JC/BTC"},{"id":"fvitbtc","name":"FVIT/BTC"},{"id":"ppibtc","name":"PPI/BTC"}]'
+    http_version: 
+  recorded_at: Sat, 19 May 2018 08:05:42 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Coinnox/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/Coinnox/integration_specs_fetch_ticker.yml
@@ -1,0 +1,88 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://coinnox.com/api/v2/tickers
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - coinnox.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 19 May 2018 08:05:43 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2627'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=db3be7739499b40bbd3fcb666ee17bcac1526717142; expires=Sun, 19-May-19
+        08:05:42 GMT; path=/; domain=.coinnox.com; HttpOnly
+      Access-Control-Allow-Origin:
+      - coinnox.com
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept, Authorization
+      Vary:
+      - Origin
+      Version:
+      - HTTP/1.1
+      Host:
+      - coinnox.com
+      X-Real-Ip:
+      - 59.148.173.158
+      X-Forwarded-For:
+      - 59.148.173.158, 59.148.173.158
+      X-Forwarded-Proto:
+      - https
+      X-Forwarded-Ssl:
+      - 'on'
+      X-Forwarded-Port:
+      - '443'
+      Accept-Encoding:
+      - gzip
+      Cf-Ipcountry:
+      - HK
+      Cf-Visitor:
+      - '{"scheme":"https"}'
+      User-Agent:
+      - http.rb/3.0.0
+      Cf-Connecting-Ip:
+      - 59.148.173.158
+      X-Forwarded-Host:
+      - coinnox.com
+      Etag:
+      - W/"af2aa2c244fbe652185738aaf3966ca7"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - ba090761-eb54-4d7f-bc7c-1f241df5e4ba
+      X-Runtime:
+      - '0.025548'
+      Strict-Transport-Security:
+      - max-age=31536000
+      - max-age=31536000
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 41d50f5f4d227098-SIN
+    body:
+      encoding: ASCII-8BIT
+      string: '{"trfbtc":{"at":1526717143,"ticker":{"buy":"0.00001665","sell":"0.00001666","low":"0.00001666","high":"0.00001671","last":"0.00001666","vol":"30.3592"}},"ltcbtc":{"at":1526717143,"ticker":{"buy":"0.0160023","sell":"0.0","low":"0.0","high":"0.0","last":"0.0170023","vol":"0.0"}},"dashbtc":{"at":1526717143,"ticker":{"buy":"0.0342702","sell":"0.0352702","low":"0.0","high":"0.0","last":"0.0442702","vol":"0.0"}},"xzcbtc":{"at":1526717143,"ticker":{"buy":"0.0030205","sell":"0.00412","low":"0.0","high":"0.0","last":"0.0030205","vol":"0.0"}},"ethbtc":{"at":1526717143,"ticker":{"buy":"0.0563352","sell":"0.0564353","low":"0.0553352","high":"0.0563352","last":"0.0563352","vol":"0.0"}},"dopebtc":{"at":1526717143,"ticker":{"buy":"0.00000797","sell":"0.00000817","low":"0.0","high":"0.0","last":"0.00000797","vol":"0.0"}},"bchbtc":{"at":1526717143,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0","high":"0.0","last":"0.0","vol":"0.0"}},"alqobtc":{"at":1526717143,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0","high":"0.0","last":"0.0","vol":"0.0"}},"kmdbtc":{"at":1526717143,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0","high":"0.0","last":"0.0","vol":"0.0"}},"navbtc":{"at":1526717143,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0","high":"0.0","last":"0.0","vol":"0.0"}},"pivxbtc":{"at":1526717143,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0","high":"0.0","last":"0.0","vol":"0.0"}},"superbtc":{"at":1526717143,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0","high":"0.0","last":"0.0","vol":"0.0"}},"thcbtc":{"at":1526717143,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0","high":"0.0","last":"0.0","vol":"0.0"}},"xvgbtc":{"at":1526717143,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0","high":"0.0","last":"0.0","vol":"0.0"}},"zecbtc":{"at":1526717143,"ticker":{"buy":"0.0315","sell":"0.0","low":"0.0","high":"0.0","last":"0.0","vol":"0.0"}},"zenbtc":{"at":1526717143,"ticker":{"buy":"0.0043","sell":"0.0","low":"0.0","high":"0.0","last":"0.0","vol":"0.0"}},"cannbtc":{"at":1526717143,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0","high":"0.0","last":"0.0","vol":"0.0"}},"qaubtc":{"at":1526717143,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0","high":"0.0","last":"0.0000001","vol":"0.0"}},"jcbtc":{"at":1526717143,"ticker":{"buy":"0.00000013","sell":"0.00000014","low":"0.00000014","high":"0.00000014","last":"0.00000014","vol":"0.1"}},"fvitbtc":{"at":1526717143,"ticker":{"buy":"0.0000011","sell":"0.0004","low":"0.000001","high":"0.0000045","last":"0.0000028","vol":"115.0"}},"ppibtc":{"at":1526717143,"ticker":{"buy":"0.00001537","sell":"0.000025","low":"0.0000095","high":"0.00001537","last":"0.00001537","vol":"12.046"}}}'
+    http_version: 
+  recorded_at: Sat, 19 May 2018 08:05:43 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Coinnox/integration_specs_fetch_trade.yml
+++ b/spec/cassettes/vcr_cassettes/Coinnox/integration_specs_fetch_trade.yml
@@ -1,0 +1,88 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://coinnox.com/api/v2/trades?limit=50&market=trfbtc&order_by=desc
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - coinnox.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 19 May 2018 08:05:45 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '7081'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d8cd51b004cb2635bf90bd139f9599cff1526717145; expires=Sun, 19-May-19
+        08:05:45 GMT; path=/; domain=.coinnox.com; HttpOnly
+      Access-Control-Allow-Origin:
+      - coinnox.com
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept, Authorization
+      Vary:
+      - Origin
+      Version:
+      - HTTP/1.1
+      Host:
+      - coinnox.com
+      X-Real-Ip:
+      - 59.148.173.158
+      X-Forwarded-For:
+      - 59.148.173.158, 59.148.173.158
+      X-Forwarded-Proto:
+      - https
+      X-Forwarded-Ssl:
+      - 'on'
+      X-Forwarded-Port:
+      - '443'
+      Accept-Encoding:
+      - gzip
+      Cf-Ipcountry:
+      - HK
+      Cf-Visitor:
+      - '{"scheme":"https"}'
+      User-Agent:
+      - http.rb/3.0.0
+      Cf-Connecting-Ip:
+      - 59.148.173.158
+      X-Forwarded-Host:
+      - coinnox.com
+      Etag:
+      - W/"6ce1b4af9d898e220d13efd7c218e814"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - eb26c6fe-624b-422d-8f46-281e1d81233d
+      X-Runtime:
+      - '0.018337'
+      Strict-Transport-Security:
+      - max-age=31536000
+      - max-age=31536000
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 41d50f6c7aa5a9ba-SIN
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"id":1237,"price":"0.00001666","volume":"10.47984","funds":"0.0001745941344","market":"trfbtc","created_at":"2018-05-19T06:59:33+02:00","side":null},{"id":1236,"price":"0.00001666","volume":"0.47984","funds":"0.0000079941344","market":"trfbtc","created_at":"2018-05-19T06:59:33+02:00","side":null},{"id":1235,"price":"0.00001667","volume":"3.43984","funds":"0.0000573421328","market":"trfbtc","created_at":"2018-05-19T06:59:14+02:00","side":null},{"id":1234,"price":"0.00001667","volume":"1.47984","funds":"0.0000246689328","market":"trfbtc","created_at":"2018-05-19T06:59:13+02:00","side":null},{"id":1233,"price":"0.00001668","volume":"1.47984","funds":"0.0000246837312","market":"trfbtc","created_at":"2018-05-19T06:56:05+02:00","side":null},{"id":1232,"price":"0.00001669","volume":"10.0","funds":"0.0001669","market":"trfbtc","created_at":"2018-05-19T06:55:55+02:00","side":null},{"id":1231,"price":"0.00001669","volume":"1.0","funds":"0.00001669","market":"trfbtc","created_at":"2018-05-19T06:55:55+02:00","side":null},{"id":1230,"price":"0.00001671","volume":"2.0","funds":"0.00003342","market":"trfbtc","created_at":"2018-05-19T06:55:43+02:00","side":null},{"id":1167,"price":"0.00001675","volume":"10.0","funds":"0.0001675","market":"trfbtc","created_at":"2018-05-15T11:10:52+02:00","side":null},{"id":1166,"price":"0.00001675","volume":"1.0","funds":"0.00001675","market":"trfbtc","created_at":"2018-05-15T11:10:52+02:00","side":null},{"id":1165,"price":"0.00001676","volume":"40.0","funds":"0.0006704","market":"trfbtc","created_at":"2018-05-15T11:10:40+02:00","side":null},{"id":1164,"price":"0.00001676","volume":"2.0","funds":"0.00003352","market":"trfbtc","created_at":"2018-05-15T11:10:40+02:00","side":null},{"id":1163,"price":"0.00001676","volume":"2.0","funds":"0.00003352","market":"trfbtc","created_at":"2018-05-15T11:10:40+02:00","side":null},{"id":1158,"price":"0.00001677","volume":"7.3181521","funds":"0.000122725410717","market":"trfbtc","created_at":"2018-05-15T06:40:40+02:00","side":null},{"id":1157,"price":"0.00001677","volume":"5.65907605","funds":"0.0000949027053585","market":"trfbtc","created_at":"2018-05-15T06:40:40+02:00","side":null},{"id":1156,"price":"0.00001677","volume":"1.65907605","funds":"0.0000278227053585","market":"trfbtc","created_at":"2018-05-15T06:40:40+02:00","side":null},{"id":1135,"price":"0.00001678","volume":"9.0","funds":"0.00015102","market":"trfbtc","created_at":"2018-05-14T17:45:39+02:00","side":null},{"id":1134,"price":"0.00001678","volume":"1.0","funds":"0.00001678","market":"trfbtc","created_at":"2018-05-14T17:45:39+02:00","side":null},{"id":1133,"price":"0.00001679","volume":"9.0","funds":"0.00015111","market":"trfbtc","created_at":"2018-05-14T17:45:28+02:00","side":null},{"id":1132,"price":"0.00001679","volume":"2.0","funds":"0.00003358","market":"trfbtc","created_at":"2018-05-14T17:45:28+02:00","side":null},{"id":1095,"price":"0.00001681","volume":"14.0","funds":"0.00023534","market":"trfbtc","created_at":"2018-05-13T12:40:53+02:00","side":null},{"id":1094,"price":"0.00001681","volume":"4.0","funds":"0.00006724","market":"trfbtc","created_at":"2018-05-13T12:40:53+02:00","side":null},{"id":1093,"price":"0.00001682","volume":"13.0","funds":"0.00021866","market":"trfbtc","created_at":"2018-05-13T12:39:19+02:00","side":null},{"id":1092,"price":"0.00001682","volume":"1.0","funds":"0.00001682","market":"trfbtc","created_at":"2018-05-13T12:33:33+02:00","side":null},{"id":1091,"price":"0.00001682","volume":"1.0","funds":"0.00001682","market":"trfbtc","created_at":"2018-05-13T12:33:20+02:00","side":null},{"id":1090,"price":"0.00001682","volume":"1.0","funds":"0.00001682","market":"trfbtc","created_at":"2018-05-13T12:32:57+02:00","side":null},{"id":1089,"price":"0.00001683","volume":"15.0","funds":"0.00025245","market":"trfbtc","created_at":"2018-05-13T12:28:37+02:00","side":null},{"id":1088,"price":"0.00001683","volume":"5.0","funds":"0.00008415","market":"trfbtc","created_at":"2018-05-13T12:28:37+02:00","side":null},{"id":1087,"price":"0.00001684","volume":"10.0","funds":"0.0001684","market":"trfbtc","created_at":"2018-05-13T12:26:16+02:00","side":null},{"id":1086,"price":"0.00001685","volume":"13.0","funds":"0.00021905","market":"trfbtc","created_at":"2018-05-13T12:23:55+02:00","side":null},{"id":1085,"price":"0.00001685","volume":"3.0","funds":"0.00005055","market":"trfbtc","created_at":"2018-05-13T12:23:55+02:00","side":null},{"id":1084,"price":"0.00001686","volume":"5.0","funds":"0.0000843","market":"trfbtc","created_at":"2018-05-13T12:22:45+02:00","side":null},{"id":1083,"price":"0.00001686","volume":"6.0","funds":"0.00010116","market":"trfbtc","created_at":"2018-05-13T12:22:45+02:00","side":null},{"id":1075,"price":"0.00001688","volume":"5.0","funds":"0.0000844","market":"trfbtc","created_at":"2018-05-10T09:35:57+02:00","side":null},{"id":1074,"price":"0.00001688","volume":"7.0","funds":"0.00011816","market":"trfbtc","created_at":"2018-05-10T09:35:57+02:00","side":null},{"id":1073,"price":"0.00001725","volume":"30.0","funds":"0.0005175","market":"trfbtc","created_at":"2018-05-10T09:35:46+02:00","side":null},{"id":1072,"price":"0.00001735","volume":"30.0","funds":"0.0005205","market":"trfbtc","created_at":"2018-05-10T09:35:39+02:00","side":null},{"id":1071,"price":"0.00001735","volume":"30.0","funds":"0.0005205","market":"trfbtc","created_at":"2018-05-09T07:43:04+02:00","side":null},{"id":1070,"price":"0.00001725","volume":"10.0","funds":"0.0001725","market":"trfbtc","created_at":"2018-05-09T07:42:58+02:00","side":null},{"id":1069,"price":"0.00001725","volume":"30.0","funds":"0.0005175","market":"trfbtc","created_at":"2018-05-09T07:42:48+02:00","side":null},{"id":1068,"price":"0.00001735","volume":"40.0","funds":"0.000694","market":"trfbtc","created_at":"2018-05-07T06:46:27+02:00","side":null},{"id":1067,"price":"0.00001755","volume":"20.0","funds":"0.000351","market":"trfbtc","created_at":"2018-05-07T06:46:18+02:00","side":null},{"id":1066,"price":"0.00001765","volume":"20.0","funds":"0.000353","market":"trfbtc","created_at":"2018-05-07T06:46:09+02:00","side":null},{"id":1065,"price":"0.00001765","volume":"20.0","funds":"0.000353","market":"trfbtc","created_at":"2018-05-04T07:28:56+02:00","side":null},{"id":1064,"price":"0.00001755","volume":"20.0","funds":"0.000351","market":"trfbtc","created_at":"2018-05-04T07:28:49+02:00","side":null},{"id":1063,"price":"0.00001735","volume":"40.0","funds":"0.000694","market":"trfbtc","created_at":"2018-05-04T07:28:41+02:00","side":null},{"id":1062,"price":"0.00001725","volume":"40.0","funds":"0.00069","market":"trfbtc","created_at":"2018-05-04T07:28:33+02:00","side":null},{"id":1061,"price":"0.00001725","volume":"20.0","funds":"0.000345","market":"trfbtc","created_at":"2018-05-04T07:28:25+02:00","side":null},{"id":1060,"price":"0.00001735","volume":"20.0","funds":"0.000347","market":"trfbtc","created_at":"2018-05-04T07:28:16+02:00","side":null},{"id":1059,"price":"0.00001755","volume":"20.0","funds":"0.000351","market":"trfbtc","created_at":"2018-05-03T18:19:07+02:00","side":null}]'
+    http_version: 
+  recorded_at: Sat, 19 May 2018 08:05:45 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/coinnox/integration/market_spec.rb
+++ b/spec/exchanges/coinnox/integration/market_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+RSpec.describe 'Coinnox integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:trf_btc_pair) { Cryptoexchange::Models::MarketPair.new(base: 'TRF', target: 'BTC', market: 'coinnox') }
+
+  it 'fetch pairs' do
+    pairs = client.pairs('coinnox')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.market).to eq 'coinnox'
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(trf_btc_pair)
+
+    expect(ticker.base).to eq 'TRF'
+    expect(ticker.target).to eq 'BTC'
+    expect(ticker.market).to eq 'coinnox'
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.ask).to be_a Numeric
+    expect(ticker.bid).to be_a Numeric
+    expect(ticker.low).to be_a Numeric
+    expect(ticker.high).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+    expect(ticker.timestamp).to be_a Numeric
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
+    expect(ticker.payload).to_not be nil
+  end
+
+  it 'fetch order book' do
+    order_book = client.order_book(trf_btc_pair)
+
+    expect(order_book.base).to eq 'TRF'
+    expect(order_book.target).to eq 'BTC'
+    expect(order_book.market).to eq 'coinnox'
+    expect(order_book.asks).to_not be_empty
+    expect(order_book.bids).to_not be_empty
+    expect(order_book.asks.first.price).to_not be_nil
+    expect(order_book.bids.first.amount).to_not be_nil
+    expect(order_book.bids.first.timestamp).to be_nil
+    expect(order_book.asks.count).to_not be_nil
+    expect(order_book.bids.count).to_not be_nil
+    expect(order_book.timestamp).to be_a Numeric
+    expect(order_book.payload).to_not be nil
+  end
+
+  it 'fetch trade' do
+    trades = client.trades(trf_btc_pair)
+    trade = trades.sample
+
+    expect(trades).to_not be_empty
+    expect(trade.base).to eq 'TRF'
+    expect(trade.target).to eq 'BTC'
+    expect(trade.market).to eq 'coinnox'
+    expect(trade.trade_id).to_not be_nil
+    expect(trade.type).to be_nil
+    expect(trade.price).to_not be_nil
+    expect(trade.amount).to_not be_nil
+    expect(trade.timestamp).to be_a Numeric
+    expect(trade.payload).to_not be nil
+  end
+
+end

--- a/spec/exchanges/coinnox/market_spec.rb
+++ b/spec/exchanges/coinnox/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Coinnox::Market do
+  it { expect(described_class::NAME).to eq 'coinnox' }
+  it { expect(described_class::API_URL).to eq 'https://coinnox.com/api/v2' }
+end


### PR DESCRIPTION
- What is the purpose of this Pull Request? as title
- What is the related issue for this Pull Request? #502
- [x] I have added Specs
- [x] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [x] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly

ticker on `TRF_BTC`
```ruby
{
 "trfbtc": {
  "at": 1526715083,
  "ticker": {
   "buy": "0.00001665",
   "sell": "0.00001666",
   "low": "0.00001666",
   "high": "0.00001671",
   "last": "0.00001666",
   "vol": "30.3592"
  }
 }
}
```
took `vol` as base vol, seems this website's traffic is few
https://coinnox.com/markets/trfbtc#

order book 
```ruby
{
 "timestamp": 1526717359,
 "asks": [
  [
   "0.00001667",
   "5.08032"
  ],
  [
   "0.00001666",
   "9.04032"
  ]
 ],
 "bids": [
  [
   "0.00001665",
   "1.47984"
  ],
  [
   "0.00001664",
   "44.95968"
  ]
 ]
}
```
trades
```ruby
[
 {
  "id": 1237,
  "price": "0.00001666",
  "volume": "10.47984",
  "funds": "0.0001745941344",
  "market": "trfbtc",
  "created_at": "2018-05-19T06:59:33+02:00",
  "side": null
 },
 {
  "id": 1236,
  "price": "0.00001666",
  "volume": "0.47984",
  "funds": "0.0000079941344",
  "market": "trfbtc",
  "created_at": "2018-05-19T06:59:33+02:00",
  "side": null
 }
]
```
there's no type on trades
