### PR TITLE
✨ Implement Bitbegin ticker

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Or install it yourself as:
 | Bit-Z             | Y       |            |         |         | Y           |          | bit_z             |
 | Bitbank           | Y       | Y          | Y       |         | User-Defined| Y        | bitbank           |
 | Bitbay            | Y       |            |         |         | User-Defined|          | bitbay            |
+| Bitbegin          | Y       | N          | N       |         | Y           | Y        | bitbegin          |
 | BitBNS            | Y       |            |         |         | Y           |          | bitbns            |
 | Bitbox (Auth)     | Y       |            |         |         | User-Defined| Y        | bitbox            |
 | Bitconnect        | Y       |            |         |         | Y           |          | bitconnect        |

--- a/lib/cryptoexchange/exchanges/bitbegin/market.rb
+++ b/lib/cryptoexchange/exchanges/bitbegin/market.rb
@@ -1,0 +1,12 @@
+module Cryptoexchange::Exchanges
+  module Bitbegin
+    class Market < Cryptoexchange::Models::Market
+      NAME = 'bitbegin'
+      API_URL = 'https://bitbegin.io/api'
+
+      def self.trade_page_url(args={})
+        "https://bitbegin.io/trade?PairName=#{args[:base]}-#{args[:target]}"
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/bitbegin/services/market.rb
+++ b/lib/cryptoexchange/exchanges/bitbegin/services/market.rb
@@ -1,0 +1,43 @@
+module Cryptoexchange::Exchanges
+  module Bitbegin
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            false
+          end
+        end
+
+        def fetch
+          output = super(ticker_url)
+          adapt_all(output)
+        end
+
+        def ticker_url
+          "#{Cryptoexchange::Exchanges::Bitbegin::Market::API_URL}/getmarketsummaries"
+        end
+
+        def adapt_all(output)
+          output['result'].map do |ticker|
+            adapt(ticker)
+          end
+        end
+
+        def adapt(output)
+          base, target     = output['MarketName'].split('_')
+          ticker           = Cryptoexchange::Models::Ticker.new
+          ticker.base      = base
+          ticker.target    = target
+          ticker.market    = Bitbegin::Market::NAME
+          ticker.high      = NumericHelper.to_d(output['High'])
+          ticker.low       = NumericHelper.to_d(output['Low'])
+          ticker.last      = NumericHelper.to_d(output['Last'])
+          ticker.volume    = NumericHelper.to_d(output['Volume'])
+          ticker.timestamp = nil
+          ticker.payload   = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/bitbegin/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/bitbegin/services/pairs.rb
@@ -1,0 +1,25 @@
+module Cryptoexchange::Exchanges
+  module Bitbegin
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Bitbegin::Market::API_URL}/getmarkets"
+
+        def fetch
+          output = super
+          adapt(output)
+        end
+
+        def adapt(output)
+          output['result'].map do |pair|
+            next unless pair['IsActive']
+            Cryptoexchange::Models::MarketPair.new(
+              base:   pair['MarketCurrency'],
+              target: pair['BaseCurrency'],
+              market: Bitbegin::Market::NAME
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/Bitbegin/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/Bitbegin/integration_specs_fetch_pairs.yml
@@ -1,0 +1,107 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://bitbegin.io/api/getmarkets
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - bitbegin.io
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 28 Oct 2018 04:07:24 GMT
+      Content-Type:
+      - text/plain;charset=ISO-8859-1
+      Content-Length:
+      - '7480'
+      Connection:
+      - close
+      Server:
+      - nginx/1.12.1
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ISO-8859-1
+      string: '{"result":[{"MarketCurrency":"EXBT","BaseCurrency":"BINS","MarketCurrencyLong":"EXHIBITTOKEN
+        ","BaseCurrencyLong":"BITSENSE","MinTradeSize":"0.0000000","MarketName":"EXBT_BINS","IsActive":true,"Created":"2018-09-30
+        09:57:00.0"},{"MarketCurrency":"OMG","BaseCurrency":"BIB","MarketCurrencyLong":"OMISEGO","BaseCurrencyLong":"BITBEGIN
+        COIN","MinTradeSize":"0.0000000","MarketName":"OMG_BIB","IsActive":true,"Created":"2018-10-24
+        19:57:56.0"},{"MarketCurrency":"ICX","BaseCurrency":"BIB","MarketCurrencyLong":"ICON","BaseCurrencyLong":"BITBEGIN
+        COIN","MinTradeSize":"0.0000000","MarketName":"ICX_BIB","IsActive":true,"Created":"2018-10-24
+        19:59:05.0"},{"MarketCurrency":"GVT","BaseCurrency":"BIB","MarketCurrencyLong":"GENESIS
+        VISION","BaseCurrencyLong":"BITBEGIN COIN","MinTradeSize":"0.0000000","MarketName":"GVT_BIB","IsActive":true,"Created":"2018-10-24
+        19:56:19.0"},{"MarketCurrency":"TUSD","BaseCurrency":"BIB","MarketCurrencyLong":"TRUEUSD
+        ","BaseCurrencyLong":"BITBEGIN COIN","MinTradeSize":"0.0000000","MarketName":"TUSD_BIB","IsActive":true,"Created":"2018-10-24
+        19:58:04.0"},{"MarketCurrency":"STCDR","BaseCurrency":"BINS","MarketCurrencyLong":"SMARTER  THAN
+        CRYPTO","BaseCurrencyLong":"BITSENSE","MinTradeSize":"0.0000000","MarketName":"STCDR_BINS","IsActive":true,"Created":"2018-09-20
+        22:55:45.0"},{"MarketCurrency":"STCDR","BaseCurrency":"ETH","MarketCurrencyLong":"SMARTER  THAN
+        CRYPTO","BaseCurrencyLong":"ETHEREUM","MinTradeSize":"0.0000000","MarketName":"STCDR_ETH","IsActive":true,"Created":"2018-09-20
+        22:55:20.0"},{"MarketCurrency":"BIB","BaseCurrency":"BTC","MarketCurrencyLong":"BITBEGIN
+        COIN","BaseCurrencyLong":"BITCOIN","MinTradeSize":"0.0000000","MarketName":"BIB_BTC","IsActive":true,"Created":"2018-10-22
+        10:11:37.0"},{"MarketCurrency":"BAT","BaseCurrency":"BTC","MarketCurrencyLong":"BASIC
+        ATTENTION TOKEN","BaseCurrencyLong":"BITCOIN","MinTradeSize":"0.0000000","MarketName":"BAT_BTC","IsActive":true,"Created":"2018-10-06
+        10:23:55.0"},{"MarketCurrency":"ICX","BaseCurrency":"BTC","MarketCurrencyLong":"ICON","BaseCurrencyLong":"BITCOIN","MinTradeSize":"0.0000000","MarketName":"ICX_BTC","IsActive":true,"Created":"2018-10-06
+        12:16:19.0"},{"MarketCurrency":"TUSD","BaseCurrency":"BTC","MarketCurrencyLong":"TRUEUSD
+        ","BaseCurrencyLong":"BITCOIN","MinTradeSize":"0.0000000","MarketName":"TUSD_BTC","IsActive":true,"Created":"2018-10-06
+        12:34:54.0"},{"MarketCurrency":"OMG","BaseCurrency":"BTC","MarketCurrencyLong":"OMISEGO","BaseCurrencyLong":"BITCOIN","MinTradeSize":"0.0000000","MarketName":"OMG_BTC","IsActive":true,"Created":"2018-10-06
+        11:58:00.0"},{"MarketCurrency":"SHEL","BaseCurrency":"ETH","MarketCurrencyLong":"SHELTERDAO","BaseCurrencyLong":"ETHEREUM","MinTradeSize":"0.0000000","MarketName":"SHEL_ETH","IsActive":true,"Created":"2018-09-29
+        15:55:13.0"},{"MarketCurrency":"BIB","BaseCurrency":"ETH","MarketCurrencyLong":"BITBEGIN
+        COIN","BaseCurrencyLong":"ETHEREUM","MinTradeSize":"0.0000000","MarketName":"BIB_ETH","IsActive":true,"Created":"2018-10-22
+        10:11:50.0"},{"MarketCurrency":"EXBT","BaseCurrency":"ETH","MarketCurrencyLong":"EXHIBITTOKEN
+        ","BaseCurrencyLong":"ETHEREUM","MinTradeSize":"0.0000000","MarketName":"EXBT_ETH","IsActive":true,"Created":"2018-09-30
+        09:53:49.0"},{"MarketCurrency":"BINS","BaseCurrency":"BTC","MarketCurrencyLong":"BITSENSE","BaseCurrencyLong":"BITCOIN","MinTradeSize":"0.0000000","MarketName":"BINS_BTC","IsActive":true,"Created":"2018-09-20
+        22:41:51.0"},{"MarketCurrency":"SHEL","BaseCurrency":"BINS","MarketCurrencyLong":"SHELTERDAO","BaseCurrencyLong":"BITSENSE","MinTradeSize":"0.0000000","MarketName":"SHEL_BINS","IsActive":true,"Created":"2018-09-29
+        15:55:01.0"},{"MarketCurrency":"TUSD","BaseCurrency":"ETH","MarketCurrencyLong":"TRUEUSD
+        ","BaseCurrencyLong":"ETHEREUM","MinTradeSize":"0.0000000","MarketName":"TUSD_ETH","IsActive":true,"Created":"2018-10-06
+        12:33:50.0"},{"MarketCurrency":"BAT","BaseCurrency":"ETH","MarketCurrencyLong":"BASIC
+        ATTENTION TOKEN","BaseCurrencyLong":"ETHEREUM","MinTradeSize":"0.0000000","MarketName":"BAT_ETH","IsActive":true,"Created":"2018-10-06
+        10:38:38.0"},{"MarketCurrency":"OMG","BaseCurrency":"ETH","MarketCurrencyLong":"OMISEGO","BaseCurrencyLong":"ETHEREUM","MinTradeSize":"0.0000000","MarketName":"OMG_ETH","IsActive":true,"Created":"2018-10-06
+        11:55:50.0"},{"MarketCurrency":"BINS","BaseCurrency":"ETH","MarketCurrencyLong":"BITSENSE","BaseCurrencyLong":"ETHEREUM","MinTradeSize":"0.0000000","MarketName":"BINS_ETH","IsActive":true,"Created":"2018-09-20
+        22:41:18.0"},{"MarketCurrency":"GVT","BaseCurrency":"ETH","MarketCurrencyLong":"GENESIS
+        VISION","BaseCurrencyLong":"ETHEREUM","MinTradeSize":"0.0000000","MarketName":"GVT_ETH","IsActive":true,"Created":"2018-10-06
+        12:23:53.0"},{"MarketCurrency":"GVT","BaseCurrency":"BTC","MarketCurrencyLong":"GENESIS
+        VISION","BaseCurrencyLong":"BITCOIN","MinTradeSize":"0.0000000","MarketName":"GVT_BTC","IsActive":true,"Created":"2018-10-06
+        12:25:28.0"},{"MarketCurrency":"BAT","BaseCurrency":"BINS","MarketCurrencyLong":"BASIC
+        ATTENTION TOKEN","BaseCurrencyLong":"BITSENSE","MinTradeSize":"0.0000000","MarketName":"BAT_BINS","IsActive":true,"Created":"2018-10-06
+        10:28:07.0"},{"MarketCurrency":"ETH","BaseCurrency":"BTC","MarketCurrencyLong":"ETHEREUM","BaseCurrencyLong":"BITCOIN","MinTradeSize":"0.0000000","MarketName":"ETH_BTC","IsActive":true,"Created":"2018-09-20
+        22:47:51.0"},{"MarketCurrency":"TUSD","BaseCurrency":"BINS","MarketCurrencyLong":"TRUEUSD
+        ","BaseCurrencyLong":"BITSENSE","MinTradeSize":"0.0000000","MarketName":"TUSD_BINS","IsActive":true,"Created":"2018-10-06
+        12:36:02.0"},{"MarketCurrency":"BAT","BaseCurrency":"BIB","MarketCurrencyLong":"BASIC
+        ATTENTION TOKEN","BaseCurrencyLong":"BITBEGIN COIN","MinTradeSize":"0.0000000","MarketName":"BAT_BIB","IsActive":true,"Created":"2018-10-24
+        19:58:20.0"},{"MarketCurrency":"ICX","BaseCurrency":"ETH","MarketCurrencyLong":"ICON","BaseCurrencyLong":"ETHEREUM","MinTradeSize":"0.0000000","MarketName":"ICX_ETH","IsActive":true,"Created":"2018-10-06
+        12:14:57.0"},{"MarketCurrency":"BIB","BaseCurrency":"NGN","MarketCurrencyLong":"BITBEGIN
+        COIN","BaseCurrencyLong":"NAIRA","MinTradeSize":"0.0000000","MarketName":"BIB_NGN","IsActive":true,"Created":"2018-10-22
+        10:11:23.0"},{"MarketCurrency":"OMG","BaseCurrency":"BINS","MarketCurrencyLong":"OMISEGO","BaseCurrencyLong":"BITSENSE","MinTradeSize":"0.0000000","MarketName":"OMG_BINS","IsActive":true,"Created":"2018-10-06
+        11:59:12.0"},{"MarketCurrency":"GVT","BaseCurrency":"BINS","MarketCurrencyLong":"GENESIS
+        VISION","BaseCurrencyLong":"BITSENSE","MinTradeSize":"0.0000000","MarketName":"GVT_BINS","IsActive":true,"Created":"2018-10-06
+        12:26:20.0"},{"MarketCurrency":"TUSD","BaseCurrency":"NGN","MarketCurrencyLong":"TRUEUSD
+        ","BaseCurrencyLong":"NAIRA","MinTradeSize":"0.0000000","MarketName":"TUSD_NGN","IsActive":true,"Created":"2018-10-06
+        12:37:05.0"},{"MarketCurrency":"BINS","BaseCurrency":"NGN","MarketCurrencyLong":"BITSENSE","BaseCurrencyLong":"NAIRA","MinTradeSize":"0.0000000","MarketName":"BINS_NGN","IsActive":true,"Created":"2018-09-20
+        22:44:14.0"},{"MarketCurrency":"ETH","BaseCurrency":"NGN","MarketCurrencyLong":"ETHEREUM","BaseCurrencyLong":"NAIRA","MinTradeSize":"0.0000000","MarketName":"ETH_NGN","IsActive":true,"Created":"2018-09-20
+        22:48:38.0"},{"MarketCurrency":"BTC","BaseCurrency":"NGN","MarketCurrencyLong":"BITCOIN","BaseCurrencyLong":"NAIRA","MinTradeSize":"0.0000000","MarketName":"BTC_NGN","IsActive":true,"Created":"2018-10-01
+        18:31:46.0"}],"success":true,"message":""}'
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 04:07:24 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Bitbegin/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/Bitbegin/integration_specs_fetch_ticker.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://bitbegin.io/api/getmarketsummaries
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - bitbegin.io
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 28 Oct 2018 04:07:38 GMT
+      Content-Type:
+      - text/plain;charset=ISO-8859-1
+      Content-Length:
+      - '4127'
+      Connection:
+      - close
+      Server:
+      - nginx/1.12.1
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Frame-Options:
+      - SAMEORIGIN
+    body:
+      encoding: ISO-8859-1
+      string: '{"result":[{"MarketName":"BTC_NGN","High":2308659,"Low":2.30865E+6,"Volume":7.8176,"Last":2308659,"BaseVolume":18048144.6138,"OpenOrders":56},{"MarketName":"ETH_NGN","High":72309,"Low":7.23E+4,"Volume":77.909,"Last":72309,"BaseVolume":5633170.881,"OpenOrders":39},{"MarketName":"TUSD_NGN","High":364,"Low":363.348287,"Volume":416,"Last":364,"BaseVolume":151371.86296,"OpenOrders":56},{"MarketName":"BAT_BIB","High":0.41484154,"Low":0.41000448,"Volume":599.99363,"Last":0.41000448,"BaseVolume":247.45600052,"OpenOrders":0},{"MarketName":"GVT_ETH","High":0.07248967,"Low":0.06975833,"Volume":74755.53607774,"Last":0.06975833,"BaseVolume":5336.37686219,"OpenOrders":119},{"MarketName":"ETH_BTC","High":0.03136368,"Low":0.03118935,"Volume":3339,"Last":0.03121959,"BaseVolume":104.37777882,"OpenOrders":336},{"MarketName":"OMG_ETH","High":0.01635894,"Low":0.01583048,"Volume":46074.0666232,"Last":0.01583048,"BaseVolume":738.74639468,"OpenOrders":322},{"MarketName":"BAT_ETH","High":0.01,"Low":0.00123546,"Volume":501335.953019,"Last":0.00126393,"BaseVolume":628.87838045,"OpenOrders":352},{"MarketName":"TUSD_ETH","High":0.00503445,"Low":0.00487782,"Volume":173485.2110816,"Last":0.00503445,"BaseVolume":855.28986161,"OpenOrders":496},{"MarketName":"ICX_ETH","High":0.00326666,"Low":0.00319343,"Volume":26014.034186,"Last":0.00324983,"BaseVolume":84.56411025,"OpenOrders":266},{"MarketName":"GVT_BTC","High":0.00231747,"Low":0.00197383,"Volume":7.512E+4,"Last":0.00197383,"BaseVolume":156.2204256,"OpenOrders":204},{"MarketName":"OMG_BTC","High":0.000501,"Low":0.000491,"Volume":119188.97886,"Last":0.00049901,"BaseVolume":59.16474972,"OpenOrders":602},{"MarketName":"TUSD_BTC","High":0.00015764,"Low":0.0001559,"Volume":93178.5596222,"Last":0.000156,"BaseVolume":14.60317871,"OpenOrders":416},{"MarketName":"ICX_BTC","High":0.0000993,"Low":0.00009912,"Volume":28112,"Last":0.00009912,"BaseVolume":2.78886804,"OpenOrders":350},{"MarketName":"BAT_BTC","High":0.00003886,"Low":0.00003879,"Volume":376599.2153,"Last":0.00003886,"BaseVolume":14.6233617,"OpenOrders":88},{"MarketName":"EXBT_ETH","High":0.0000221,"Low":0.000019,"Volume":363379.939664,"Last":0.0000221,"BaseVolume":7.70870973,"OpenOrders":322},{"MarketName":"BIB_BTC","High":0.0000161,"Low":0.00001458,"Volume":1.1158E+5,"Last":0.00001594,"BaseVolume":1.7647542,"OpenOrders":26},{"MarketName":"BINS_BTC","High":0,"Low":0,"Volume":0,"Last":0.00061793,"BaseVolume":0,"OpenOrders":0},{"MarketName":"BINS_ETH","High":0,"Low":0,"Volume":0,"Last":0.0142,"BaseVolume":0,"OpenOrders":0},{"MarketName":"BINS_NGN","High":0,"Low":0,"Volume":0,"Last":1010.76549,"BaseVolume":0,"OpenOrders":0},{"MarketName":"STCDR_ETH","High":0,"Low":0,"Volume":0,"Last":0.00000789,"BaseVolume":0,"OpenOrders":0},{"MarketName":"STCDR_BINS","High":0,"Low":0,"Volume":0,"Last":8E-8,"BaseVolume":0,"OpenOrders":0},{"MarketName":"SHEL_ETH","High":0,"Low":0,"Volume":0,"Last":0.000005,"BaseVolume":0,"OpenOrders":0},{"MarketName":"SHEL_BINS","High":0,"Low":0,"Volume":0,"Last":0.005,"BaseVolume":0,"OpenOrders":0},{"MarketName":"EXBT_BINS","High":0,"Low":0,"Volume":0,"Last":0,"BaseVolume":0,"OpenOrders":0},{"MarketName":"BAT_BINS","High":0,"Low":0,"Volume":0,"Last":0.08574388,"BaseVolume":0,"OpenOrders":0},{"MarketName":"OMG_BINS","High":0,"Low":0,"Volume":0,"Last":1.22056578,"BaseVolume":0,"OpenOrders":0},{"MarketName":"OMG_BIB","High":0,"Low":0,"Volume":0,"Last":0,"BaseVolume":0,"OpenOrders":0},{"MarketName":"ICX_BIB","High":0,"Low":0,"Volume":0,"Last":0,"BaseVolume":0,"OpenOrders":0},{"MarketName":"GVT_BINS","High":0,"Low":0,"Volume":0,"Last":5.49378328,"BaseVolume":0,"OpenOrders":0},{"MarketName":"GVT_BIB","High":0,"Low":0,"Volume":0,"Last":0,"BaseVolume":0,"OpenOrders":0},{"MarketName":"TUSD_BINS","High":0,"Low":0,"Volume":0,"Last":0.35456646,"BaseVolume":0,"OpenOrders":0},{"MarketName":"TUSD_BIB","High":0,"Low":0,"Volume":0,"Last":0,"BaseVolume":0,"OpenOrders":0},{"MarketName":"BIB_ETH","High":0,"Low":0,"Volume":0,"Last":0.001,"BaseVolume":0,"OpenOrders":0},{"MarketName":"BIB_NGN","High":0,"Low":0,"Volume":0,"Last":39,"BaseVolume":0,"OpenOrders":0}],"success":true,"message":""}'
+    http_version: 
+  recorded_at: Sun, 28 Oct 2018 04:07:38 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/bitbegin/integration/market_spec.rb
+++ b/spec/exchanges/bitbegin/integration/market_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+RSpec.describe 'Bitbegin integration specs' do
+  client = Cryptoexchange::Client.new
+  let(:btc_ngn_pair) { Cryptoexchange::Models::MarketPair.new(base: 'BTC', target: 'NGN', market: 'bitbegin') }
+
+  it 'fetch pairs' do
+    pairs = client.pairs('bitbegin')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.market).to eq 'bitbegin'
+  end
+
+  it 'give trade url' do
+    trade_page_url = client.trade_page_url 'bitbegin', base: btc_ngn_pair.base, target: btc_ngn_pair.target
+    expect(trade_page_url).to eq "https://bitbegin.io/trade?PairName=BTC-NGN"
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(btc_ngn_pair)
+    expect(ticker.base).to eq 'BTC'
+    expect(ticker.target).to eq 'NGN'
+    expect(ticker.market).to eq 'bitbegin'
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.high).to be_a Numeric
+    expect(ticker.low).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+    expect(ticker.timestamp).to be nil
+    expect(ticker.payload).to_not be nil
+  end
+end

--- a/spec/exchanges/bitbegin/market_spec.rb
+++ b/spec/exchanges/bitbegin/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Bitbegin::Market do
+  it { expect(described_class::NAME).to eq 'bitbegin' }
+  it { expect(described_class::API_URL).to eq 'https://bitbegin.io/api' }
+end


### PR DESCRIPTION
 - What is the purpose of this Pull Request? as title
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")? close #1051
- [x] I have added Specs
- [x] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [x] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [x] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [x] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

most of ticker's volume on exchange page and api return are different, asked and they say follow the volume from endpoint

ticker on `ETH_BTC`
```ruby
{
 "MarketName":"ETH_BTC",
 "High":0.03136368, 
 "Low":0.03118935, 
 "Volume":3339,
 "Last":0.03121959,
 "BaseVolume":104.37777882,
 "OpenOrders":336
}
```
took `Volume` as base volume
