### PR TITLE
✨ Implement Bitsten ticker and order book

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Or install it yourself as:
 | Bits Blockchain   | Y       | Y          |         |         | Y           |          | bits_blockchain   |
 | Bitso             | Y       |            |         |         | Y           |          | bitso             |
 | Bitstamp          | Y       | Y          | Y       |         | User-Defined|          | bitstamp          |
+| Bitsten           | Y       | Y          | N       |         | Y           | Y        | bitsten           |
 | Bittrex           | Y       |            |         |         | Y           |          | bittrex           |
 | Bleutrade         | Y       |            |         |         | Y           |          | bleutrade         |
 | Blockonix         | Y       | Y          | Y       |         | Y           |          | blockonix         |

--- a/lib/cryptoexchange/exchanges/bitsten/market.rb
+++ b/lib/cryptoexchange/exchanges/bitsten/market.rb
@@ -1,0 +1,12 @@
+module Cryptoexchange::Exchanges
+  module Bitsten
+    class Market < Cryptoexchange::Models::Market
+      NAME = 'bitsten'
+      API_URL = 'https://bitsten.com/api/v1'
+
+      def self.trade_page_url(args={})
+        "https://bitsten.com/exchange/#{args[:base].downcase}_#{args[:target].downcase}"
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/bitsten/services/market.rb
+++ b/lib/cryptoexchange/exchanges/bitsten/services/market.rb
@@ -1,0 +1,50 @@
+module Cryptoexchange::Exchanges
+  module Bitsten
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            false
+          end
+        end
+
+        def fetch
+          output = super(ticker_url)
+          adapt_all(output)
+        end
+
+        def ticker_url
+          "#{Cryptoexchange::Exchanges::Bitsten::Market::API_URL}/public/getticker/all"
+        end
+
+        def adapt_all(output)
+          output['result'].map do |pair, ticker|
+            base, target = pair.split('_')
+            market_pair  = Cryptoexchange::Models::MarketPair.new(
+              base:   base,
+              target: target,
+              market: Bitsten::Market::NAME
+            )
+            adapt(ticker, market_pair)
+          end
+        end
+
+        def adapt(output, market_pair)
+          ticker         = Cryptoexchange::Models::Ticker.new
+          ticker.base    = market_pair.base
+          ticker.target  = market_pair.target
+          ticker.market  = Bitsten::Market::NAME
+          ticker.ask     = NumericHelper.to_d(output['ask'])
+          ticker.bid     = NumericHelper.to_d(output['bid'])
+          ticker.last    = NumericHelper.to_d(output['last'])
+          ticker.high    = NumericHelper.to_d(output['high'])
+          ticker.low     = NumericHelper.to_d(output['low'])
+          ticker.change  = NumericHelper.to_d(output['change'])
+          ticker.volume  = NumericHelper.divide(NumericHelper.to_d(output['basevolume']), ticker.last)
+          ticker.payload = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/bitsten/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/bitsten/services/order_book.rb
@@ -1,0 +1,44 @@
+module Cryptoexchange::Exchanges
+  module Bitsten
+    module Services
+      class OrderBook < Cryptoexchange::Services::Market
+        LIMIT = 100
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          base   = market_pair.base
+          target = market_pair.target
+          "#{Cryptoexchange::Exchanges::Bitsten::Market::API_URL}/public/getorderbook/#{base}_#{target}/both/#{LIMIT}"
+        end
+
+        def adapt(output, market_pair)
+          order_book           = Cryptoexchange::Models::OrderBook.new
+          order_book.base      = market_pair.base
+          order_book.target    = market_pair.target
+          order_book.market    = Bitsten::Market::NAME
+          order_book.asks      = adapt_orders(HashHelper.dig(output, 'result', 'selllimit'))
+          order_book.bids      = adapt_orders(HashHelper.dig(output, 'result', 'buylimit'))
+          order_book.payload   = output
+          order_book
+        end
+
+        def adapt_orders(orders)
+          orders.collect do |order_entry|
+            Cryptoexchange::Models::Order.new(price:     order_entry['price'],
+                                              amount:    order_entry['amount'],
+                                              timestamp: nil)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/bitsten/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/bitsten/services/pairs.rb
@@ -1,0 +1,26 @@
+module Cryptoexchange::Exchanges
+  module Bitsten
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Bitsten::Market::API_URL}/public/getticker/all"
+
+        def fetch
+          output = super
+          adapt(output)
+        end
+
+        def adapt(output)
+          pairs = output['result']
+          pairs.map do |pair, _ticker|
+            base, target = pair.split('_')
+            Cryptoexchange::Models::MarketPair.new(
+              base:   base,
+              target: target,
+              market: Bitsten::Market::NAME
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/Bitsten/integration_specs_fetch_order_book.yml
+++ b/spec/cassettes/vcr_cassettes/Bitsten/integration_specs_fetch_order_book.yml
@@ -1,0 +1,313 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://bitsten.com/api/v1/public/getorderbook/STN_BTC/both/100
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - bitsten.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 07 Oct 2018 02:42:22 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '6891'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d92baea848908977a401bb719dd48a1091538880142; expires=Mon, 07-Oct-19
+        02:42:22 GMT; path=/; domain=.bitsten.com; HttpOnly; Secure
+      - ci_session=7ecskhn4aq7vck0m7vh1basf35rld5l8; expires=Sun, 07-Oct-2018 04:42:22
+        GMT; Max-Age=7200; path=/; HttpOnly
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      Accept-Ranges:
+      - bytes
+      X-Turbo-Charged-By:
+      - LiteSpeed
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 465d039c3fc9849c-HKG
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+            "success": true,
+            "message": "",
+            "result": {
+                "buylimit": [
+                    {
+                        "price": "0.00000302",
+                        "amount": "2068.83112583"
+                    },
+                    {
+                        "price": "0.00000299",
+                        "amount": "2295.13500000"
+                    },
+                    {
+                        "price": "0.00000286",
+                        "amount": "601.00000000"
+                    },
+                    {
+                        "price": "0.00000280",
+                        "amount": "305.13928571"
+                    },
+                    {
+                        "price": "0.00000270",
+                        "amount": "1362.00000000"
+                    },
+                    {
+                        "price": "0.00000265",
+                        "amount": "159.17358490"
+                    },
+                    {
+                        "price": "0.00000260",
+                        "amount": "3654.43119658"
+                    },
+                    {
+                        "price": "0.00000253",
+                        "amount": "25650.84584980"
+                    },
+                    {
+                        "price": "0.00000250",
+                        "amount": "100.00000000"
+                    },
+                    {
+                        "price": "0.00000200",
+                        "amount": "6886.97500000"
+                    },
+                    {
+                        "price": "0.00000002",
+                        "amount": "600.00000000"
+                    }
+                ],
+                "selllimit": [
+                    {
+                        "price": "0.00000339",
+                        "amount": "1010.53109200"
+                    },
+                    {
+                        "price": "0.00000342",
+                        "amount": "1532.42520000"
+                    },
+                    {
+                        "price": "0.00000343",
+                        "amount": "2147.91600000"
+                    },
+                    {
+                        "price": "0.00000350",
+                        "amount": "915.52380000"
+                    },
+                    {
+                        "price": "0.00000353",
+                        "amount": "1424.02270000"
+                    },
+                    {
+                        "price": "0.00000356",
+                        "amount": "1597.45298665"
+                    },
+                    {
+                        "price": "0.00000360",
+                        "amount": "100.00000000"
+                    },
+                    {
+                        "price": "0.00000370",
+                        "amount": "100.00000000"
+                    },
+                    {
+                        "price": "0.00000375",
+                        "amount": "100.00000000"
+                    },
+                    {
+                        "price": "0.00000377",
+                        "amount": "505.02565400"
+                    },
+                    {
+                        "price": "0.00000378",
+                        "amount": "1872.20570000"
+                    },
+                    {
+                        "price": "0.00000380",
+                        "amount": "100.00000000"
+                    },
+                    {
+                        "price": "0.00000388",
+                        "amount": "320.96990155"
+                    },
+                    {
+                        "price": "0.00000390",
+                        "amount": "5500.00000000"
+                    },
+                    {
+                        "price": "0.00000410",
+                        "amount": "100.00000000"
+                    },
+                    {
+                        "price": "0.00000420",
+                        "amount": "100.00000000"
+                    },
+                    {
+                        "price": "0.00000449",
+                        "amount": "511.05117617"
+                    },
+                    {
+                        "price": "0.00000450",
+                        "amount": "23.69847017"
+                    },
+                    {
+                        "price": "0.00000485",
+                        "amount": "59.09950570"
+                    },
+                    {
+                        "price": "0.00000549",
+                        "amount": "500.00000000"
+                    },
+                    {
+                        "price": "0.00000550",
+                        "amount": "1299.14846638"
+                    },
+                    {
+                        "price": "0.00000600",
+                        "amount": "188.71663303"
+                    },
+                    {
+                        "price": "0.00000649",
+                        "amount": "505.00643752"
+                    },
+                    {
+                        "price": "0.00000700",
+                        "amount": "28.49648951"
+                    },
+                    {
+                        "price": "0.00000750",
+                        "amount": "1030.48163303"
+                    },
+                    {
+                        "price": "0.00000845",
+                        "amount": "9.00175226"
+                    },
+                    {
+                        "price": "0.00000850",
+                        "amount": "59.96431624"
+                    },
+                    {
+                        "price": "0.00000875",
+                        "amount": "5.00000000"
+                    },
+                    {
+                        "price": "0.00000997",
+                        "amount": "1000.00000000"
+                    },
+                    {
+                        "price": "0.00001000",
+                        "amount": "5000.00000000"
+                    },
+                    {
+                        "price": "0.00002890",
+                        "amount": "499.02247977"
+                    },
+                    {
+                        "price": "0.00004604",
+                        "amount": "753.54031669"
+                    },
+                    {
+                        "price": "0.00005000",
+                        "amount": "490.00000000"
+                    },
+                    {
+                        "price": "0.00005100",
+                        "amount": "1000.00000000"
+                    },
+                    {
+                        "price": "0.00005406",
+                        "amount": "5.00000000"
+                    },
+                    {
+                        "price": "0.00007800",
+                        "amount": "122.01885300"
+                    },
+                    {
+                        "price": "0.00009900",
+                        "amount": "8005.19961864"
+                    },
+                    {
+                        "price": "0.00010000",
+                        "amount": "880.63828389"
+                    },
+                    {
+                        "price": "0.00010048",
+                        "amount": "399.20019951"
+                    },
+                    {
+                        "price": "0.00011000",
+                        "amount": "5.00000000"
+                    },
+                    {
+                        "price": "0.00021000",
+                        "amount": "127.96424405"
+                    },
+                    {
+                        "price": "0.00040500",
+                        "amount": "5.00000000"
+                    },
+                    {
+                        "price": "0.00050000",
+                        "amount": "8983.21214706"
+                    },
+                    {
+                        "price": "0.00061000",
+                        "amount": "1200.00353492"
+                    },
+                    {
+                        "price": "0.00061700",
+                        "amount": "998.00000000"
+                    },
+                    {
+                        "price": "0.00095000",
+                        "amount": "656.00000000"
+                    },
+                    {
+                        "price": "0.00099400",
+                        "amount": "5.00411260"
+                    },
+                    {
+                        "price": "0.00100000",
+                        "amount": "20.00779797"
+                    },
+                    {
+                        "price": "0.00500000",
+                        "amount": "5.00000000"
+                    },
+                    {
+                        "price": "0.00520000",
+                        "amount": "300.00000000"
+                    },
+                    {
+                        "price": "0.05000000",
+                        "amount": "1140.25267511"
+                    }
+                ]
+            }
+        }
+    http_version: 
+  recorded_at: Sun, 07 Oct 2018 02:42:22 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Bitsten/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/Bitsten/integration_specs_fetch_pairs.yml
@@ -1,0 +1,336 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://bitsten.com/api/v1/public/getticker/all
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - bitsten.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 07 Oct 2018 02:42:40 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=dc70a365f253fb3e8079d9ffe82e3f0ea1538880159; expires=Mon, 07-Oct-19
+        02:42:39 GMT; path=/; domain=.bitsten.com; HttpOnly; Secure
+      - ci_session=g4iru2cdc9f9lfaf40rlne26o53g9krd; expires=Sun, 07-Oct-2018 04:42:39
+        GMT; Max-Age=7200; path=/; HttpOnly
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      Accept-Ranges:
+      - bytes
+      X-Turbo-Charged-By:
+      - LiteSpeed
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 465d04075a4284f6-HKG
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+            "success": true,
+            "message": "",
+            "result": {
+                "stn_btc": {
+                    "last": "0.00000302",
+                    "bid": "0.00000302",
+                    "ask": "0.00000339",
+                    "high": "0.00000356",
+                    "low": "0.00000300",
+                    "open": "0.00000342",
+                    "basevolume": "0.43820903",
+                    "btcvolume": "0.43820903",
+                    "change": "-11.70"
+                },
+                "ltc_btc": {
+                    "last": "0.00893247",
+                    "bid": "0.00894651",
+                    "ask": "0.00894753",
+                    "high": "0.00901722",
+                    "low": "0.00887444",
+                    "open": "0.00901722",
+                    "basevolume": "0.04825487",
+                    "btcvolume": "0.04825487",
+                    "change": "-0.94"
+                },
+                "doge_stn": {
+                    "last": "0.26212001",
+                    "bid": "0.27184001",
+                    "ask": "0.27392000",
+                    "high": "0.26212001",
+                    "low": "0.25545001",
+                    "open": "0.25545001",
+                    "basevolume": "2766.99389648",
+                    "btcvolume": "0.00835632",
+                    "change": "2.61"
+                },
+                "qtum_btc": {
+                    "last": "0.00057843",
+                    "bid": "0.00056786",
+                    "ask": "0.00057859",
+                    "high": "0.00057843",
+                    "low": "0.00057843",
+                    "open": "0.00057843",
+                    "basevolume": "0.00063714",
+                    "btcvolume": "0.00063714",
+                    "change": "0.00"
+                },
+                "pso_stn": {
+                    "last": "0.00100000",
+                    "bid": "0.00100000",
+                    "ask": "0.01000000",
+                    "high": "0.00100000",
+                    "low": "0.00100000",
+                    "open": "0.00100000",
+                    "basevolume": "0.40000001",
+                    "btcvolume": "0.00000121",
+                    "change": "0.00"
+                },
+                "dash_btc": {
+                    "last": "0.02749065",
+                    "bid": "0.02737102",
+                    "ask": "0.02747099",
+                    "high": "0.02825013",
+                    "low": "0.02749065",
+                    "open": "0.02751056",
+                    "basevolume": "0.00301609",
+                    "btcvolume": "0.00301609",
+                    "change": "-0.07"
+                },
+                "bch_btc": {
+                    "last": "0.07747970",
+                    "bid": "0.07765333",
+                    "ask": "0.07769791",
+                    "high": "0.07854779",
+                    "low": "0.07713479",
+                    "open": "0.07831005",
+                    "basevolume": "0.01846910",
+                    "btcvolume": "0.01846910",
+                    "change": "-1.06"
+                },
+                "dgb_stn": {
+                    "last": "1.26565003",
+                    "bid": "1.26670003",
+                    "ask": "1.29859996",
+                    "high": "1.26565003",
+                    "low": "1.09422004",
+                    "open": "1.18513000",
+                    "basevolume": "75568.90625000",
+                    "btcvolume": "0.22821810",
+                    "change": "6.79"
+                },
+                "zcl_btc": {
+                    "last": "0.00052796",
+                    "bid": "0.00051322",
+                    "ask": "0.00052748",
+                    "high": "0.00054439",
+                    "low": "0.00052796",
+                    "open": "0.00054226",
+                    "basevolume": "0.00336852",
+                    "btcvolume": "0.00336852",
+                    "change": "-2.64"
+                },
+                "zec_btc": {
+                    "last": "0.01917615",
+                    "bid": "0.01906730",
+                    "ask": "0.01909310",
+                    "high": "0.01952866",
+                    "low": "0.01917615",
+                    "open": "0.01952866",
+                    "basevolume": "0.00788063",
+                    "btcvolume": "0.00788063",
+                    "change": "-1.81"
+                },
+                "lgs_stn": {
+                    "last": "399.21823120",
+                    "bid": "444.19097900",
+                    "ask": "528.83264160",
+                    "high": "414.58145142",
+                    "low": "399.21823120",
+                    "open": "414.58145142",
+                    "basevolume": "14730.71679688",
+                    "btcvolume": "0.04448676",
+                    "change": "-3.71"
+                },
+                "lgs_btc": {
+                    "last": "0.00138010",
+                    "bid": "0.00137540",
+                    "ask": "0.00142404",
+                    "high": "0.00171424",
+                    "low": "0.00137540",
+                    "open": "0.00171424",
+                    "basevolume": "0.20577088",
+                    "btcvolume": "0.20577088",
+                    "change": "-19.49"
+                },
+                "doge_btc": {
+                    "last": "0.00000085",
+                    "bid": "0.00000084",
+                    "ask": "0.00000085",
+                    "high": "0.00000088",
+                    "low": "0.00000085",
+                    "open": "0.00000088",
+                    "basevolume": "0.00136460",
+                    "btcvolume": "0.00136460",
+                    "change": "-3.41"
+                },
+                "dgb_btc": {
+                    "last": "0.00000379",
+                    "bid": "0.00000379",
+                    "ask": "0.00000380",
+                    "high": "0.00000395",
+                    "low": "0.00000379",
+                    "open": "0.00000394",
+                    "basevolume": "0.10136148",
+                    "btcvolume": "0.10136148",
+                    "change": "-3.81"
+                },
+                "qtum_stn": {
+                    "last": "190.36819458",
+                    "bid": "189.80903625",
+                    "ask": "190.29069519",
+                    "high": "191.08325195",
+                    "low": "160.26231384",
+                    "open": "169.43673706",
+                    "basevolume": "15264.02539062",
+                    "btcvolume": "0.04609736",
+                    "change": "12.35"
+                },
+                "anon_btc": {
+                    "last": "0.00007389",
+                    "bid": "0.00007389",
+                    "ask": "0.00007574",
+                    "high": "0.00008450",
+                    "low": "0.00007389",
+                    "open": "0.00008293",
+                    "basevolume": "0.01954709",
+                    "btcvolume": "0.01954709",
+                    "change": "-10.90"
+                },
+                "btx_btc": {
+                    "last": "0.00011980",
+                    "bid": "0.00011991",
+                    "ask": "0.00011993",
+                    "high": "0.00012110",
+                    "low": "0.00011837",
+                    "open": "0.00011851",
+                    "basevolume": "0.01135920",
+                    "btcvolume": "0.01135920",
+                    "change": "1.09"
+                },
+                "bsd_btc": {
+                    "last": "0.00002328",
+                    "bid": "0.00002328",
+                    "ask": "0.00002372",
+                    "high": "0.00002369",
+                    "low": "0.00002315",
+                    "open": "0.00002315",
+                    "basevolume": "0.01277564",
+                    "btcvolume": "0.01277564",
+                    "change": "0.56"
+                },
+                "btx_stn": {
+                    "last": "39.99750137",
+                    "bid": "40.09598923",
+                    "ask": "40.32540894",
+                    "high": "40.09090042",
+                    "low": "34.28918839",
+                    "open": "36.87163925",
+                    "basevolume": "4895.04003906",
+                    "btcvolume": "0.01478302",
+                    "change": "8.48"
+                },
+                "bsd_stn": {
+                    "last": "7.72022009",
+                    "bid": "7.64246988",
+                    "ask": "7.64447021",
+                    "high": "7.72022009",
+                    "low": "6.66712999",
+                    "open": "6.98250008",
+                    "basevolume": "4209.50390625",
+                    "btcvolume": "0.01271270",
+                    "change": "10.57"
+                },
+                "dash_stn": {
+                    "last": "9146.85449219",
+                    "bid": "9092.21386719",
+                    "ask": "9129.38867188",
+                    "high": "9174.56054688",
+                    "low": "7740.46435547",
+                    "open": "8059.38232422",
+                    "basevolume": "4156.66162109",
+                    "btcvolume": "0.01255312",
+                    "change": "13.49"
+                },
+                "zcl_stn": {
+                    "last": "176.12771606",
+                    "bid": "177.43907166",
+                    "ask": "185.22459412",
+                    "high": "176.38973999",
+                    "low": "157.66287231",
+                    "open": "160.71803284",
+                    "basevolume": "1237.77160645",
+                    "btcvolume": "0.00373807",
+                    "change": "9.59"
+                },
+                "hpc_btc": {
+                    "last": "0.00004413",
+                    "bid": "0.00004159",
+                    "ask": "0.00004413",
+                    "high": "0.00004415",
+                    "low": "0.00003910",
+                    "open": "0.00004020",
+                    "basevolume": "0.00856314",
+                    "btcvolume": "0.00856314",
+                    "change": "9.78"
+                },
+                "hpc_stn": {
+                    "last": "13.26661015",
+                    "bid": "13.89507961",
+                    "ask": "14.79981041",
+                    "high": "13.26661015",
+                    "low": "12.06820965",
+                    "open": "12.06820965",
+                    "basevolume": "1395.36254883",
+                    "btcvolume": "0.00421399",
+                    "change": "9.93"
+                },
+                "btg_btc": {
+                    "last": "0.00422742",
+                    "bid": "0.00420993",
+                    "ask": "0.00421193",
+                    "high": "0.00447169",
+                    "low": "0.00415215",
+                    "open": "0.00415215",
+                    "basevolume": "0.02432270",
+                    "btcvolume": "0.02432270",
+                    "change": "1.81"
+                }
+            }
+        }
+    http_version: 
+  recorded_at: Sun, 07 Oct 2018 02:42:40 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Bitsten/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/Bitsten/integration_specs_fetch_ticker.yml
@@ -1,0 +1,336 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://bitsten.com/api/v1/public/getticker/all
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - bitsten.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 07 Oct 2018 02:42:22 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d10785e034e9a9ceaa3e02ed194d740401538880142; expires=Mon, 07-Oct-19
+        02:42:22 GMT; path=/; domain=.bitsten.com; HttpOnly; Secure
+      - ci_session=9n40qbapvirohukrnq5fs15c4uvjahvb; expires=Sun, 07-Oct-2018 04:42:22
+        GMT; Max-Age=7200; path=/; HttpOnly
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      Accept-Ranges:
+      - bytes
+      X-Turbo-Charged-By:
+      - LiteSpeed
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 465d039a4eb9a362-HKG
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+            "success": true,
+            "message": "",
+            "result": {
+                "stn_btc": {
+                    "last": "0.00000302",
+                    "bid": "0.00000302",
+                    "ask": "0.00000339",
+                    "high": "0.00000356",
+                    "low": "0.00000300",
+                    "open": "0.00000342",
+                    "basevolume": "0.43820903",
+                    "btcvolume": "0.43820903",
+                    "change": "-11.70"
+                },
+                "ltc_btc": {
+                    "last": "0.00893247",
+                    "bid": "0.00894651",
+                    "ask": "0.00894753",
+                    "high": "0.00901722",
+                    "low": "0.00887444",
+                    "open": "0.00901722",
+                    "basevolume": "0.04825487",
+                    "btcvolume": "0.04825487",
+                    "change": "-0.94"
+                },
+                "doge_stn": {
+                    "last": "0.26212001",
+                    "bid": "0.27184001",
+                    "ask": "0.27392000",
+                    "high": "0.26212001",
+                    "low": "0.25545001",
+                    "open": "0.25545001",
+                    "basevolume": "2766.99389648",
+                    "btcvolume": "0.00835632",
+                    "change": "2.61"
+                },
+                "qtum_btc": {
+                    "last": "0.00057843",
+                    "bid": "0.00056786",
+                    "ask": "0.00057859",
+                    "high": "0.00057843",
+                    "low": "0.00057843",
+                    "open": "0.00057843",
+                    "basevolume": "0.00063714",
+                    "btcvolume": "0.00063714",
+                    "change": "0.00"
+                },
+                "pso_stn": {
+                    "last": "0.00100000",
+                    "bid": "0.00100000",
+                    "ask": "0.01000000",
+                    "high": "0.00100000",
+                    "low": "0.00100000",
+                    "open": "0.00100000",
+                    "basevolume": "0.40000001",
+                    "btcvolume": "0.00000121",
+                    "change": "0.00"
+                },
+                "dash_btc": {
+                    "last": "0.02749065",
+                    "bid": "0.02737102",
+                    "ask": "0.02747099",
+                    "high": "0.02825013",
+                    "low": "0.02749065",
+                    "open": "0.02751056",
+                    "basevolume": "0.00301609",
+                    "btcvolume": "0.00301609",
+                    "change": "-0.07"
+                },
+                "bch_btc": {
+                    "last": "0.07747970",
+                    "bid": "0.07765333",
+                    "ask": "0.07769791",
+                    "high": "0.07854779",
+                    "low": "0.07713479",
+                    "open": "0.07831005",
+                    "basevolume": "0.01846910",
+                    "btcvolume": "0.01846910",
+                    "change": "-1.06"
+                },
+                "dgb_stn": {
+                    "last": "1.26565003",
+                    "bid": "1.26670003",
+                    "ask": "1.29859996",
+                    "high": "1.26565003",
+                    "low": "1.09422004",
+                    "open": "1.18513000",
+                    "basevolume": "75568.90625000",
+                    "btcvolume": "0.22821810",
+                    "change": "6.79"
+                },
+                "zcl_btc": {
+                    "last": "0.00052796",
+                    "bid": "0.00051322",
+                    "ask": "0.00052748",
+                    "high": "0.00054439",
+                    "low": "0.00052796",
+                    "open": "0.00054226",
+                    "basevolume": "0.00336852",
+                    "btcvolume": "0.00336852",
+                    "change": "-2.64"
+                },
+                "zec_btc": {
+                    "last": "0.01917615",
+                    "bid": "0.01906730",
+                    "ask": "0.01909310",
+                    "high": "0.01952866",
+                    "low": "0.01917615",
+                    "open": "0.01952866",
+                    "basevolume": "0.00788063",
+                    "btcvolume": "0.00788063",
+                    "change": "-1.81"
+                },
+                "lgs_stn": {
+                    "last": "399.21823120",
+                    "bid": "444.19097900",
+                    "ask": "528.83264160",
+                    "high": "414.58145142",
+                    "low": "399.21823120",
+                    "open": "414.58145142",
+                    "basevolume": "14730.71679688",
+                    "btcvolume": "0.04448676",
+                    "change": "-3.71"
+                },
+                "lgs_btc": {
+                    "last": "0.00138010",
+                    "bid": "0.00137540",
+                    "ask": "0.00142404",
+                    "high": "0.00171424",
+                    "low": "0.00137540",
+                    "open": "0.00171424",
+                    "basevolume": "0.20577088",
+                    "btcvolume": "0.20577088",
+                    "change": "-19.49"
+                },
+                "doge_btc": {
+                    "last": "0.00000085",
+                    "bid": "0.00000084",
+                    "ask": "0.00000085",
+                    "high": "0.00000088",
+                    "low": "0.00000085",
+                    "open": "0.00000088",
+                    "basevolume": "0.00136460",
+                    "btcvolume": "0.00136460",
+                    "change": "-3.41"
+                },
+                "dgb_btc": {
+                    "last": "0.00000379",
+                    "bid": "0.00000379",
+                    "ask": "0.00000380",
+                    "high": "0.00000395",
+                    "low": "0.00000379",
+                    "open": "0.00000394",
+                    "basevolume": "0.10136148",
+                    "btcvolume": "0.10136148",
+                    "change": "-3.81"
+                },
+                "qtum_stn": {
+                    "last": "190.36819458",
+                    "bid": "189.80903625",
+                    "ask": "190.29069519",
+                    "high": "191.08325195",
+                    "low": "160.26231384",
+                    "open": "169.43673706",
+                    "basevolume": "15264.02539062",
+                    "btcvolume": "0.04609736",
+                    "change": "12.35"
+                },
+                "anon_btc": {
+                    "last": "0.00007389",
+                    "bid": "0.00007389",
+                    "ask": "0.00007574",
+                    "high": "0.00008450",
+                    "low": "0.00007389",
+                    "open": "0.00008293",
+                    "basevolume": "0.01954709",
+                    "btcvolume": "0.01954709",
+                    "change": "-10.90"
+                },
+                "btx_btc": {
+                    "last": "0.00011980",
+                    "bid": "0.00011991",
+                    "ask": "0.00011993",
+                    "high": "0.00012110",
+                    "low": "0.00011837",
+                    "open": "0.00011851",
+                    "basevolume": "0.01135920",
+                    "btcvolume": "0.01135920",
+                    "change": "1.09"
+                },
+                "bsd_btc": {
+                    "last": "0.00002328",
+                    "bid": "0.00002328",
+                    "ask": "0.00002372",
+                    "high": "0.00002369",
+                    "low": "0.00002315",
+                    "open": "0.00002315",
+                    "basevolume": "0.01277564",
+                    "btcvolume": "0.01277564",
+                    "change": "0.56"
+                },
+                "btx_stn": {
+                    "last": "39.99750137",
+                    "bid": "40.09598923",
+                    "ask": "40.32540894",
+                    "high": "40.09090042",
+                    "low": "34.28918839",
+                    "open": "36.87163925",
+                    "basevolume": "4895.04003906",
+                    "btcvolume": "0.01478302",
+                    "change": "8.48"
+                },
+                "bsd_stn": {
+                    "last": "7.72022009",
+                    "bid": "7.64246988",
+                    "ask": "7.64447021",
+                    "high": "7.72022009",
+                    "low": "6.66712999",
+                    "open": "6.98250008",
+                    "basevolume": "4209.50390625",
+                    "btcvolume": "0.01271270",
+                    "change": "10.57"
+                },
+                "dash_stn": {
+                    "last": "9146.85449219",
+                    "bid": "9092.21386719",
+                    "ask": "9129.38867188",
+                    "high": "9174.56054688",
+                    "low": "7740.46435547",
+                    "open": "8059.38232422",
+                    "basevolume": "4156.66162109",
+                    "btcvolume": "0.01255312",
+                    "change": "13.49"
+                },
+                "zcl_stn": {
+                    "last": "176.12771606",
+                    "bid": "177.43907166",
+                    "ask": "185.22459412",
+                    "high": "176.38973999",
+                    "low": "157.66287231",
+                    "open": "160.71803284",
+                    "basevolume": "1237.77160645",
+                    "btcvolume": "0.00373807",
+                    "change": "9.59"
+                },
+                "hpc_btc": {
+                    "last": "0.00004413",
+                    "bid": "0.00004159",
+                    "ask": "0.00004413",
+                    "high": "0.00004415",
+                    "low": "0.00003910",
+                    "open": "0.00004020",
+                    "basevolume": "0.00856314",
+                    "btcvolume": "0.00856314",
+                    "change": "9.78"
+                },
+                "hpc_stn": {
+                    "last": "13.26661015",
+                    "bid": "13.89507961",
+                    "ask": "14.79981041",
+                    "high": "13.26661015",
+                    "low": "12.06820965",
+                    "open": "12.06820965",
+                    "basevolume": "1395.36254883",
+                    "btcvolume": "0.00421399",
+                    "change": "9.93"
+                },
+                "btg_btc": {
+                    "last": "0.00422742",
+                    "bid": "0.00420993",
+                    "ask": "0.00421193",
+                    "high": "0.00447169",
+                    "low": "0.00415215",
+                    "open": "0.00415215",
+                    "basevolume": "0.02432270",
+                    "btcvolume": "0.02432270",
+                    "change": "1.81"
+                }
+            }
+        }
+    http_version: 
+  recorded_at: Sun, 07 Oct 2018 02:42:22 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/bitsten/integration/market_spec.rb
+++ b/spec/exchanges/bitsten/integration/market_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+RSpec.describe 'Bitsten integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:stn_btc_pair) { Cryptoexchange::Models::Bilaxy::MarketPair.new(base: 'STN', target: 'BTC', market: 'bitsten') }
+
+  it 'fetch pairs' do
+    pairs = client.pairs('bitsten')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.market).to eq 'bitsten'
+  end
+
+  it 'give trade url' do
+    trade_page_url = client.trade_page_url 'bitsten', base: stn_btc_pair.base, target: stn_btc_pair.target
+    expect(trade_page_url).to eq "https://bitsten.com/exchange/stn_btc"
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(stn_btc_pair)
+
+    expect(ticker.base).to eq 'STN'
+    expect(ticker.target).to eq 'BTC'
+    expect(ticker.market).to eq 'bitsten'
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.ask).to be_a Numeric
+    expect(ticker.bid).to be_a Numeric
+    expect(ticker.low).to be_a Numeric
+    expect(ticker.high).to be_a Numeric
+    expect(ticker.change).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+    expect(ticker.timestamp).to be nil
+    expect(ticker.payload).to_not be nil
+  end
+
+  it 'fetch order book' do
+    order_book = client.order_book(stn_btc_pair)
+
+    expect(order_book.base).to eq 'STN'
+    expect(order_book.target).to eq 'BTC'
+    expect(order_book.market).to eq 'bitsten'
+    expect(order_book.asks).to_not be_empty
+    expect(order_book.bids).to_not be_empty
+    expect(order_book.asks.first.price).to_not be_nil
+    expect(order_book.bids.first.amount).to_not be_nil
+    expect(order_book.bids.first.timestamp).to be_nil
+    expect(order_book.asks.count).to be > 0
+    expect(order_book.bids.count).to be > 0
+    expect(order_book.timestamp).to be_nil
+    expect(order_book.payload).to_not be nil
+  end
+end

