### PR TITLE
Huulk Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Or install it yourself as:
 | Hotbit            | Y       | N          | N       |         | Y           | Y        | hotbit            |
 | HPX               | Y       | Y          | Y       |         | Y           |          | hpx               |
 | Huobi             | Y       |            |         |         | Y           | Y        | huobi             |
+| Huulk             | Y       | Y          |         |         | Y           | Y        | huulk             |
 | Ice3x             | Y       | Y          | Y       |         | Y           |          | ice3x             |
 | Idax              | Y       | N          | N       |         | Y           | Y        | idax              |
 | Idcm              | Y       |            |         |         | Y           | Y        | idcm              |

--- a/lib/cryptoexchange/exchanges/huulk/huulk.yml
+++ b/lib/cryptoexchange/exchanges/huulk/huulk.yml
@@ -1,0 +1,5 @@
+:pairs:
+  - :base: CPC
+    :target: BTC
+  - :base: OGC
+    :target: BTC

--- a/lib/cryptoexchange/exchanges/huulk/market.rb
+++ b/lib/cryptoexchange/exchanges/huulk/market.rb
@@ -1,0 +1,12 @@
+module Cryptoexchange::Exchanges
+  module Huulk
+    class Market < Cryptoexchange::Models::Market
+      NAME = 'huulk'
+      API_URL = 'https://huulk.com/api/public/market'
+
+      def self.trade_page_url(args={})
+        "https://huulk.com/"
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/huulk/services/market.rb
+++ b/lib/cryptoexchange/exchanges/huulk/services/market.rb
@@ -1,0 +1,38 @@
+module Cryptoexchange::Exchanges
+  module Huulk
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          "#{Cryptoexchange::Exchanges::Huulk::Market::API_URL}/#{market_pair.base.downcase}-#{market_pair.target.downcase}/ticker/"
+        end
+
+        def adapt(output, market_pair)
+          ticker           = Cryptoexchange::Models::Ticker.new
+          ticker.base      = market_pair.base
+          ticker.target    = market_pair.target
+          ticker.market    = Huulk::Market::NAME
+          ticker.last      = NumericHelper.to_d(output['price']['last'])
+          ticker.high      = NumericHelper.to_d(output['price']['high'])
+          ticker.low       = NumericHelper.to_d(output['price']['low'])
+          ticker.bid       = NumericHelper.to_d(output['price']['best_bid'])
+          ticker.ask       = NumericHelper.to_d(output['price']['best_ask'])
+          ticker.volume    = NumericHelper.to_d(output['volume']['24h'])
+          ticker.timestamp = nil
+          ticker.payload   = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/huulk/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/huulk/services/order_book.rb
@@ -1,0 +1,42 @@
+module Cryptoexchange::Exchanges
+  module Huulk
+    module Services
+      class OrderBook < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          "#{Cryptoexchange::Exchanges::Huulk::Market::API_URL}/#{market_pair.base.downcase}-#{market_pair.target.downcase}/depth/"
+        end
+
+        def adapt(output, market_pair)
+          order_book = Cryptoexchange::Models::OrderBook.new
+
+          order_book.base      = market_pair.base
+          order_book.target    = market_pair.target
+          order_book.market    = Huulk::Market::NAME
+          order_book.asks      = adapt_orders(output['asks'])
+          order_book.bids      = adapt_orders(output['bids'])
+          order_book.timestamp = Time.now.to_i
+          order_book.payload   = output
+          order_book
+        end
+
+        def adapt_orders(orders)
+          orders.collect do |order_entry|
+            Cryptoexchange::Models::Order.new(price: order_entry[0],
+                                              amount: order_entry[1])
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/huulk/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/huulk/services/pairs.rb
@@ -1,0 +1,25 @@
+module Cryptoexchange::Exchanges
+  module Huulk
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+
+        def fetch
+          output = super
+          adapt(output)
+        end
+
+        def adapt(output)
+          market_pairs = []
+          output.each do |pair|
+            market_pairs << Cryptoexchange::Models::MarketPair.new(
+                              base: pair[:base],
+                              target: pair[:target],
+                              market: Huulk::Market::NAME
+                            )
+          end
+          market_pairs
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/Huulk/integration_specs_fetch_order_book.yml
+++ b/spec/cassettes/vcr_cassettes/Huulk/integration_specs_fetch_order_book.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://huulk.com/api/public/market/cpc-btc/depth/
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - huulk.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 11 Nov 2018 10:14:52 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1670'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d22514c9ca099fc273d030881cd96e55e1541931292; expires=Mon, 11-Nov-19
+        10:14:52 GMT; path=/; domain=.huulk.com; HttpOnly; Secure
+      Vary:
+      - Accept, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, s-maxage=1, max-age=1
+      Expires:
+      - Sun, 11 Nov 2018 10:14:53 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Access-Control-Allow-Origin:
+      - "*"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'self'; script-src 'self'; style-src 'self'; img-src 'none'; font-src
+        'none'; connect-src 'self'; media-src 'none'; child-src 'none'; worker-src
+        'none'; frame-ancestors 'self'; form-action 'self'; upgrade-insecure-requests;
+        block-all-mixed-content; referrer origin-when-cross-origin;
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - clear
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 477ffe90fc5f6a79-LHR
+    body:
+      encoding: ASCII-8BIT
+      string: '{"bids":[["0.0000015","217511.9"],["0.00000151","119711.9"],["0.00002765","20560.9"],["0.00002766","13260.9"],["0.000062","10494.9"],["0.00007018","10493.9"],["0.0000735","10483.9"],["0.00007581","9503.9"],["0.0000801","9489.9"],["0.00008099","8473.9"],["0.00008106","7473.9"],["0.00008508","7373.9"],["0.00008513","3970.9"],["0.00008514","3770.9"],["0.00008515","2257.7"],["0.00008516","2137.7"],["0.00008555","2135"],["0.00009","2070"],["0.00009001","2000"]],"asks":[["0.00010838","80"],["0.00010839","391.01650268"],["0.0001084","800.01650268"],["0.00010989","1797.01650268"],["0.00010995","1847.01650268"],["0.00011999","1914.01650268"],["0.00012971","2885.01650268"],["0.00012974","5859.01650268"],["0.0001379","7169.01650268"],["0.000138","9109.38627725"],["0.00015","9129.38627725"],["0.00015589","9229.38627725"],["0.000158","9329.38627725"],["0.00016666","10851.38627725"],["0.00016667","16851.38627725"],["0.0001751","17351.38627725"],["0.00017583","17410.38627725"],["0.00017951","17709.38627725"],["0.00018201","18209.38627725"],["0.000185","18218.61627725"],["0.00019","18313.61627725"],["0.00022631","19583.61627725"],["0.00022632","22215.61627725"],["0.00022638","27915.61627725"],["0.00033333","29415.61627725"],["0.00111109","40524.61627725"],["0.0011111","40632.61627725"],["0.0011165","40642.61627725"],["0.0017","40742.61627725"],["0.00199999","50741.61627725"],["0.002","57452.07089305"],["0.003","57467.07089305"],["0.04545455","57467.15889305"],["0.3","57567.15889305"],["0.5","57567.17889305"],["0.6","57569.17889305"],["1","57574.49889305"],["83.33333333","57574.51089305"]],"totals":[["1.45681908","217511.9"],["89.03597576","57574.51089305"]]}'
+    http_version: 
+  recorded_at: Sun, 11 Nov 2018 10:14:52 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Huulk/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/Huulk/integration_specs_fetch_ticker.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://huulk.com/api/public/market/cpc-btc/ticker/
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - huulk.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 11 Nov 2018 09:49:20 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '259'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d4cd364d0478f04758af531ab93b9e7a11541929760; expires=Mon, 11-Nov-19
+        09:49:20 GMT; path=/; domain=.huulk.com; HttpOnly; Secure
+      Vary:
+      - Accept, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, s-maxage=1, max-age=1
+      Expires:
+      - Sun, 11 Nov 2018 09:49:21 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Access-Control-Allow-Origin:
+      - "*"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Security-Policy:
+      - default-src 'self'; script-src 'self'; style-src 'self'; img-src 'none'; font-src
+        'none'; connect-src 'self'; media-src 'none'; child-src 'none'; worker-src
+        'none'; frame-ancestors 'self'; form-action 'self'; upgrade-insecure-requests;
+        block-all-mixed-content; referrer origin-when-cross-origin;
+      X-Frame-Options:
+      - SAMEORIGIN
+      Via:
+      - 1.1 google
+      Alt-Svc:
+      - clear
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 477fd92c7dfc6b61-LHR
+    body:
+      encoding: ASCII-8BIT
+      string: '{"price":{"last":"0.00008514","low":"0.00007983","high":"0.00010838","change":"0.00002855","best_bid":"0.00009001","best_ask":"0.00010838"},"volume":{"24h":"1466.11679","30d":"50206.07345326","3m":"79294.51171105","6m":"79294.51171105","1y":"79294.51171105"}}'
+    http_version: 
+  recorded_at: Sun, 11 Nov 2018 09:49:20 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/huulk/integration/market_spec.rb
+++ b/spec/exchanges/huulk/integration/market_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+RSpec.describe 'Huulk integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:cpc_btc_pair) { Cryptoexchange::Models::MarketPair.new(base: 'CPC', target: 'BTC', market: 'huulk') }
+
+  it 'fetch pairs' do
+    pairs = client.pairs('huulk')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.market).to eq 'huulk'
+  end
+
+  it 'give trade url' do
+    trade_page_url = client.trade_page_url 'huulk'
+    expect(trade_page_url).to eq "https://huulk.com/"
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(cpc_btc_pair)
+
+    expect(ticker.base).to eq 'CPC'
+    expect(ticker.target).to eq 'BTC'
+    expect(ticker.market).to eq 'huulk'
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.low).to be_a Numeric
+    expect(ticker.high).to be_a Numeric
+    expect(ticker.bid).to be_a Numeric
+    expect(ticker.ask).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+    expect(ticker.timestamp).to be_nil
+    expect(ticker.payload).to_not be nil
+  end
+
+  it 'fetch order book' do
+    order_book = client.order_book(cpc_btc_pair)
+
+    expect(order_book.base).to eq 'CPC'
+    expect(order_book.target).to eq 'BTC'
+    expect(order_book.market).to eq 'huulk'
+    expect(order_book.asks).to_not be_empty
+    expect(order_book.bids).to_not be_empty
+    expect(order_book.asks.first.price).to_not be_nil
+    expect(order_book.bids.first.amount).to_not be_nil
+    expect(order_book.bids.first.timestamp).to be_nil
+    expect(order_book.asks.count).to be > 10
+    expect(order_book.bids.count).to be > 10
+    expect(order_book.timestamp).to be_a Numeric
+    expect(order_book.payload).to_not be nil
+  end
+  #
+  # it 'fetch trade' do
+  #   trades = client.trades(cpc_btc_pair)
+  #   trade = trades.sample
+  #
+  #   expect(trades).to_not be_empty
+  #   expect(trade.base).to eq 'CPC'
+  #   expect(trade.target).to eq 'BTC'
+  #   expect(trade.market).to eq 'huulk'
+  #   expect(trade.trade_id).to_not be_nil
+  #   expect(['buy', 'sell']).to include trade.type
+  #   expect(trade.price).to_not be_nil
+  #   expect(trade.amount).to_not be_nil
+  #   expect(trade.timestamp).to be_a Numeric
+  #   expect(trade.payload).to_not be nil
+  # end
+end

--- a/spec/exchanges/huulk/market_spec.rb
+++ b/spec/exchanges/huulk/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Huulk::Market do
+  it { expect(described_class::NAME).to eq 'huulk' }
+  it { expect(described_class::API_URL).to eq 'https://huulk.com/api/public/market' }
+end


### PR DESCRIPTION
- Add Pairs, Tickers, OrderBook, Trade URL, and updated README for Huulk
- Closes: #1122 
- [X] I have added Specs
- [X] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [X] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [X] I have implemented the `trade_page_url` method that links to the root domain of the exchange website.
- [X] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below) - _(Volume from trades made in the last 24 hours on trading page need to be manually summed)_

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
