### PR TITLE
✨ Implement Bitmax ticker, order book and trades

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Or install it yourself as:
 | Bitkub            | Y       | Y          | Y       |         | Y           | Y        | bitkub            |
 | Bitlish           | Y       | Y          | Y       |         | Y           |          | bitlish           |
 | Bitmart           | Y       | Y          | Y       |         | Y           |          | bitmart           |
+| Bitmax            | Y       | Y          | Y       |         | Y           | Y        | bitmax            |
 | Bitmex            | Y       | Y          | Y       |         | Y           |          | bitmex            |
 | Bitpaction        | Y       | Y          | Y       |         | Y           |          | bitpaction        |
 | Bitrue            | Y       | N          | N       |         | Y           | Y        | bitrue            |

--- a/lib/cryptoexchange/exchanges/bitmax/market.rb
+++ b/lib/cryptoexchange/exchanges/bitmax/market.rb
@@ -1,0 +1,14 @@
+module Cryptoexchange::Exchanges
+  module Bitmax
+    class Market
+      NAME    = 'bitmax'
+      API_URL = 'https://bitmax.io/api/v1'
+
+      def self.trade_page_url(args = {})
+        base   = args[:base].downcase
+        target = args[:target].downcase
+        "https://bitmax.io/#/trade/#{target}/#{base}"
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/bitmax/services/market.rb
+++ b/lib/cryptoexchange/exchanges/bitmax/services/market.rb
@@ -1,0 +1,48 @@
+module Cryptoexchange::Exchanges
+  module Bitmax
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            false
+          end
+        end
+
+        def fetch
+          output = super(ticker_url)
+          adapt_all(output)
+        end
+
+        def ticker_url
+          "#{Cryptoexchange::Exchanges::Bitmax::Market::API_URL}/ticker/24hr"
+        end
+
+        def adapt_all(output)
+          output.map do |ticker|
+            base, target = ticker['symbol'].split('/')
+            market_pair  = Cryptoexchange::Models::MarketPair.new(
+              base:   base,
+              target: target,
+              market: Bitmax::Market::NAME
+            )
+            adapt(market_pair, ticker)
+          end
+        end
+
+        def adapt(market_pair, output)
+          ticker           = Cryptoexchange::Models::Ticker.new
+          ticker.base      = market_pair.base
+          ticker.target    = market_pair.target
+          ticker.market    = Bitmax::Market::NAME
+          ticker.last      = NumericHelper.to_d(output['closePrice'])
+          ticker.high      = NumericHelper.to_d(output['highPrice'])
+          ticker.low       = NumericHelper.to_d(output['lowPrice'])
+          ticker.volume    = NumericHelper.to_d(output['volume'])
+          ticker.timestamp = NumericHelper.to_d(output['barStartTime']) / 1000
+          ticker.payload   = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/bitmax/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/bitmax/services/order_book.rb
@@ -1,0 +1,45 @@
+module Cryptoexchange::Exchanges
+  module Bitmax
+    module Services
+      class OrderBook < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(order_book_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def order_book_url(market_pair)
+          base   = market_pair.base
+          target = market_pair.target
+          "#{Cryptoexchange::Exchanges::Bitmax::Market::API_URL}/depth?symbol=#{base}-#{target}"
+        end
+
+        def adapt(output, market_pair)
+          order_book = Cryptoexchange::Models::OrderBook.new
+
+          order_book.base    = market_pair.base
+          order_book.target  = market_pair.target
+          order_book.market  = Bitmax::Market::NAME
+          order_book.asks    = adapt_orders(output['asks'])
+          order_book.bids    = adapt_orders(output['bids'])
+          order_book.payload = output
+          order_book
+        end
+
+        def adapt_orders(orders)
+          orders.collect do |order_entry|
+            price, amount = order_entry
+            Cryptoexchange::Models::Order.new(price:     price,
+                                              amount:    amount,
+                                              timestamp: nil)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/bitmax/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/bitmax/services/pairs.rb
@@ -1,0 +1,24 @@
+module Cryptoexchange::Exchanges
+  module Bitmax
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Bitmax::Market::API_URL}/products"
+
+        def fetch
+          output = super
+          adapt(output)
+        end
+
+        def adapt(output)
+          output.map do |pair|
+            Cryptoexchange::Models::MarketPair.new(
+              base:   pair['baseAsset'],
+              target: pair['quoteAsset'],
+              market: Bitmax::Market::NAME
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/bitmax/services/trades.rb
+++ b/lib/cryptoexchange/exchanges/bitmax/services/trades.rb
@@ -1,0 +1,34 @@
+module Cryptoexchange::Exchanges
+  module Bitmax
+    module Services
+      class Trades < Cryptoexchange::Services::Market
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          base   = market_pair.base
+          target = market_pair.target
+          "#{Cryptoexchange::Exchanges::Bitmax::Market::API_URL}/trades?symbol=#{base}-#{target}"
+        end
+
+        def adapt(output, market_pair)
+          output['trades'].collect do |trade|
+            tr           = Cryptoexchange::Models::Trade.new
+            tr.base      = market_pair.base
+            tr.target    = market_pair.target
+            tr.market    = Bitmax::Market::NAME
+            tr.type      = trade['bm'] == true ? 'sell' : 'buy'
+            tr.price     = trade['p']
+            tr.amount    = trade['q']
+            tr.timestamp = trade['t'] / 1000
+            tr.payload   = trade
+            tr
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/Bitmax/integration_specs_fetch_order_book.yml
+++ b/spec/cassettes/vcr_cassettes/Bitmax/integration_specs_fetch_order_book.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://bitmax.io/api/v1/depth?symbol=ETH-BTC
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - bitmax.io
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 02 Oct 2018 11:38:59 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '482'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=dcaa1015366c94c81afe45ce5222f03a21538480339; expires=Wed, 02-Oct-19
+        11:38:59 GMT; path=/; domain=.bitmax.io; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Frame-Operations:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4636e2c8bb548839-HKG
+    body:
+      encoding: ASCII-8BIT
+      string: '{"m":"depth","s":"ETH/BTC","asks":[["0.03479","0.0664"],["0.034791","8.7312"],["0.034797","2.104"],["0.034799","0.472"],["0.0348","0.048"],["0.034805","0.0448"],["0.034811","0.0448"],["0.034814","0.7096"],["0.034817","2.184"],["0.034818","0.0832"]],"bids":[["0.034772","1.7016"],["0.034758","10.3576"],["0.03475","29.7790739"],["0.034749","0.4872"],["0.034744","6.6336"],["0.034739","4.9288"],["0.034735","0.0496"],["0.034733","3.9616"],["0.034731","15.7856"],["0.03473","0.6328"]]}'
+    http_version: 
+  recorded_at: Tue, 02 Oct 2018 11:38:59 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Bitmax/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/Bitmax/integration_specs_fetch_pairs.yml
@@ -1,0 +1,441 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://bitmax.io/api/v1/products
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - bitmax.io
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 02 Oct 2018 11:38:59 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '8551'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d58c178d330b5263dcfd6b859fd3983751538480338; expires=Wed, 02-Oct-19
+        11:38:58 GMT; path=/; domain=.bitmax.io; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Frame-Operations:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4636e2c538cc3283-HKG
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        [
+          {
+            "symbol" : "LBA/BTC",
+            "baseAsset" : "LBA",
+            "quoteAsset" : "BTC",
+            "priceScale" : 8,
+            "qtyScale" : 2,
+            "notionalScale" : 8,
+            "minQty" : "10",
+            "maxQty" : "1000000",
+            "minNotional" : "0.001",
+            "maxNotional" : "100.000",
+            "status" : "Normal"
+          },
+          {
+            "symbol" : "BCH/USDT",
+            "baseAsset" : "BCH",
+            "quoteAsset" : "USDT",
+            "priceScale" : 2,
+            "qtyScale" : 7,
+            "notionalScale" : 4,
+            "minQty" : "0.01",
+            "maxQty" : "1000.00",
+            "minNotional" : "10",
+            "maxNotional" : "1000000",
+            "status" : "Normal"
+          },
+          {
+            "symbol" : "BCH/BTC",
+            "baseAsset" : "BCH",
+            "quoteAsset" : "BTC",
+            "priceScale" : 6,
+            "qtyScale" : 7,
+            "notionalScale" : 8,
+            "minQty" : "0.01",
+            "maxQty" : "1000.00",
+            "minNotional" : "0.001",
+            "maxNotional" : "100.000",
+            "status" : "Normal"
+          },
+          {
+            "symbol" : "LBA/ETH",
+            "baseAsset" : "LBA",
+            "quoteAsset" : "ETH",
+            "priceScale" : 8,
+            "qtyScale" : 2,
+            "notionalScale" : 7,
+            "minQty" : "10",
+            "maxQty" : "1000000",
+            "minNotional" : "0.01",
+            "maxNotional" : "1000.00",
+            "status" : "Normal"
+          },
+          {
+            "symbol" : "OLT/BTC",
+            "baseAsset" : "OLT",
+            "quoteAsset" : "BTC",
+            "priceScale" : 8,
+            "qtyScale" : 2,
+            "notionalScale" : 8,
+            "minQty" : "10",
+            "maxQty" : "1000000",
+            "minNotional" : "0.001",
+            "maxNotional" : "100.000",
+            "status" : "Normal"
+          },
+          {
+            "symbol" : "ETC/USDT",
+            "baseAsset" : "ETC",
+            "quoteAsset" : "USDT",
+            "priceScale" : 4,
+            "qtyScale" : 5,
+            "notionalScale" : 4,
+            "minQty" : "1",
+            "maxQty" : "100000",
+            "minNotional" : "10",
+            "maxNotional" : "1000000",
+            "status" : "Normal"
+          },
+          {
+            "symbol" : "ETC/ETH",
+            "baseAsset" : "ETC",
+            "quoteAsset" : "ETH",
+            "priceScale" : 7,
+            "qtyScale" : 5,
+            "notionalScale" : 7,
+            "minQty" : "1",
+            "maxQty" : "100000",
+            "minNotional" : "0.01",
+            "maxNotional" : "1000.00",
+            "status" : "Normal"
+          },
+          {
+            "symbol" : "BTC/USDT",
+            "baseAsset" : "BTC",
+            "quoteAsset" : "USDT",
+            "priceScale" : 1,
+            "qtyScale" : 8,
+            "notionalScale" : 4,
+            "minQty" : "0.001",
+            "maxQty" : "100.000",
+            "minNotional" : "10",
+            "maxNotional" : "1000000",
+            "status" : "Normal"
+          },
+          {
+            "symbol" : "ZRX/ETH",
+            "baseAsset" : "ZRX",
+            "quoteAsset" : "ETH",
+            "priceScale" : 8,
+            "qtyScale" : 3,
+            "notionalScale" : 7,
+            "minQty" : "10",
+            "maxQty" : "1000000",
+            "minNotional" : "0.01",
+            "maxNotional" : "1000.00",
+            "status" : "NoTrading"
+          },
+          {
+            "symbol" : "BAT/ETH",
+            "baseAsset" : "BAT",
+            "quoteAsset" : "ETH",
+            "priceScale" : 8,
+            "qtyScale" : 3,
+            "notionalScale" : 7,
+            "minQty" : "10",
+            "maxQty" : "1000000",
+            "minNotional" : "0.01",
+            "maxNotional" : "1000.00",
+            "status" : "NoTrading"
+          },
+          {
+            "symbol" : "ELF/ETH",
+            "baseAsset" : "ELF",
+            "quoteAsset" : "ETH",
+            "priceScale" : 8,
+            "qtyScale" : 3,
+            "notionalScale" : 7,
+            "minQty" : "10",
+            "maxQty" : "1000000",
+            "minNotional" : "0.01",
+            "maxNotional" : "1000.00",
+            "status" : "Normal"
+          },
+          {
+            "symbol" : "LTC/USDT",
+            "baseAsset" : "LTC",
+            "quoteAsset" : "USDT",
+            "priceScale" : 3,
+            "qtyScale" : 6,
+            "notionalScale" : 4,
+            "minQty" : "0.1",
+            "maxQty" : "10000.0",
+            "minNotional" : "10",
+            "maxNotional" : "1000000",
+            "status" : "Normal"
+          },
+          {
+            "symbol" : "BAT/BTC",
+            "baseAsset" : "BAT",
+            "quoteAsset" : "BTC",
+            "priceScale" : 8,
+            "qtyScale" : 3,
+            "notionalScale" : 8,
+            "minQty" : "10",
+            "maxQty" : "1000000",
+            "minNotional" : "0.001",
+            "maxNotional" : "100.000",
+            "status" : "NoTrading"
+          },
+          {
+            "symbol" : "LTC/BTC",
+            "baseAsset" : "LTC",
+            "quoteAsset" : "BTC",
+            "priceScale" : 7,
+            "qtyScale" : 6,
+            "notionalScale" : 8,
+            "minQty" : "0.1",
+            "maxQty" : "10000.0",
+            "minNotional" : "0.001",
+            "maxNotional" : "100.000",
+            "status" : "Normal"
+          },
+          {
+            "symbol" : "BCH/ETH",
+            "baseAsset" : "BCH",
+            "quoteAsset" : "ETH",
+            "priceScale" : 5,
+            "qtyScale" : 7,
+            "notionalScale" : 7,
+            "minQty" : "0.01",
+            "maxQty" : "1000.00",
+            "minNotional" : "0.01",
+            "maxNotional" : "1000.00",
+            "status" : "Normal"
+          },
+          {
+            "symbol" : "ZIL/BTC",
+            "baseAsset" : "ZIL",
+            "quoteAsset" : "BTC",
+            "priceScale" : 8,
+            "qtyScale" : 2,
+            "notionalScale" : 8,
+            "minQty" : "10",
+            "maxQty" : "1000000",
+            "minNotional" : "0.001",
+            "maxNotional" : "100.000",
+            "status" : "Normal"
+          },
+          {
+            "symbol" : "ZIL/ETH",
+            "baseAsset" : "ZIL",
+            "quoteAsset" : "ETH",
+            "priceScale" : 8,
+            "qtyScale" : 2,
+            "notionalScale" : 7,
+            "minQty" : "10",
+            "maxQty" : "1000000",
+            "minNotional" : "0.01",
+            "maxNotional" : "1000.00",
+            "status" : "Normal"
+          },
+          {
+            "symbol" : "OLT/ETH",
+            "baseAsset" : "OLT",
+            "quoteAsset" : "ETH",
+            "priceScale" : 8,
+            "qtyScale" : 2,
+            "notionalScale" : 7,
+            "minQty" : "10",
+            "maxQty" : "1000000",
+            "minNotional" : "0.01",
+            "maxNotional" : "1000.00",
+            "status" : "Normal"
+          },
+          {
+            "symbol" : "ETH/BTC",
+            "baseAsset" : "ETH",
+            "quoteAsset" : "BTC",
+            "priceScale" : 6,
+            "qtyScale" : 7,
+            "notionalScale" : 8,
+            "minQty" : "0.01",
+            "maxQty" : "1000.00",
+            "minNotional" : "0.001",
+            "maxNotional" : "100.000",
+            "status" : "Normal"
+          },
+          {
+            "symbol" : "ZRX/BTC",
+            "baseAsset" : "ZRX",
+            "quoteAsset" : "BTC",
+            "priceScale" : 8,
+            "qtyScale" : 3,
+            "notionalScale" : 8,
+            "minQty" : "10",
+            "maxQty" : "1000000",
+            "minNotional" : "0.001",
+            "maxNotional" : "100.000",
+            "status" : "NoTrading"
+          },
+          {
+            "symbol" : "SEELE/BTC",
+            "baseAsset" : "SEELE",
+            "quoteAsset" : "BTC",
+            "priceScale" : 8,
+            "qtyScale" : 2,
+            "notionalScale" : 8,
+            "minQty" : "10",
+            "maxQty" : "1000000",
+            "minNotional" : "0.001",
+            "maxNotional" : "100.000",
+            "status" : "NoTrading"
+          },
+          {
+            "symbol" : "LFT/BTC",
+            "baseAsset" : "LFT",
+            "quoteAsset" : "BTC",
+            "priceScale" : 8,
+            "qtyScale" : 2,
+            "notionalScale" : 8,
+            "minQty" : "10",
+            "maxQty" : "1000000",
+            "minNotional" : "0.001",
+            "maxNotional" : "100.000",
+            "status" : "NoTrading"
+          },
+          {
+            "symbol" : "ETC/BTC",
+            "baseAsset" : "ETC",
+            "quoteAsset" : "BTC",
+            "priceScale" : 8,
+            "qtyScale" : 5,
+            "notionalScale" : 8,
+            "minQty" : "1",
+            "maxQty" : "100000",
+            "minNotional" : "0.001",
+            "maxNotional" : "100.000",
+            "status" : "Normal"
+          },
+          {
+            "symbol" : "LFT/ETH",
+            "baseAsset" : "LFT",
+            "quoteAsset" : "ETH",
+            "priceScale" : 8,
+            "qtyScale" : 2,
+            "notionalScale" : 7,
+            "minQty" : "10",
+            "maxQty" : "1000000",
+            "minNotional" : "0.01",
+            "maxNotional" : "1000.00",
+            "status" : "NoTrading"
+          },
+          {
+            "symbol" : "SEELE/ETH",
+            "baseAsset" : "SEELE",
+            "quoteAsset" : "ETH",
+            "priceScale" : 8,
+            "qtyScale" : 2,
+            "notionalScale" : 7,
+            "minQty" : "10",
+            "maxQty" : "1000000",
+            "minNotional" : "0.01",
+            "maxNotional" : "1000.00",
+            "status" : "NoTrading"
+          },
+          {
+            "symbol" : "LTC/ETH",
+            "baseAsset" : "LTC",
+            "quoteAsset" : "ETH",
+            "priceScale" : 6,
+            "qtyScale" : 6,
+            "notionalScale" : 7,
+            "minQty" : "0.1",
+            "maxQty" : "10000.0",
+            "minNotional" : "0.01",
+            "maxNotional" : "1000.00",
+            "status" : "Normal"
+          },
+          {
+            "symbol" : "IOST/ETH",
+            "baseAsset" : "IOST",
+            "quoteAsset" : "ETH",
+            "priceScale" : 8,
+            "qtyScale" : 2,
+            "notionalScale" : 7,
+            "minQty" : "10",
+            "maxQty" : "1000000",
+            "minNotional" : "0.01",
+            "maxNotional" : "1000.00",
+            "status" : "Normal"
+          },
+          {
+            "symbol" : "ETH/USDT",
+            "baseAsset" : "ETH",
+            "quoteAsset" : "USDT",
+            "priceScale" : 2,
+            "qtyScale" : 7,
+            "notionalScale" : 4,
+            "minQty" : "0.01",
+            "maxQty" : "1000.00",
+            "minNotional" : "10",
+            "maxNotional" : "1000000",
+            "status" : "Normal"
+          },
+          {
+            "symbol" : "ELF/BTC",
+            "baseAsset" : "ELF",
+            "quoteAsset" : "BTC",
+            "priceScale" : 8,
+            "qtyScale" : 3,
+            "notionalScale" : 8,
+            "minQty" : "10",
+            "maxQty" : "1000000",
+            "minNotional" : "0.001",
+            "maxNotional" : "100.000",
+            "status" : "Normal"
+          },
+          {
+            "symbol" : "IOST/BTC",
+            "baseAsset" : "IOST",
+            "quoteAsset" : "BTC",
+            "priceScale" : 8,
+            "qtyScale" : 2,
+            "notionalScale" : 8,
+            "minQty" : "10",
+            "maxQty" : "1000000",
+            "minNotional" : "0.001",
+            "maxNotional" : "100.000",
+            "status" : "Normal"
+          }
+        ]
+    http_version: 
+  recorded_at: Tue, 02 Oct 2018 11:38:59 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Bitmax/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/Bitmax/integration_specs_fetch_ticker.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://bitmax.io/api/v1/ticker/24hr
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - bitmax.io
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 02 Oct 2018 11:38:59 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '5365'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d9a55960a5dad0f6d19de84e8fb42666d1538480339; expires=Wed, 02-Oct-19
+        11:38:59 GMT; path=/; domain=.bitmax.io; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Frame-Operations:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4636e2c7ce5e3427-HKG
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"symbol":"ETC/USDT","interval":"1d","barStartTime":1538480100000,"openPrice":"11.1617","closePrice":"11.2147","highPrice":"11.3782","lowPrice":"11.1294","volume":"16228.56929"},{"symbol":"ETC/BTC","interval":"1d","barStartTime":1538480100000,"openPrice":"0.00170599","closePrice":"0.00170599","highPrice":"0.00170701","lowPrice":"0.00170501","volume":"6481.16474"},{"symbol":"OLT/BTC","interval":"1d","barStartTime":0,"openPrice":"0.00000000","closePrice":"0.00000000","highPrice":"0.00000000","lowPrice":"0.00000000","volume":"0.00"},{"symbol":"ZRX/BTC","interval":"1d","barStartTime":0,"openPrice":"0.00000000","closePrice":"0.00000000","highPrice":"0.00000000","lowPrice":"0.00000000","volume":"0.000"},{"symbol":"IOST/BTC","interval":"1d","barStartTime":1538480100000,"openPrice":"0.00000191","closePrice":"0.00000205","highPrice":"0.00000206","lowPrice":"0.00000205","volume":"12492020.36"},{"symbol":"LBA/BTC","interval":"1d","barStartTime":1538480100000,"openPrice":"0.00000423","closePrice":"0.00000470","highPrice":"0.00000470","lowPrice":"0.00000448","volume":"32143.13"},{"symbol":"SEELE/ETH","interval":"1d","barStartTime":0,"openPrice":"0.00000000","closePrice":"0.00000000","highPrice":"0.00000000","lowPrice":"0.00000000","volume":"0.00"},{"symbol":"BCH/BTC","interval":"1d","barStartTime":1538480100000,"openPrice":"0.081316","closePrice":"0.081751","highPrice":"0.081963","lowPrice":"0.081699","volume":"1089.9045904"},{"symbol":"ZIL/BTC","interval":"1d","barStartTime":1538480100000,"openPrice":"0.00000555","closePrice":"0.00000566","highPrice":"0.00000566","lowPrice":"0.00000566","volume":"262201.38"},{"symbol":"ZRX/ETH","interval":"1d","barStartTime":0,"openPrice":"0.00000000","closePrice":"0.00000000","highPrice":"0.00000000","lowPrice":"0.00000000","volume":"0.000"},{"symbol":"LFT/ETH","interval":"1d","barStartTime":0,"openPrice":"0.00000000","closePrice":"0.00000000","highPrice":"0.00000000","lowPrice":"0.00000000","volume":"0.00"},{"symbol":"LTC/USDT","interval":"1d","barStartTime":1538480100000,"openPrice":"60.011","closePrice":"60.231","highPrice":"61.779","lowPrice":"59.551","volume":"4657.923113"},{"symbol":"LTC/ETH","interval":"1d","barStartTime":1538480100000,"openPrice":"0.265799","closePrice":"0.263541","highPrice":"0.263541","lowPrice":"0.263541","volume":"286.670164"},{"symbol":"IOST/ETH","interval":"1d","barStartTime":1538480100000,"openPrice":"0.00005495","closePrice":"0.00005854","highPrice":"0.00005906","lowPrice":"0.00005854","volume":"2001615.42"},{"symbol":"BAT/ETH","interval":"1d","barStartTime":0,"openPrice":"0.00000000","closePrice":"0.00000000","highPrice":"0.00000000","lowPrice":"0.00000000","volume":"0.000"},{"symbol":"ETC/ETH","interval":"1d","barStartTime":1538480100000,"openPrice":"0.0491179","closePrice":"0.0491549","highPrice":"0.0491549","lowPrice":"0.0489441","volume":"1123.10213"},{"symbol":"ETH/BTC","interval":"1d","barStartTime":1538480100000,"openPrice":"0.034819","closePrice":"0.034764","highPrice":"0.034856","lowPrice":"0.034718","volume":"6471.3609116"},{"symbol":"OLT/ETH","interval":"1d","barStartTime":0,"openPrice":"0.00000000","closePrice":"0.00000000","highPrice":"0.00000000","lowPrice":"0.00000000","volume":"0.00"},{"symbol":"ELF/BTC","interval":"1d","barStartTime":1538480100000,"openPrice":"0.00005225","closePrice":"0.00005622","highPrice":"0.00005644","lowPrice":"0.00005596","volume":"301674.260"},{"symbol":"LBA/ETH","interval":"1d","barStartTime":1538480100000,"openPrice":"0.00012201","closePrice":"0.00013499","highPrice":"0.00013499","lowPrice":"0.00012801","volume":"366713.76"},{"symbol":"BCH/ETH","interval":"1d","barStartTime":1538480100000,"openPrice":"2.33061","closePrice":"2.35959","highPrice":"2.35959","lowPrice":"2.35506","volume":"31.5374002"},{"symbol":"BTC/USDT","interval":"1d","barStartTime":1538480100000,"openPrice":"6599.8","closePrice":"6573.9","highPrice":"6597.1","lowPrice":"6561.7","volume":"603.24224917"},{"symbol":"ZIL/ETH","interval":"1d","barStartTime":1538480100000,"openPrice":"0.00015994","closePrice":"0.00016350","highPrice":"0.00016350","lowPrice":"0.00016329","volume":"724040.96"},{"symbol":"BCH/USDT","interval":"1d","barStartTime":1538480100000,"openPrice":"530.01","closePrice":"537.38","highPrice":"553.81","lowPrice":"525.32","volume":"1218.3029829"},{"symbol":"ELF/ETH","interval":"1d","barStartTime":1538480100000,"openPrice":"0.00150291","closePrice":"0.00161370","highPrice":"0.00162073","lowPrice":"0.00161014","volume":"97426.186"},{"symbol":"ETH/USDT","interval":"1d","barStartTime":1538480100000,"openPrice":"229.86","closePrice":"228.91","highPrice":"229.67","lowPrice":"228.32","volume":"10751.0626371"},{"symbol":"LFT/BTC","interval":"1d","barStartTime":0,"openPrice":"0.00000000","closePrice":"0.00000000","highPrice":"0.00000000","lowPrice":"0.00000000","volume":"0.00"},{"symbol":"BAT/BTC","interval":"1d","barStartTime":0,"openPrice":"0.00000000","closePrice":"0.00000000","highPrice":"0.00000000","lowPrice":"0.00000000","volume":"0.000"},{"symbol":"SEELE/BTC","interval":"1d","barStartTime":0,"openPrice":"0.00000000","closePrice":"0.00000000","highPrice":"0.00000000","lowPrice":"0.00000000","volume":"0.00"},{"symbol":"LTC/BTC","interval":"1d","barStartTime":1538480100000,"openPrice":"0.0092521","closePrice":"0.0091721","highPrice":"0.0091929","lowPrice":"0.0091621","volume":"6441.230816"}]'
+    http_version: 
+  recorded_at: Tue, 02 Oct 2018 11:38:59 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Bitmax/integration_specs_fetch_trade.yml
+++ b/spec/cassettes/vcr_cassettes/Bitmax/integration_specs_fetch_trade.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://bitmax.io/api/v1/trades?symbol=ETH-BTC
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - bitmax.io
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 02 Oct 2018 11:39:00 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '656'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=dc2058a344d833d3bbdfbea6244b1c67c1538480339; expires=Wed, 02-Oct-19
+        11:38:59 GMT; path=/; domain=.bitmax.io; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Frame-Operations:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4636e2cb1ce53283-HKG
+    body:
+      encoding: ASCII-8BIT
+      string: '{"m":"marketTrades","s":"ETH/BTC","trades":[{"p":"0.034777","q":"0.1672000","t":1538480230844,"bm":true},{"p":"0.034777","q":"0.0664000","t":1538480230845,"bm":true},{"p":"0.034759","q":"0.0640000","t":1538480245123,"bm":true},{"p":"0.034763","q":"1.2048000","t":1538480257271,"bm":false},{"p":"0.03474","q":"0.1208000","t":1538480259358,"bm":true},{"p":"0.034774","q":"0.0552000","t":1538480267135,"bm":false},{"p":"0.03477","q":"0.5304000","t":1538480318132,"bm":true},{"p":"0.034763","q":"0.1464000","t":1538480319166,"bm":true},{"p":"0.034764","q":"1.5520000","t":1538480319258,"bm":true},{"p":"0.034793","q":"0.0360000","t":1538480332293,"bm":false}]}'
+    http_version: 
+  recorded_at: Tue, 02 Oct 2018 11:39:00 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/bitmax/integration/market_spec.rb
+++ b/spec/exchanges/bitmax/integration/market_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+RSpec.describe 'Bitmax integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:eth_btc_pair) { Cryptoexchange::Models::MarketPair.new(base: 'ETH', target: 'BTC', market: 'bitmax') }
+
+  it 'fetch pairs' do
+    pairs = client.pairs('bitmax')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.market).to eq 'bitmax'
+  end
+
+  it 'give trade url' do
+    trade_page_url = client.trade_page_url 'bitmax', base: eth_btc_pair.base, target: eth_btc_pair.target
+    expect(trade_page_url).to eq "https://bitmax.io/#/trade/btc/eth"
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(eth_btc_pair)
+
+    expect(ticker.base).to eq 'ETH'
+    expect(ticker.target).to eq 'BTC'
+    expect(ticker.market).to eq 'bitmax'
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.low).to be_a Numeric
+    expect(ticker.high).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+    expect(ticker.timestamp).to be_a Numeric
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
+    expect(ticker.payload).to_not be nil
+  end
+
+  it 'fetch order book' do
+    order_book = client.order_book(eth_btc_pair)
+
+    expect(order_book.base).to eq 'ETH'
+    expect(order_book.target).to eq 'BTC'
+    expect(order_book.market).to eq 'bitmax'
+    expect(order_book.asks).to_not be_empty
+    expect(order_book.bids).to_not be_empty
+    expect(order_book.asks.first.price).to_not be_nil
+    expect(order_book.bids.first.amount).to_not be_nil
+    expect(order_book.bids.first.timestamp).to be_nil
+    expect(order_book.asks.count).to be > 0
+    expect(order_book.bids.count).to be > 0
+    expect(order_book.timestamp).to be_nil
+    expect(order_book.payload).to_not be nil
+  end
+
+  it 'fetch trade' do
+    trades = client.trades(eth_btc_pair)
+    trade = trades.sample
+
+    expect(trades).to_not be_empty
+    expect(trade.base).to eq 'ETH'
+    expect(trade.target).to eq 'BTC'
+    expect(trade.market).to eq 'bitmax'
+    expect(trade.trade_id).to be_nil
+    expect(['buy', 'sell']).to include trade.type
+    expect(trade.price).to_not be_nil
+    expect(trade.amount).to_not be_nil
+    expect(trade.timestamp).to be_a Numeric
+    expect(trade.payload).to_not be nil
+  end
+end

--- a/spec/exchanges/bitmax/market_spec.rb
+++ b/spec/exchanges/bitmax/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Bitmax::Market do
+  it { expect(described_class::NAME).to eq 'bitmax' }
+  it { expect(described_class::API_URL).to eq 'https://bitmax.io/api/v1' }
+end


### PR DESCRIPTION
- What is the purpose of this Pull Request? as title
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")? closes #827
- [x] I have added Specs
- [x] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [x] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly

ticker about `ETH-BTC`
```ruby
{
 "symbol": "ETH/BTC",
 "interval": "1d",
 "barStartTime": 1538478600000,
 "openPrice": "0.034733",
 "closePrice": "0.034767",
 "highPrice": "0.034856",
 "lowPrice": "0.034718",
 "volume": "6445.2025116"
}
```
took `volume` as base volume