--- a/spec/exchanges/bitsten/market_spec.rb
+++ b/spec/exchanges/bitsten/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Bitsten::Market do
+  it { expect(described_class::NAME).to eq 'bitsten' }
+  it { expect(described_class::API_URL).to eq 'https://bitsten.com/api/v1' }
+end

--- a/spec/exchanges/coinchangex/market_spec.rb
+++ b/spec/exchanges/coinchangex/market_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Cryptoexchange::Exchanges::Coinchangex::Market do
   it { expect(described_class::TOKEN_URL).to eq 'https://www.coinchangex.com/config/main.json' }
 
   it 'fetch symbol' do
-    VCR.use_cassette('coinchangex/fetch_symbol') do
+    VCR.use_cassette('Coinchangex/fetch_symbol') do
       output = described_class.fetch_symbol
       expect(output).to_not be_nil
       expect(output.count).to be > 20


### PR DESCRIPTION
- What is the purpose of this Pull Request? as title
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")? closes #973
- [x] I have added Specs
- [x] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [x] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly

ticker about `STN_BTC`
```ruby
{ 
 "stn_btc": {
  "last": "0.00000302",
  "bid": "0.00000299",
  "ask": "0.00000302",
  "high": "0.00000356",
  "low": "0.00000300",
  "open": "0.00000343",
  "basevolume": "0.44106790",
  "btcvolume": "0.44106790",
  "change": "-11.95"
 }
}
```
took `basevolume` / `last` as volume
