### PR TITLE
✨ Implement Blokmy ticker, order book and trades

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Or install it yourself as:
 | Bkex              | Y       | N          | N       |         | Y           | Y        | bkex              |
 | Bleutrade         | Y       |            |         |         | Y           |          | bleutrade         |
 | Blockonix         | Y       | Y          | Y       |         | Y           |          | blockonix         |
+| Blokmy            | Y       | Y          | Y       |         | Y           | Y        | blokmy            |
 | Braziliex         | Y       | Y          | Y       |         | Y           |          | braziliex         |
 | BTC38             |         |            |         |         |             |          |                   |
 | BTC-e             |         |            |         |         |             |          |                   |

--- a/lib/cryptoexchange/exchanges/blokmy/market.rb
+++ b/lib/cryptoexchange/exchanges/blokmy/market.rb
@@ -1,0 +1,14 @@
+module Cryptoexchange::Exchanges
+  module Blokmy
+    class Market < Cryptoexchange::Models::Market
+      NAME    = 'blokmy'
+      API_URL = 'https://blokmy.com/api/v2'
+
+      def self.trade_page_url(args = {})
+        base   = args[:base].downcase
+        target = args[:target].downcase
+        "https://blokmy.com/markets/#{base}#{target}"
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/blokmy/services/market.rb
+++ b/lib/cryptoexchange/exchanges/blokmy/services/market.rb
@@ -1,0 +1,46 @@
+module Cryptoexchange::Exchanges
+  module Blokmy
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            false
+          end
+        end
+
+        def fetch
+          output = super(ticker_url)
+          adapt_all(output)
+        end
+
+        def ticker_url
+          "#{Cryptoexchange::Exchanges::Blokmy::Market::API_URL}/tickers.json"
+        end
+
+        def adapt_all(output)
+          output.map do |pair, ticker|
+            adapt(pair, ticker)
+          end
+        end
+
+        def adapt(pair, output)
+          base, target     = pair.split(/(BTC$)+|(MYR$)+/i)
+          info             = output['ticker']
+          ticker           = Cryptoexchange::Models::Ticker.new
+          ticker.base      = base
+          ticker.target    = target
+          ticker.market    = Blokmy::Market::NAME
+          ticker.last      = NumericHelper.to_d(info['last'])
+          ticker.high      = NumericHelper.to_d(info['high'])
+          ticker.low       = NumericHelper.to_d(info['low'])
+          ticker.bid       = NumericHelper.to_d(info['buy'])
+          ticker.ask       = NumericHelper.to_d(info['sell'])
+          ticker.volume    = NumericHelper.to_d(info['vol'])
+          ticker.timestamp = NumericHelper.to_d(output['at'])
+          ticker.payload   = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/blokmy/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/blokmy/services/order_book.rb
@@ -1,0 +1,45 @@
+module Cryptoexchange::Exchanges
+  module Blokmy
+    module Services
+      class OrderBook < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          base   = market_pair.base.downcase
+          target = market_pair.target.downcase
+          "#{Cryptoexchange::Exchanges::Blokmy::Market::API_URL}/depth.json?market=#{base}#{target}"
+        end
+
+        def adapt(output, market_pair)
+          order_book = Cryptoexchange::Models::OrderBook.new
+
+          order_book.base      = market_pair.base
+          order_book.target    = market_pair.target
+          order_book.market    = Blokmy::Market::NAME
+          order_book.asks      = adapt_orders(output['asks'])
+          order_book.bids      = adapt_orders(output['bids'])
+          order_book.timestamp = output['timestamp']
+          order_book.payload   = output
+          order_book
+        end
+
+        def adapt_orders(orders)
+          orders.collect do |order_entry|
+            price, amount = order_entry
+            Cryptoexchange::Models::Order.new(price:  price,
+                                              amount: amount)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/blokmy/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/blokmy/services/pairs.rb
@@ -1,0 +1,25 @@
+module Cryptoexchange::Exchanges
+  module Blokmy
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Blokmy::Market::API_URL}/tickers.json"
+
+        def fetch
+          output = super
+          adapt(output)
+        end
+
+        def adapt(output)
+          output.map do |pair, _ticker|
+            base, target = pair.split(/(BTC$)+|(MYR$)+/i)
+            Cryptoexchange::Models::MarketPair.new(
+            base: base,
+            target: target,
+            market: Blokmy::Market::NAME
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/blokmy/services/trades.rb
+++ b/lib/cryptoexchange/exchanges/blokmy/services/trades.rb
@@ -1,0 +1,34 @@
+module Cryptoexchange::Exchanges
+  module Blokmy
+    module Services
+      class Trades < Cryptoexchange::Services::Market
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          base   = market_pair.base.downcase
+          target = market_pair.target.downcase
+          "#{Cryptoexchange::Exchanges::Blokmy::Market::API_URL}/trades.json?market=#{base}#{target}"
+        end
+
+        def adapt(output, market_pair)
+          output.collect do |trade|
+            tr           = Cryptoexchange::Models::Trade.new
+            tr.trade_id  = trade['id']
+            tr.base      = market_pair.base
+            tr.target    = market_pair.target
+            tr.market    = Blokmy::Market::NAME
+            tr.type      = trade['side']
+            tr.price     = trade['price']
+            tr.amount    = trade['volume']
+            tr.timestamp = Time.parse(trade['created_at']).to_i
+            tr.payload   = trade
+            tr
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/Blokmy/integration_specs_fetch_order_book.yml
+++ b/spec/cassettes/vcr_cassettes/Blokmy/integration_specs_fetch_order_book.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://blokmy.com/api/v2/depth.json?market=btcmyr
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - blokmy.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 10 Nov 2018 07:46:59 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '79'
+      Connection:
+      - close
+      Vary:
+      - Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      Set-Cookie:
+      - _mkra_stck=postgresql%3A1541836024.5149205; path=/; max-age=10; expires=Sat,
+        10 Nov 2018 07:47:09 -0000; HttpOnly; secure
+      - _session_id=%2FyHDDrAea9YVB8OyNL1jiL%2FVuBIrLs%2FM4zHkSSc9aPhQAny32LrMGSbYdeLP2jI5kQ%3D%3D--4%2BIHg3Ie%2FXx77Ki7--4WryPUtoCfG4lQBRGLsVBQ%3D%3D;
+        path=/; secure; HttpOnly
+      - _session_id=rP%2FVIlw%2F3lXAmCdXomc4hEuKPA4qxGtzvtjoYFad5BEKVArHftE4SWvOb7Akb7a%2BZw%3D%3D--jLmBEEChCeI9Hq8p--XPyDqmQQlpWQkiX8ST3wiA%3D%3D;
+        path=/; secure; HttpOnly
+      - incap_ses_530_1813126=uKyyJSzidlVuQn+dJfFaB/OM5lsAAAAAQ1hfuRMMC9+qIrNiaGxcrQ==;
+        path=/; Domain=.blokmy.com
+      - visid_incap_1813126=x2mkGiHARY22Xedl56XsrPOM5lsAAAAAQUIPAAAAAAA5K5FGJ1ilR7R78KT0C4oK;
+        expires=Sat, 09 Nov 2019 12:39:01 GMT; path=/; Domain=.blokmy.com
+      Etag:
+      - W/"fc95ada1a7a26e42ec63542f76641eda"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - f91b6ad0-e9a5-401a-82ed-047291304fbe
+      X-Runtime:
+      - '0.008375'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Iinfo:
+      - 5-16273169-16273351 NNNN CT(0 0 0) RT(1541836018308 513) q(0 0 0 -1) r(2 2)
+        U2
+      X-Cdn:
+      - Incapsula
+    body:
+      encoding: ASCII-8BIT
+      string: '{"timestamp":1541836019,"asks":[["27200.0","0.03"]],"bids":[["25000.0","0.3"]]}'
+    http_version: 
+  recorded_at: Sat, 10 Nov 2018 07:46:59 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Blokmy/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/Blokmy/integration_specs_fetch_pairs.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://blokmy.com/api/v2/tickers.json
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - blokmy.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 10 Nov 2018 07:46:55 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '853'
+      Connection:
+      - close
+      Vary:
+      - Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      Set-Cookie:
+      - _mkra_stck=postgresql%3A1541836020.9428267; path=/; max-age=10; expires=Sat,
+        10 Nov 2018 07:47:05 -0000; HttpOnly; secure
+      - _session_id=kvCgBAXClCN%2BJ%2BPXaXZ%2Fo3TxjqoXCcPQRc1248P0q%2Fyvgfk3nrgvLtY5je%2B3qt18HQ%3D%3D--xQe4IQ3tXuAGVZ95--rPuVncOUBFGFn1qL%2FuX4JA%3D%3D;
+        path=/; secure; HttpOnly
+      - _session_id=yuT%2B%2FzOvgkySYALiAIqpZXytDCKrl%2Fx728%2BZU4Y2HN7pjBO2Z%2BGyQM6KzUzoLhgkWw%3D%3D--TIeWaq9auR9FgKvo--0o7YSRD9OHoRQYEU8F5UWQ%3D%3D;
+        path=/; secure; HttpOnly
+      - incap_ses_530_1813126=IOF0cBd9GzMGZX6dJfFaB++M5lsAAAAA1i6j/KTLq1lkkEgCI0v/uQ==;
+        path=/; Domain=.blokmy.com
+      - visid_incap_1813126=97tCDJ/4S7aTA3n1jAws+6SM5lsAAAAAQUIPAAAAAABn6ig9pR1D0IHZyrqvLIG4;
+        expires=Sat, 09 Nov 2019 12:39:01 GMT; path=/; Domain=.blokmy.com
+      Etag:
+      - W/"f07fb6ea529c4d60ab0200ae4c7203bc"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 76d91074-6d1a-4866-92fb-3738f36226ac
+      X-Runtime:
+      - '0.035326'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Iinfo:
+      - 5-16271677-16271911 NNNN CT(249 253 0) RT(1541836014101 616) q(0 0 5 2) r(8
+        8) U2
+      X-Cdn:
+      - Incapsula
+    body:
+      encoding: ASCII-8BIT
+      string: '{"btcmyr":{"at":1541836015,"ticker":{"buy":"25000.0","sell":"27200.0","low":"26288.95","high":"26300.0","last":"26288.95","vol":"2.04837"}},"ethmyr":{"at":1541836015,"ticker":{"buy":"20.0","sell":"3000.0","low":"0.0","high":"0.0","last":"950.95","vol":"0.0"}},"ltcmyr":{"at":1541836015,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0","high":"0.0","last":"203.85","vol":"0.0"}},"xrpmyr":{"at":1541836015,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0","high":"0.0","last":"2.5","vol":"0.0"}},"ethbtc":{"at":1541836015,"ticker":{"buy":"0.0","sell":"0.0","low":"0.034049","high":"0.034049","last":"0.034151","vol":"0.0"}},"ltcbtc":{"at":1541836015,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0","high":"0.0","last":"0.008461","vol":"0.0"}},"xrpbtc":{"at":1541836015,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0","high":"0.0","last":"0.000073","vol":"0.0"}}}'
+    http_version: 
+  recorded_at: Sat, 10 Nov 2018 07:46:56 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Blokmy/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/Blokmy/integration_specs_fetch_ticker.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://blokmy.com/api/v2/tickers.json
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - blokmy.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 10 Nov 2018 07:46:58 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '853'
+      Connection:
+      - close
+      Vary:
+      - Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      Set-Cookie:
+      - _mkra_stck=postgresql%3A1541836023.0986018; path=/; max-age=10; expires=Sat,
+        10 Nov 2018 07:47:08 -0000; HttpOnly; secure
+      - _session_id=KuXMpMnPt1wo13bjmeIM3JIpPMAmF2MSS3Bb7hwSoniuObXOE8lNSHG%2Fn51vDZ%2BkGQ%3D%3D--SjiUQ5by0CsI7RAj--jsqNxTvewukk1Oq4X2nTYw%3D%3D;
+        path=/; secure; HttpOnly
+      - _session_id=P62S2Dn87jAhWGxxgonjN0HocGVROrFOlbYiK8euJYn2Gq%2BJ4FHVumorTnOx%2FIK8fA%3D%3D--zmi%2BgF4JkUSqU6va--Jy9SNgVjgOxDOO6FGBlydQ%3D%3D;
+        path=/; secure; HttpOnly
+      - incap_ses_530_1813126=BPXLLvJZdG2HPn+dJfFaB/GM5lsAAAAAj+zSL99rzxFslV/DeuibJA==;
+        path=/; Domain=.blokmy.com
+      - visid_incap_1813126=iFBFAWfRSc+Phk3eXhb5MfGM5lsAAAAAQUIPAAAAAACshFDRsfHTMtDaGQOpJkXS;
+        expires=Sat, 09 Nov 2019 12:39:01 GMT; path=/; Domain=.blokmy.com
+      Etag:
+      - W/"9cbaa3d856818586b0e06c74f02db45e"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 56eba39c-9aab-4d2d-9f12-4b734e7b799a
+      X-Runtime:
+      - '0.024910'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Iinfo:
+      - 5-16272353-16272867 NNNN CT(0 0 0) RT(1541836016102 1287) q(0 0 0 -1) r(3
+        3) U2
+      X-Cdn:
+      - Incapsula
+    body:
+      encoding: ASCII-8BIT
+      string: '{"btcmyr":{"at":1541836018,"ticker":{"buy":"25000.0","sell":"27200.0","low":"26288.95","high":"26300.0","last":"26288.95","vol":"2.04837"}},"ethmyr":{"at":1541836018,"ticker":{"buy":"20.0","sell":"3000.0","low":"0.0","high":"0.0","last":"950.95","vol":"0.0"}},"ltcmyr":{"at":1541836018,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0","high":"0.0","last":"203.85","vol":"0.0"}},"xrpmyr":{"at":1541836018,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0","high":"0.0","last":"2.5","vol":"0.0"}},"ethbtc":{"at":1541836018,"ticker":{"buy":"0.0","sell":"0.0","low":"0.034049","high":"0.034049","last":"0.034151","vol":"0.0"}},"ltcbtc":{"at":1541836018,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0","high":"0.0","last":"0.008461","vol":"0.0"}},"xrpbtc":{"at":1541836018,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0","high":"0.0","last":"0.000073","vol":"0.0"}}}'
+    http_version: 
+  recorded_at: Sat, 10 Nov 2018 07:46:58 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Blokmy/integration_specs_fetch_trade.yml
+++ b/spec/cassettes/vcr_cassettes/Blokmy/integration_specs_fetch_trade.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://blokmy.com/api/v2/trades.json?market=btcmyr
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - blokmy.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Sat, 10 Nov 2018 07:47:00 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '7125'
+      Connection:
+      - close
+      Vary:
+      - Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      Set-Cookie:
+      - _mkra_stck=postgresql%3A1541836025.9471498; path=/; max-age=10; expires=Sat,
+        10 Nov 2018 07:47:10 -0000; HttpOnly; secure
+      - _session_id=7Kku3Ebuji9daUvFw4YqVe4MQz8xejaPFieNhUeuryoiDT1UllrloariXNvZBWb5nQ%3D%3D--BVRvLP%2BtxS0CZIx3--lF4Z%2BT3NfJ4PO9yxEgVjLw%3D%3D;
+        path=/; secure; HttpOnly
+      - _session_id=reJ%2F0Evr%2F9pV6e50yfrntTbXUJJcsa7K75HrSfu6WtPbxJp3VLlHQQqBYXPHECG6Jw%3D%3D--ZbcX4IG2c3ONy7%2Bn--iXqv5sr8Zp0Pt6no1Zw6Xw%3D%3D;
+        path=/; secure; HttpOnly
+      - incap_ses_530_1813126=CliCHXnwahmARn+dJfFaB/SM5lsAAAAAa3a5z3aqWehbfkuMUcjqVQ==;
+        path=/; Domain=.blokmy.com
+      - visid_incap_1813126=YV7pAKbdTEmq/diNfGeqjPSM5lsAAAAAQUIPAAAAAACLut8xfcmYF59B80UHLfhb;
+        expires=Sat, 09 Nov 2019 12:39:14 GMT; path=/; Domain=.blokmy.com
+      Etag:
+      - W/"44b05427d396413070e6f72411039cae"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 335e7f92-f816-4cf4-96a2-b91c72fdae3d
+      X-Runtime:
+      - '0.019152'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Iinfo:
+      - 10-20935975-20936313 NNNN CT(0 0 0) RT(1541836019641 617) q(0 0 0 -1) r(3
+        3) U2
+      X-Cdn:
+      - Incapsula
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"id":375329,"price":"26288.95","volume":"0.026525","funds":"697.31439875","market":"btcmyr","created_at":"2018-11-09T22:42:35+08:00","side":null},{"id":375328,"price":"26288.95","volume":"0.013175","funds":"346.35691625","market":"btcmyr","created_at":"2018-11-09T22:42:35+08:00","side":null},{"id":375327,"price":"26288.95","volume":"0.026525","funds":"697.31439875","market":"btcmyr","created_at":"2018-11-09T22:42:35+08:00","side":null},{"id":375326,"price":"26290.49","volume":"0.673474","funds":"17705.96146226","market":"btcmyr","created_at":"2018-11-09T22:42:35+08:00","side":null},{"id":375325,"price":"26290.49","volume":"0.191371","funds":"5031.23736179","market":"btcmyr","created_at":"2018-11-09T22:42:35+08:00","side":null},{"id":375324,"price":"26290.49","volume":"0.288826","funds":"7593.37706474","market":"btcmyr","created_at":"2018-11-09T22:42:35+08:00","side":null},{"id":375323,"price":"26290.49","volume":"0.671474","funds":"17653.38048226","market":"btcmyr","created_at":"2018-11-09T22:42:35+08:00","side":null},{"id":375322,"price":"26290.49","volume":"0.002","funds":"52.58098","market":"btcmyr","created_at":"2018-11-09T22:42:35+08:00","side":null},{"id":375321,"price":"26300.0","volume":"0.055","funds":"1446.5","market":"btcmyr","created_at":"2018-11-09T22:42:14+08:00","side":null},{"id":375320,"price":"26500.0","volume":"0.1","funds":"2650.0","market":"btcmyr","created_at":"2018-11-09T17:36:26+08:00","side":null},{"id":375319,"price":"26890.0","volume":"0.0215","funds":"578.135","market":"btcmyr","created_at":"2018-11-08T22:35:03+08:00","side":null},{"id":375317,"price":"27262.79","volume":"0.1","funds":"2726.279","market":"btcmyr","created_at":"2018-11-07T10:23:55+08:00","side":null},{"id":375316,"price":"14000.0","volume":"0.000142","funds":"1.988","market":"btcmyr","created_at":"2018-11-07T09:51:18+08:00","side":null},{"id":375315,"price":"14000.0","volume":"0.38179","funds":"5345.06","market":"btcmyr","created_at":"2018-11-07T09:34:04+08:00","side":null},{"id":375314,"price":"14000.0","volume":"0.114755","funds":"1606.57","market":"btcmyr","created_at":"2018-11-07T09:34:04+08:00","side":null},{"id":375313,"price":"14000.0","volume":"0.003455","funds":"48.37","market":"btcmyr","created_at":"2018-11-07T09:34:04+08:00","side":null},{"id":375312,"price":"27153.34","volume":"1.0","funds":"27153.34","market":"btcmyr","created_at":"2018-11-07T08:28:14+08:00","side":null},{"id":375311,"price":"27153.34","volume":"0.000073","funds":"1.98219382","market":"btcmyr","created_at":"2018-11-07T08:28:14+08:00","side":null},{"id":375310,"price":"27001.0","volume":"0.197728","funds":"5338.853728","market":"btcmyr","created_at":"2018-11-07T08:26:05+08:00","side":null},{"id":375309,"price":"27001.0","volume":"0.002012","funds":"54.326012","market":"btcmyr","created_at":"2018-11-07T08:26:05+08:00","side":null},{"id":375308,"price":"27001.0","volume":"0.061","funds":"1647.061","market":"btcmyr","created_at":"2018-11-07T08:26:05+08:00","side":null},{"id":375307,"price":"27001.0","volume":"0.1","funds":"2700.1","market":"btcmyr","created_at":"2018-11-07T08:25:04+08:00","side":null},{"id":375306,"price":"27001.0","volume":"0.02","funds":"540.02","market":"btcmyr","created_at":"2018-11-07T08:25:04+08:00","side":null},{"id":375305,"price":"27001.0","volume":"0.044862","funds":"1211.318862","market":"btcmyr","created_at":"2018-11-07T08:25:04+08:00","side":null},{"id":375304,"price":"27001.0","volume":"0.038277","funds":"1033.517277","market":"btcmyr","created_at":"2018-11-07T08:25:04+08:00","side":null},{"id":375303,"price":"27001.0","volume":"0.062","funds":"1674.062","market":"btcmyr","created_at":"2018-11-07T08:25:04+08:00","side":null},{"id":375302,"price":"27001.0","volume":"0.061","funds":"1647.061","market":"btcmyr","created_at":"2018-11-07T08:25:04+08:00","side":null},{"id":375301,"price":"27001.0","volume":"0.413121","funds":"11154.680121","market":"btcmyr","created_at":"2018-11-07T08:25:03+08:00","side":null},{"id":375300,"price":"27000.02","volume":"0.525879","funds":"14198.74351758","market":"btcmyr","created_at":"2018-11-07T08:25:03+08:00","side":null},{"id":375299,"price":"27000.02","volume":"0.272095","funds":"7346.5704419","market":"btcmyr","created_at":"2018-11-07T08:25:03+08:00","side":null},{"id":375298,"price":"27000.02","volume":"0.202026","funds":"5454.70604052","market":"btcmyr","created_at":"2018-11-07T08:25:03+08:00","side":null},{"id":375297,"price":"27000.0","volume":"1.0","funds":"27000.0","market":"btcmyr","created_at":"2018-11-07T08:25:03+08:00","side":null},{"id":375296,"price":"27000.0","volume":"0.297974","funds":"8045.298","market":"btcmyr","created_at":"2018-11-07T08:25:03+08:00","side":null},{"id":375295,"price":"27000.0","volume":"0.702026","funds":"18954.702","market":"btcmyr","created_at":"2018-11-07T08:25:03+08:00","side":null},{"id":375294,"price":"27000.0","volume":"0.297974","funds":"8045.298","market":"btcmyr","created_at":"2018-11-07T08:25:03+08:00","side":null},{"id":375293,"price":"26900.0","volume":"0.883859","funds":"23775.8071","market":"btcmyr","created_at":"2018-11-07T08:16:58+08:00","side":null},{"id":375292,"price":"26690.1","volume":"0.049363","funds":"1317.5034063","market":"btcmyr","created_at":"2018-11-06T16:33:33+08:00","side":null},{"id":375291,"price":"26692.68","volume":"0.038931","funds":"1039.17272508","market":"btcmyr","created_at":"2018-11-06T16:33:33+08:00","side":null},{"id":375290,"price":"26706.0","volume":"0.001115","funds":"29.77719","market":"btcmyr","created_at":"2018-11-06T16:33:33+08:00","side":null},{"id":375289,"price":"26706.0","volume":"0.000385","funds":"10.28181","market":"btcmyr","created_at":"2018-11-06T16:33:33+08:00","side":null},{"id":375288,"price":"26706.0","volume":"0.010206","funds":"272.561436","market":"btcmyr","created_at":"2018-11-06T16:33:32+08:00","side":null},{"id":375285,"price":"26692.54","volume":"0.000475","funds":"12.6789565","market":"btcmyr","created_at":"2018-11-06T13:14:52+08:00","side":null},{"id":375284,"price":"26689.03","volume":"0.003253","funds":"86.81941459","market":"btcmyr","created_at":"2018-11-06T13:14:52+08:00","side":null},{"id":375279,"price":"26800.0","volume":"0.1","funds":"2680.0","market":"btcmyr","created_at":"2018-11-06T13:12:38+08:00","side":null},{"id":375278,"price":"26615.17","volume":"0.1","funds":"2661.517","market":"btcmyr","created_at":"2018-11-06T13:11:46+08:00","side":null},{"id":375277,"price":"26900.0","volume":"0.000036","funds":"0.9684","market":"btcmyr","created_at":"2018-11-06T09:10:45+08:00","side":null},{"id":375276,"price":"26900.0","volume":"0.004105","funds":"110.4245","market":"btcmyr","created_at":"2018-11-05T11:03:10+08:00","side":null},{"id":375275,"price":"26900.0","volume":"0.112","funds":"3012.8","market":"btcmyr","created_at":"2018-11-05T11:02:11+08:00","side":null},{"id":375274,"price":"26672.44","volume":"0.375905","funds":"10026.3035582","market":"btcmyr","created_at":"2018-11-05T00:03:54+08:00","side":null},{"id":375273,"price":"26400.0","volume":"0.010816","funds":"285.5424","market":"btcmyr","created_at":"2018-11-04T23:35:45+08:00","side":null}]'
+    http_version: 
+  recorded_at: Sat, 10 Nov 2018 07:47:01 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/blokmy/integration/market_spec.rb
+++ b/spec/exchanges/blokmy/integration/market_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+RSpec.describe 'Blokmy integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:btc_myr_pair) { Cryptoexchange::Models::MarketPair.new(base: 'BTC', target: 'MYR', market: 'blokmy') }
+
+  it 'fetch pairs' do
+    pairs = client.pairs('blokmy')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.market).to eq 'blokmy'
+  end
+
+  it 'give trade url' do
+    trade_page_url = client.trade_page_url 'blokmy', base: btc_myr_pair.base, target: btc_myr_pair.target
+    expect(trade_page_url).to eq "https://blokmy.com/markets/btcmyr"
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(btc_myr_pair)
+
+    expect(ticker.base).to eq 'BTC'
+    expect(ticker.target).to eq 'MYR'
+    expect(ticker.market).to eq 'blokmy'
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.low).to be_a Numeric
+    expect(ticker.high).to be_a Numeric
+    expect(ticker.bid).to be_a Numeric
+    expect(ticker.ask).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+    expect(ticker.timestamp).to be_a Numeric
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
+    expect(ticker.payload).to_not be nil
+  end
+
+  it 'fetch order book' do
+    order_book = client.order_book(btc_myr_pair)
+
+    expect(order_book.base).to eq 'BTC'
+    expect(order_book.target).to eq 'MYR'
+    expect(order_book.market).to eq 'blokmy'
+    expect(order_book.asks).to_not be_empty
+    expect(order_book.bids).to_not be_empty
+    expect(order_book.asks.first.price).to_not be_nil
+    expect(order_book.bids.first.amount).to_not be_nil
+    expect(order_book.bids.first.timestamp).to be_nil
+    expect(order_book.asks.count).to be > 0
+    expect(order_book.bids.count).to be > 0
+    expect(order_book.timestamp).to be_a Numeric
+    expect(order_book.payload).to_not be nil
+  end
+
+  it 'fetch trade' do
+    trades = client.trades(btc_myr_pair)
+    trade  = trades.sample
+
+    expect(trades).to_not be_empty
+    expect(trade.base).to eq 'BTC'
+    expect(trade.target).to eq 'MYR'
+    expect(trade.market).to eq 'blokmy'
+    expect(trade.trade_id).to_not be_nil
+    expect(trade.type).to be_nil
+    expect(trade.price).to_not be_nil
+    expect(trade.amount).to_not be_nil
+    expect(trade.timestamp).to be_a Numeric
+    expect(trade.payload).to_not be nil
+  end
+end

--- a/spec/exchanges/blokmy/market_spec.rb
+++ b/spec/exchanges/blokmy/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Blokmy::Market do
+  it { expect(described_class::NAME).to eq 'blokmy' }
+  it { expect(described_class::API_URL).to eq 'https://blokmy.com/api/v2' }
+end


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")? resolve #1140 
- [x] I have added Specs
- [x] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [x] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [x] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [x] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```

ticker about `BTC_MYR`
```ruby
{
 "btcmyr": {
  "at": 1541834832,
  "ticker": {
   "buy": "25000.0",
   "sell": "27200.0",
   "low": "26288.95",
   "high": "26300.0",
   "last": "26288.95",
   "vol": "2.04837"
  }
 }
}
```
took `vol` as base volume