### PR TITLE
[#hotfix] add missing superclass for market - ABCC and Graviex

### DIFF
--- a/lib/cryptoexchange/exchanges/abcc/market.rb
+++ b/lib/cryptoexchange/exchanges/abcc/market.rb
@@ -1,6 +1,6 @@
 module Cryptoexchange::Exchanges
   module Abcc
-    class Market
+    class Market < Cryptoexchange::Models::Market
       NAME    = 'abcc'
       API_URL = 'https://api.abcc.com/api/v2'
     end

--- a/lib/cryptoexchange/exchanges/graviex/market.rb
+++ b/lib/cryptoexchange/exchanges/graviex/market.rb
@@ -1,6 +1,6 @@
 module Cryptoexchange::Exchanges
   module Graviex
-    class Market 
+    class Market < Cryptoexchange::Models::Market
       NAME = 'graviex'
       API_URL = 'https://graviex.net/api/v2'
     end


### PR DESCRIPTION
- What is the purpose of this Pull Request?
Hotfix for ABCC and Graviex cannot call trade_page_url