### PR TITLE
✨ Implement Secondbtc ticker

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ Or install it yourself as:
 | Rfinex            | Y       | Y          | Y       |         | Y           |          | rfinex            |
 | RightBTC          | Y       | Y          | Y       |         | Y           |          | rightbtc          |
 | SafeTrade         | Y       | N          | N       |         | Y           |          | safe_trade        |
+| Secondbtc         | Y       | N          | N       |         | Y           | Y        | secondbtc         |
 | Sigen             | Y       |            |         |         | Y           | Y        | sigen             |
 | Simex             | Y       | N          | N       |         | Y           | Y        | simex             |
 | Singularx         | Y       | N          | N       |         | Y           |          | singularx         |

--- a/lib/cryptoexchange/exchanges/secondbtc/market.rb
+++ b/lib/cryptoexchange/exchanges/secondbtc/market.rb
@@ -1,0 +1,12 @@
+module Cryptoexchange::Exchanges
+  module Secondbtc
+    class Market < Cryptoexchange::Models::Market
+      NAME = 'secondbtc'
+      API_URL = 'https://secondbtc.com/api'
+
+      def self.trade_page_url(args={})
+        "https://secondbtc.com/exchange/#{args[:target]}-#{args[:base]}"
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/secondbtc/services/market.rb
+++ b/lib/cryptoexchange/exchanges/secondbtc/services/market.rb
@@ -1,0 +1,46 @@
+module Cryptoexchange::Exchanges
+  module Secondbtc
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            false
+          end
+        end
+
+        def fetch
+          output = super ticker_url
+          adapt_all(output)
+        end
+
+        def ticker_url
+          "#{Cryptoexchange::Exchanges::Secondbtc::Market::API_URL}/ticker"
+        end
+
+        def adapt_all(output)
+          output.map do |pair, ticker|
+            next unless ticker['isFrozen'] == '0'
+            adapt(pair, ticker)
+          end.compact
+        end
+
+        def adapt(pair, output)
+          ticker         = Cryptoexchange::Models::Ticker.new
+          target, base   = pair.split('_')
+          ticker.base    = base
+          ticker.target  = target
+          ticker.market  = Secondbtc::Market::NAME
+          ticker.last    = NumericHelper.to_d(output['last'])
+          ticker.ask     = NumericHelper.to_d(output['lowestAsk'])
+          ticker.bid     = NumericHelper.to_d(output['highestBid'])
+          ticker.volume  = NumericHelper.to_d(output['quoteVolume'])
+          ticker.high    = NumericHelper.to_d(output['high24hr'])
+          ticker.low     = NumericHelper.to_d(output['low24hr'])
+          ticker.change  = NumericHelper.to_d(output['percentChange'])
+          ticker.payload = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/secondbtc/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/secondbtc/services/pairs.rb
@@ -1,0 +1,26 @@
+module Cryptoexchange::Exchanges
+  module Secondbtc
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Secondbtc::Market::API_URL}/ticker"
+
+        def fetch
+          output = super
+          adapt(output)
+        end
+
+        def adapt(output)
+          output.map do |pair, ticker|
+            next unless ticker['isFrozen'] == '0'
+            target, base = pair.split('_')
+            Cryptoexchange::Models::MarketPair.new(
+              base:   base,
+              target: target,
+              market: Secondbtc::Market::NAME,
+              )
+          end.compact
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/Secondbtc/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/Secondbtc/integration_specs_fetch_pairs.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://secondbtc.com/api/ticker
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - secondbtc.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 11 Nov 2018 04:21:10 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '3331'
+      Connection:
+      - close
+      Set-Cookie:
+      - PHPSESSID=e671q35jd1vlmhl06oaspavgr0; path=/
+      - __cfduid=d00ae92aa798ea0cab40a97b942f233c11541910068; expires=Mon, 11-Nov-19
+        04:21:08 GMT; path=/; domain=.secondbtc.com; HttpOnly
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      Accept-Ranges:
+      - bytes
+      X-Turbo-Charged-By:
+      - LiteSpeed
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 477df86ae8e6a548-NRT
+    body:
+      encoding: UTF-8
+      string: '{"BTC_ETH":{"id":200,"last":"0.03305047","lowestAsk":"0.03425000","highestBid":"0.03303536","percentChange":0.48185,"baseVolume":"100.68435947","quoteVolume":"3038.66037300","isFrozen":"0","high24hr":"0.03333332","low24hr":"0.03289042"},"BTC_XRP":{"id":205,"last":"0.00007904","lowestAsk":"0.00012900","highestBid":"0.00007885","percentChange":0.03797,"baseVolume":"8.23240683","quoteVolume":"103798.87000000","isFrozen":"0","high24hr":"0.00008019","low24hr":"0.00007826"},"BTC_LTC":{"id":206,"last":"0.00811544","lowestAsk":"0.01180000","highestBid":"0.00810154","percentChange":-0.138556,"baseVolume":"70.13449640","quoteVolume":"8605.93742700","isFrozen":"0","high24hr":"0.00819788","low24hr":"0.00808000"},"BTC_WTC":{"id":210,"last":"0.00047080","lowestAsk":"0.00064836","highestBid":"0.00047109","percentChange":1.260378,"baseVolume":"1.13969251","quoteVolume":"2420.08190000","isFrozen":"0","high24hr":"0.00047920","low24hr":"0.00046098"},"BTC_GNT":{"id":211,"last":"0.00002608","lowestAsk":"0.00003262","highestBid":"0.00002575","percentChange":1.755755,"baseVolume":"0.27665971","quoteVolume":"10763.27900000","isFrozen":"0","high24hr":"0.00002637","low24hr":"0.00002546"},"ETH_LTC":{"id":206,"last":"0.24549601","lowestAsk":"0.45000000","highestBid":"0.24509729","percentChange":-0.722369,"baseVolume":"12.81302700","quoteVolume":"52.02342333","isFrozen":"0","high24hr":"0.24807193","low24hr":"0.24517371"},"ETH_WTC":{"id":210,"last":"0.01421865","lowestAsk":"0.01921933","highestBid":"0.01424860","percentChange":1.236023,"baseVolume":"25.86419477","quoteVolume":"1819.79910000","isFrozen":"0","high24hr":"0.01458801","low24hr":"0.01399356"},"ETH_GNT":{"id":211,"last":"0.00078206","lowestAsk":"0.00090825","highestBid":"0.00077974","percentChange":0.900552,"baseVolume":"1.73341141","quoteVolume":"2208.40300000","isFrozen":"0","high24hr":"0.00079611","low24hr":"0.00077054"},"ETH_BBC":{"id":215,"last":"0.00247496","lowestAsk":"0.00020000","highestBid":"0.00000000","percentChange":-100,"baseVolume":"0.00000000","quoteVolume":"0.00000000","isFrozen":"0","high24hr":"0.00000000","low24hr":"0.00000000"},"USDT_BTC":{"id":199,"last":"6429.01000000","lowestAsk":"6550.00000000","highestBid":"6465.46980000","percentChange":-0.134311,"baseVolume":"117326.37770371","quoteVolume":"18.20014092","isFrozen":"0","high24hr":"6468.75640000","low24hr":"6423.50000000"},"USDT_ETH":{"id":200,"last":"212.36010000","lowestAsk":"219.34900000","highestBid":"212.33850000","percentChange":0.30366,"baseVolume":"12773.11059056","quoteVolume":"59.77707870","isFrozen":"0","high24hr":"215.42900000","low24hr":"211.81230000"},"USDT_XRP":{"id":205,"last":"0.50760000","lowestAsk":"0.56624864","highestBid":"0.50740000","percentChange":-0.235849,"baseVolume":"3655.50674825","quoteVolume":"7153.67995000","isFrozen":"0","high24hr":"0.51730000","low24hr":"0.50360000"},"USDT_LTC":{"id":206,"last":"52.19340000","lowestAsk":"56.77960000","highestBid":"52.09490000","percentChange":-0.320276,"baseVolume":"15627.74706782","quoteVolume":"297.37652848","isFrozen":"0","high24hr":"52.95700000","low24hr":"51.92650000"},"USDT_BBC":{"id":215,"last":"0.59990000","lowestAsk":"0.02000000","highestBid":"0.00000000","percentChange":-100,"baseVolume":"0.00000000","quoteVolume":"0.00000000","isFrozen":"0","high24hr":"0.00000000","low24hr":"0.00000000"}}'
+    http_version: 
+  recorded_at: Sun, 11 Nov 2018 04:21:10 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Secondbtc/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/Secondbtc/integration_specs_fetch_ticker.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://secondbtc.com/api/ticker
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - secondbtc.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 11 Nov 2018 04:21:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '3332'
+      Connection:
+      - close
+      Set-Cookie:
+      - PHPSESSID=949s8f1qj6dndlh8ncrbq4mac7; path=/
+      - __cfduid=d0519e1af93953f3d6257b5beb0a0e0de1541910070; expires=Mon, 11-Nov-19
+        04:21:10 GMT; path=/; domain=.secondbtc.com; HttpOnly
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      Accept-Ranges:
+      - bytes
+      X-Turbo-Charged-By:
+      - LiteSpeed
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 477df8753fd39553-NRT
+    body:
+      encoding: UTF-8
+      string: '{"BTC_ETH":{"id":200,"last":"0.03305047","lowestAsk":"0.03425000","highestBid":"0.03303536","percentChange":0.48185,"baseVolume":"100.68435947","quoteVolume":"3038.66037300","isFrozen":"0","high24hr":"0.03333332","low24hr":"0.03289042"},"BTC_XRP":{"id":205,"last":"0.00007904","lowestAsk":"0.00012900","highestBid":"0.00007885","percentChange":0.03797,"baseVolume":"8.23240683","quoteVolume":"103798.87000000","isFrozen":"0","high24hr":"0.00008019","low24hr":"0.00007826"},"BTC_LTC":{"id":206,"last":"0.00811544","lowestAsk":"0.01180000","highestBid":"0.00810154","percentChange":-0.213825,"baseVolume":"70.10088397","quoteVolume":"8601.80137700","isFrozen":"0","high24hr":"0.00819788","low24hr":"0.00808000"},"BTC_WTC":{"id":210,"last":"0.00047080","lowestAsk":"0.00064836","highestBid":"0.00047109","percentChange":1.260378,"baseVolume":"1.13969251","quoteVolume":"2420.08190000","isFrozen":"0","high24hr":"0.00047920","low24hr":"0.00046098"},"BTC_GNT":{"id":211,"last":"0.00002608","lowestAsk":"0.00003262","highestBid":"0.00002575","percentChange":1.755755,"baseVolume":"0.27665971","quoteVolume":"10763.27900000","isFrozen":"0","high24hr":"0.00002637","low24hr":"0.00002546"},"ETH_LTC":{"id":206,"last":"0.24549601","lowestAsk":"0.45000000","highestBid":"0.24509729","percentChange":-0.722369,"baseVolume":"12.81302700","quoteVolume":"52.02342333","isFrozen":"0","high24hr":"0.24807193","low24hr":"0.24517371"},"ETH_WTC":{"id":210,"last":"0.01421865","lowestAsk":"0.01921933","highestBid":"0.01424860","percentChange":1.236023,"baseVolume":"25.86419477","quoteVolume":"1819.79910000","isFrozen":"0","high24hr":"0.01458801","low24hr":"0.01399356"},"ETH_GNT":{"id":211,"last":"0.00078206","lowestAsk":"0.00090825","highestBid":"0.00077974","percentChange":0.900552,"baseVolume":"1.73341141","quoteVolume":"2208.40300000","isFrozen":"0","high24hr":"0.00079611","low24hr":"0.00077054"},"ETH_BBC":{"id":215,"last":"0.00247496","lowestAsk":"0.00020000","highestBid":"0.00000000","percentChange":-100,"baseVolume":"0.00000000","quoteVolume":"0.00000000","isFrozen":"0","high24hr":"0.00000000","low24hr":"0.00000000"},"USDT_BTC":{"id":199,"last":"6429.22910000","lowestAsk":"6550.00000000","highestBid":"6465.46980000","percentChange":-0.174624,"baseVolume":"117326.38073442","quoteVolume":"18.20014175","isFrozen":"0","high24hr":"6468.75640000","low24hr":"6423.50000000"},"USDT_ETH":{"id":200,"last":"212.36010000","lowestAsk":"219.34900000","highestBid":"212.33850000","percentChange":0.211219,"baseVolume":"12773.08095016","quoteVolume":"59.77693870","isFrozen":"0","high24hr":"215.42900000","low24hr":"211.81230000"},"USDT_XRP":{"id":205,"last":"0.50760000","lowestAsk":"0.56624864","highestBid":"0.50740000","percentChange":-0.235849,"baseVolume":"3655.50674825","quoteVolume":"7153.67995000","isFrozen":"0","high24hr":"0.51730000","low24hr":"0.50360000"},"USDT_LTC":{"id":206,"last":"52.19340000","lowestAsk":"56.77960000","highestBid":"52.09490000","percentChange":-0.320276,"baseVolume":"15627.74706782","quoteVolume":"297.37652848","isFrozen":"0","high24hr":"52.95700000","low24hr":"51.92650000"},"USDT_BBC":{"id":215,"last":"0.59990000","lowestAsk":"0.02000000","highestBid":"0.00000000","percentChange":-100,"baseVolume":"0.00000000","quoteVolume":"0.00000000","isFrozen":"0","high24hr":"0.00000000","low24hr":"0.00000000"}}'
+    http_version: 
+  recorded_at: Sun, 11 Nov 2018 04:21:12 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/secondbtc/integration/market_spec.rb
+++ b/spec/exchanges/secondbtc/integration/market_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+RSpec.describe 'Secondbtc integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:eth_btc_pair) { Cryptoexchange::Models::MarketPair.new(base: 'ETH', target: 'BTC', market: 'secondbtc') }
+
+  it 'fetch pairs' do
+    pairs = client.pairs('secondbtc')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.market).to eq 'secondbtc'
+  end
+
+  it 'give trade url' do
+    trade_page_url = client.trade_page_url 'secondbtc', base: eth_btc_pair.base, target: eth_btc_pair.target
+    expect(trade_page_url).to eq "https://secondbtc.com/exchange/BTC-ETH"
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(eth_btc_pair)
+
+    expect(ticker.base).to eq 'ETH'
+    expect(ticker.target).to eq 'BTC'
+    expect(ticker.market).to eq 'secondbtc'
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.ask).to be_a Numeric
+    expect(ticker.bid).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+    expect(ticker.high).to be_a Numeric
+    expect(ticker.low).to be_a Numeric
+    expect(ticker.change).to be_a Numeric
+    expect(ticker.timestamp).to be_nil
+    expect(ticker.payload).to_not be nil
+  end
+end

--- a/spec/exchanges/secondbtc/market_spec.rb
+++ b/spec/exchanges/secondbtc/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Secondbtc::Market do
+  it { expect(described_class::NAME).to eq 'secondbtc' }
+  it { expect(described_class::API_URL).to eq 'https://secondbtc.com/api' }
+end


### PR DESCRIPTION
- What is the purpose of this Pull Request? as title
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")? close #1130
- [x] I have added Specs
- [x] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [x] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [x] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [x] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)


ticker on `ETH_BTC`
```ruby
{
 "BTC_ETH": {
  "id": 200,
  "last": "0.03306177",
  "lowestAsk": "0.03425000",
  "highestBid": "0.03305167",
  "percentChange": 0.507527,
  "baseVolume": "101.44423662",
  "quoteVolume": "3061.84682700",
  "isFrozen": "0",
  "high24hr": "0.03333332",
  "low24hr": "0.03286346"
 }
}
```
took `quoteVolume` as base volume