### PR TITLE
[#hotfix] Bithash change volume from vol to vol_cur

### DIFF
--- a/lib/cryptoexchange/exchanges/bithash/services/market.rb
+++ b/lib/cryptoexchange/exchanges/bithash/services/market.rb
@@ -39,7 +39,7 @@ module Cryptoexchange::Exchanges
           ticker.last      = NumericHelper.to_d(output['last'])
           ticker.high      = NumericHelper.to_d(output['high'])
           ticker.low       = NumericHelper.to_d(output['low'])
-          ticker.volume    = NumericHelper.to_d(output['vol'])
+          ticker.volume    = NumericHelper.to_d(output['vol_cur'])
           ticker.timestamp = NumericHelper.to_d(output['updated'])
           ticker.payload   = output
           ticker


### PR DESCRIPTION
- What is the purpose of this Pull Request? as title 
- What is the related issue for this Pull Request? #541

according to response from BCH_BTC
```
{
 "high"=>0.14185, 
 "low"=>0.13, 
 "avg"=>0.13698, 
 "vol"=>26.60001, 
 "vol_cur"=>194.01363, 
 "last"=>0.13926, 
 "buy"=>0.13926, 
 "sell"=>0.13953, 
 "updated"=>1527230108
}
```
base volume should be `vol_cur`
