### PR TITLE
UKEX Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Or install it yourself as:
 | TrustDex **       | Y       |            |         |         | Y           |          | trust_dex         |
 | TuxExchange       | Y       |            |         |         | Y           |          | tux_exchange      |
 | UEX               | Y       |            |         |         | Y           |          | uex               |
+| UKEX              | Y       | Y          | Y       |         | Y           | Y        | ukex              |
 | Unocoin           |         |            |         |         |             |          | unocoin           |
 | Upbit             | Y       | Y          | Y       |         | Y           | Y        | upbit             |
 | Vaultmex          | Y       | Y          | Y       |         | Y           | Y        | vaultmex          |

--- a/lib/cryptoexchange/exchanges/ukex/market.rb
+++ b/lib/cryptoexchange/exchanges/ukex/market.rb
@@ -1,0 +1,12 @@
+module Cryptoexchange::Exchanges
+  module Ukex
+    class Market < Cryptoexchange::Models::Market
+      NAME = 'ukex'
+      API_URL = 'https://api.ukex.com/api/index'
+
+      def self.trade_page_url(args={})
+        "https://www.ukex.com/trade/index/market/#{args[:base].downcase}_#{args[:target].downcase}"
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/ukex/services/market.rb
+++ b/lib/cryptoexchange/exchanges/ukex/services/market.rb
@@ -1,0 +1,51 @@
+module Cryptoexchange::Exchanges
+  module Ukex
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            false
+          end
+        end
+
+        def fetch
+          output = super(ticker_url)
+          adapt_all(output)
+        end
+
+        def ticker_url
+          "#{Cryptoexchange::Exchanges::Ukex::Market::API_URL}/tickers"
+        end
+
+        def adapt_all(output)
+          output.map do |pair|
+            base, target = pair[0].split('_')
+            market_pair  = Cryptoexchange::Models::MarketPair.new(
+              base:   base.upcase,
+              target: target.upcase,
+              market: Ukex::Market::NAME
+            )
+            adapt(market_pair, pair[1])
+          end
+        end
+
+        def adapt(market_pair, output)
+          ticker           = Cryptoexchange::Models::Ticker.new
+          ticker.base      = market_pair.base
+          ticker.target    = market_pair.target
+          ticker.market    = Ukex::Market::NAME
+          ticker.last      = NumericHelper.to_d(output['last'])
+          ticker.high      = NumericHelper.to_d(output['high24hr'])
+          ticker.low       = NumericHelper.to_d(output['low24hr'])
+          ticker.bid       = NumericHelper.to_d(output['highestBid'])
+          ticker.ask       = NumericHelper.to_d(output['lowestAsk'])
+          ticker.volume    = NumericHelper.to_d(output['baseVolume'])
+          ticker.change    = NumericHelper.to_d(output['percentChange'])
+          ticker.timestamp = nil
+          ticker.payload   = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/ukex/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/ukex/services/order_book.rb
@@ -1,0 +1,42 @@
+module Cryptoexchange::Exchanges
+  module Ukex
+    module Services
+      class OrderBook < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          "#{Cryptoexchange::Exchanges::Ukex::Market::API_URL}/orderBook/#{market_pair.base.downcase}_#{market_pair.target.downcase}"
+        end
+
+        def adapt(output, market_pair)
+          order_book = Cryptoexchange::Models::OrderBook.new
+
+          order_book.base      = market_pair.base
+          order_book.target    = market_pair.target
+          order_book.market    = Ukex::Market::NAME
+          order_book.asks      = adapt_orders(output['asks'])
+          order_book.bids      = adapt_orders(output['bids'])
+          order_book.timestamp = nil
+          order_book.payload   = output
+          order_book
+        end
+
+        def adapt_orders(orders)
+          orders.collect do |order_entry|
+            Cryptoexchange::Models::Order.new(price: order_entry[0],
+                                              amount: order_entry[1])
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/ukex/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/ukex/services/pairs.rb
@@ -1,0 +1,23 @@
+module Cryptoexchange::Exchanges
+  module Ukex
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Ukex::Market::API_URL}/pairs"
+
+        def fetch
+          output = super
+          market_pairs = []
+          output.each do |pair|
+            base, target = pair.split('_')
+            market_pairs << Cryptoexchange::Models::MarketPair.new(
+                              base: base.upcase,
+                              target: target.upcase,
+                              market: Ukex::Market::NAME
+                            )
+          end
+          market_pairs
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/ukex/services/trades.rb
+++ b/lib/cryptoexchange/exchanges/ukex/services/trades.rb
@@ -1,0 +1,32 @@
+module Cryptoexchange::Exchanges
+  module Ukex
+    module Services
+      class Trades < Cryptoexchange::Services::Market
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          "#{Cryptoexchange::Exchanges::Ukex::Market::API_URL}/tradeHistory/#{market_pair.base.downcase}_#{market_pair.target.downcase}"
+        end
+
+        def adapt(output, market_pair)
+          output['data'].collect do |trade|
+            tr = Cryptoexchange::Models::Trade.new
+            tr.trade_id  = trade['tradeID']
+            tr.base      = market_pair.base
+            tr.target    = market_pair.target
+            tr.market    = Ukex::Market::NAME
+            tr.type      = trade['type']
+            tr.price     = trade['rate']
+            tr.amount    = trade['amount']
+            tr.timestamp = DateTime.parse(trade['date']).to_time.to_i
+            tr.payload   = trade
+            tr
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/UKEX/integration_specs_fetch_order_book.yml
+++ b/spec/cassettes/vcr_cassettes/UKEX/integration_specs_fetch_order_book.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.ukex.com/api/index/orderBook/eth_gbp
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.ukex.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 14 Nov 2018 09:22:20 GMT
+      Content-Type:
+      - text/html;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d2256fdd544e1d7a4dab0b447d506c68f1542187339; expires=Thu, 14-Nov-19
+        09:22:19 GMT; path=/; domain=.ukex.com; HttpOnly; Secure
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/5.6.31
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - X-Requested-With,X_Requested_With,TOKEN,ID
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 479869ba0edc9bdb-AMS
+    body:
+      encoding: UTF-8
+      string: '{"result":"true","asks":[["160.29","0.0626"],["160.22","0.074"],["160.2","0.0558"],["160.11","0.0111"],["160.08","0.0315"],["160.07","0.0727"],["160.03","0.0283"],["160.01","0.0187"],["159.91","0.0367"],["159.89","0.0599"],["159.85","0.0071"],["159.36","0.99"]],"bids":[["157.25","1"],["156.68","0.0999"],["156.63","0.0721"],["156.55","0.0959"],["156.5","0.0051"],["156.46","0.0779"],["156.42","0.0198"],["156.38","0.0687"],["156.31","0.0012"],["156.29","0.015"],["156.28","0.0368"],["155.53","0.0027"]]}'
+    http_version: 
+  recorded_at: Wed, 14 Nov 2018 09:22:49 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/UKEX/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/UKEX/integration_specs_fetch_pairs.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.ukex.com/api/index/pairs
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.ukex.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 14 Nov 2018 09:13:20 GMT
+      Content-Type:
+      - text/html;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d3b1cc0642325605efa3917b7a8784b031542186799; expires=Thu, 14-Nov-19
+        09:13:19 GMT; path=/; domain=.ukex.com; HttpOnly; Secure
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/5.6.31
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - X-Requested-With,X_Requested_With,TOKEN,ID
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 47985c86985d9c35-AMS
+    body:
+      encoding: UTF-8
+      string: '["ETH_BTC","LTC_BTC","XMR_BTC","BCH_BTC","LTC_ETH","XMR_ETH","DASH_ETH","ZEC_ETH","ETH_BUC","BTC_BUC","DASH_BUC","BCH_BUC","ZEC_BUC","LTC_BUC","BTC_GBP","ETH_GBP","BTC_EUR","ETH_EUR","LBA_ETH","QKC_ETH","HOT_ETH","OMG_ETH","ZRX_ETH","DOGE_BUC","DOGE_BTC","AE_ETH","DASH_BTC","ZEC_BTC","BTM_ETH"]'
+    http_version: 
+  recorded_at: Wed, 14 Nov 2018 09:13:49 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/UKEX/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/UKEX/integration_specs_fetch_ticker.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.ukex.com/api/index/tickers
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.ukex.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 14 Nov 2018 09:19:43 GMT
+      Content-Type:
+      - text/html;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=dc540d6b216e7f11dd4f4f3fb82497d7b1542187182; expires=Thu, 14-Nov-19
+        09:19:42 GMT; path=/; domain=.ukex.com; HttpOnly; Secure
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/5.6.31
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - X-Requested-With,X_Requested_With,TOKEN,ID
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 479865e08f86bf89-AMS
+    body:
+      encoding: UTF-8
+      string: '{"eth_btc":{"result":"true","last":0.03246582,"lowestAsk":"0.03246582","highestBid":"0.03246582","percentChange":-1.16,"baseVolume":3088.3556,"quoteVolume":94.04587607,"high24hr":0.03300361,"low24hr":0.03219917},"ltc_btc":{"result":"true","last":0.0077944,"lowestAsk":"0.00779440","highestBid":"0.00782070","percentChange":-2.13,"baseVolume":4087.2339,"quoteVolume":30.05543939,"high24hr":0.0080129,"low24hr":0.00767844},"xmr_btc":{"result":"true","last":0.016498,"lowestAsk":"0.01656758","highestBid":"0.01628795","percentChange":-1.07,"baseVolume":1066.1054,"quoteVolume":17.61557026,"high24hr":0.01670776,"low24hr":0.01626215},"bch_btc":{"result":"true","last":0.07929022,"lowestAsk":"0.07929022","highestBid":"0.07929022","percentChange":-0.83,"baseVolume":3694.2586,"quoteVolume":275.24134367,"high24hr":0.08597797,"low24hr":0.07896325},"ltc_eth":{"result":"true","last":0.241169,"lowestAsk":"0.25055700","highestBid":"0.23522400","percentChange":-0.42,"baseVolume":729.9093,"quoteVolume":205.676569,"high24hr":0.244645,"low24hr":0.23678},"xmr_eth":{"result":"true","last":0.503787,"lowestAsk":"0.50953500","highestBid":"0.50083600","percentChange":-1.56,"baseVolume":245.3346,"quoteVolume":115.9506,"high24hr":0.512289,"low24hr":0.494891},"dash_eth":{"result":"true","last":0.785665,"lowestAsk":"0.79908000","highestBid":"0.77224400","percentChange":0.74,"baseVolume":101.3758,"quoteVolume":84.82317,"high24hr":0.791188,"low24hr":0.765256},"zec_eth":{"result":"true","last":0.615685,"lowestAsk":"0.62626500","highestBid":"0.61169900","percentChange":-2.81,"baseVolume":159.8354,"quoteVolume":105.289236,"high24hr":0.646884,"low24hr":0.609999},"eth_buc":{"result":"true","last":142.366942,"lowestAsk":"144.77957200","highestBid":"142.30847400","percentChange":-1.76,"baseVolume":1109.5282,"quoteVolume":160125.710433,"high24hr":146.580581,"low24hr":142.117942},"btc_buc":{"result":"true","last":4392.122153,"lowestAsk":"4443.49662800","highestBid":"4380.43452200","percentChange":0.16,"baseVolume":247.0117,"quoteVolume":1067152.099344,"high24hr":4423.865322,"low24hr":4380.3002},"dash_buc":{"result":"true","last":113.122089,"lowestAsk":"114.18803200","highestBid":"111.34036100","percentChange":1.14,"baseVolume":250.6994,"quoteVolume":28084.79769,"high24hr":114.231536,"low24hr":110.192563},"bch_buc":{"result":"true","last":351.288857,"lowestAsk":"359.43664900","highestBid":"343.55503300","percentChange":-0.35,"baseVolume":2572.4324,"quoteVolume":866961.534732,"high24hr":380.538322,"low24hr":349.103535},"zec_buc":{"result":"true","last":88.990033,"lowestAsk":"90.12981200","highestBid":"87.41803800","percentChange":-1.8,"baseVolume":5428.1932,"quoteVolume":433995.396422,"high24hr":91.128577,"low24hr":86.052741},"ltc_buc":{"result":"true","last":34.62804,"lowestAsk":"35.33965400","highestBid":"34.10301200","percentChange":-1.03,"baseVolume":2160.9022,"quoteVolume":63274.376141,"high24hr":35.417353,"low24hr":33.973287},"btc_gbp":{"result":"true","last":4854.31,"lowestAsk":"4926.52000000","highestBid":"4827.68000000","percentChange":-1.22,"baseVolume":130.56,"quoteVolume":637421.53,"high24hr":4960.43,"low24hr":4841.47},"eth_gbp":{"result":"true","last":157.04,"lowestAsk":"162.51000000","highestBid":"151.29000000","percentChange":-1.58,"baseVolume":129.86,"quoteVolume":20740.22,"high24hr":163.24,"low24hr":155.46},"btc_eur":{"result":"true","last":5599.32,"lowestAsk":"5627.62000000","highestBid":"5528.17000000","percentChange":-0.23,"baseVolume":130.45,"quoteVolume":729987.29,"high24hr":5663.83,"low24hr":5525.28},"eth_eur":{"result":"true","last":180.18,"lowestAsk":"187.44000000","highestBid":"173.84000000","percentChange":-1.88,"baseVolume":127.03,"quoteVolume":23205.17,"high24hr":185.45,"low24hr":178.79},"lba_eth":{"result":"true","last":0.00028096,"lowestAsk":"0.00029633","highestBid":"0.00027467","percentChange":0.47,"baseVolume":532788.4257,"quoteVolume":150.2119753,"high24hr":0.00030271,"low24hr":0.00026778},"qkc_eth":{"result":"true","last":0.00027825,"lowestAsk":"0.00028145","highestBid":"0.00027351","percentChange":10.75,"baseVolume":615200.56,"quoteVolume":165.34700012,"high24hr":0.00027825,"low24hr":0.00025019},"hot_eth":{"result":"true","last":4.74e-6,"lowestAsk":"0.00000539","highestBid":"0.00000401","percentChange":1.93,"baseVolume":5849713.45,"quoteVolume":30.28390695,"high24hr":4.8e-6,"low24hr":4.55e-6},"omg_eth":{"result":"true","last":0.01533778,"lowestAsk":"0.01557923","highestBid":"0.01528151","percentChange":-1.38,"baseVolume":6498.3606,"quoteVolume":100.50098196,"high24hr":0.01566452,"low24hr":0.01514324},"zrx_eth":{"result":"true","last":0.00306549,"lowestAsk":"0.00310457","highestBid":"0.00304187","percentChange":-4.81,"baseVolume":56654.88,"quoteVolume":172.61855428,"high24hr":0.0032589,"low24hr":0.00301611},"doge_buc":{"result":"true","last":0.001989,"lowestAsk":"0.00261000","highestBid":"0.00143600","percentChange":-5.01,"baseVolume":39537163.7884,"quoteVolume":81172.483346,"high24hr":0.002098,"low24hr":0.001925},"doge_btc":{"result":"true","last":4.4e-7,"lowestAsk":"0.00000044","highestBid":"0.00000044","percentChange":-4.34,"baseVolume":462889.6457,"quoteVolume":0.20820705,"high24hr":4.7e-7,"low24hr":4.1e-7},"ae_eth":{"result":"true","last":0.00536623,"lowestAsk":"0.00574148","highestBid":"0.00507439","percentChange":-1.31,"baseVolume":17513.6198,"quoteVolume":95.34857774,"high24hr":0.00554184,"low24hr":0.00535233},"dash_btc":{"result":"true","last":0.02542952,"lowestAsk":"0.02573899","highestBid":"0.02524389","percentChange":-0.21,"baseVolume":373.3497,"quoteVolume":9.76138407,"high24hr":0.02563843,"low24hr":0.02495199},"zec_btc":{"result":"true","last":0.01999848,"lowestAsk":"0.02029877","highestBid":"0.01982633","percentChange":-3.69,"baseVolume":928.6815,"quoteVolume":21.92919782,"high24hr":0.02110528,"low24hr":0.01982301},"btm_eth":{"result":"true","last":0.00087082,"lowestAsk":"0.00090808","highestBid":"0.00083439","percentChange":-0.11,"baseVolume":128543.9309,"quoteVolume":89.97902025,"high24hr":0.00089608,"low24hr":0.00085368}}'
+    http_version: 
+  recorded_at: Wed, 14 Nov 2018 09:20:11 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/UKEX/integration_specs_fetch_trade.yml
+++ b/spec/cassettes/vcr_cassettes/UKEX/integration_specs_fetch_trade.yml
@@ -1,0 +1,100 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.ukex.com/api/index/tradeHistory/eth_gbp
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.ukex.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 14 Nov 2018 09:26:55 GMT
+      Content-Type:
+      - text/html;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=db732c7f4e37d66db97fa1d7a8329dd321542187612; expires=Thu, 14-Nov-19
+        09:26:52 GMT; path=/; domain=.ukex.com; HttpOnly; Secure
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/5.6.31
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - X-Requested-With,X_Requested_With,TOKEN,ID
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4798705faacb2b6a-AMS
+    body:
+      encoding: UTF-8
+      string: '{"result":"true","data":[{"tradeID":"16788852","date":"2018-11-14 17:26:36","type":"sell","rate":"156.65","amount":0.0044,"total":0.68926},{"tradeID":"16788828","date":"2018-11-14
+        17:26:06","type":"sell","rate":"157.34","amount":0.085,"total":13.3739},{"tradeID":"16788824","date":"2018-11-14
+        17:25:35","type":"sell","rate":"157.32","amount":0.0196,"total":3.083472},{"tradeID":"16788816","date":"2018-11-14
+        17:25:04","type":"sell","rate":"158.3","amount":0.0205,"total":3.24515},{"tradeID":"16788800","date":"2018-11-14
+        17:24:34","type":"sell","rate":"158.43","amount":0.0365,"total":5.782695},{"tradeID":"16788789","date":"2018-11-14
+        17:24:03","type":"buy","rate":"158.14","amount":0.0312,"total":4.933968},{"tradeID":"16788785","date":"2018-11-14
+        17:23:33","type":"sell","rate":"157.71","amount":0.0484,"total":7.633164},{"tradeID":"16788770","date":"2018-11-14
+        17:23:02","type":"buy","rate":"157.52","amount":0.0217,"total":3.418184},{"tradeID":"16788759","date":"2018-11-14
+        17:22:32","type":"buy","rate":"157.99","amount":0.063,"total":9.95337},{"tradeID":"16788750","date":"2018-11-14
+        17:22:01","type":"buy","rate":"157.36","amount":0.025,"total":3.934},{"tradeID":"16788739","date":"2018-11-14
+        17:21:31","type":"sell","rate":"157.81","amount":0.0419,"total":6.612239},{"tradeID":"16788725","date":"2018-11-14
+        17:21:00","type":"buy","rate":"157.69","amount":0.0943,"total":14.870167},{"tradeID":"16788721","date":"2018-11-14
+        17:20:30","type":"sell","rate":"157.5","amount":0.0272,"total":4.284},{"tradeID":"16788704","date":"2018-11-14
+        17:19:59","type":"sell","rate":"157.26","amount":0.0139,"total":2.185914},{"tradeID":"16788694","date":"2018-11-14
+        17:19:29","type":"sell","rate":"157.04","amount":0.0714,"total":11.212656},{"tradeID":"16788685","date":"2018-11-14
+        17:18:58","type":"buy","rate":"158.3","amount":0.0936,"total":14.81688},{"tradeID":"16788675","date":"2018-11-14
+        17:18:28","type":"sell","rate":"157.56","amount":0.0927,"total":14.605812},{"tradeID":"16788666","date":"2018-11-14
+        17:17:57","type":"sell","rate":"157.71","amount":0.0917,"total":14.462007},{"tradeID":"16788655","date":"2018-11-14
+        17:17:27","type":"buy","rate":"156.82","amount":0.0488,"total":7.652816},{"tradeID":"16788640","date":"2018-11-14
+        17:16:56","type":"sell","rate":"158.17","amount":0.0721,"total":11.404057},{"tradeID":"16788636","date":"2018-11-14
+        17:16:26","type":"buy","rate":"158.46","amount":0.091,"total":14.41986},{"tradeID":"16788620","date":"2018-11-14
+        17:15:55","type":"sell","rate":"157.21","amount":0.0475,"total":7.467475},{"tradeID":"16788611","date":"2018-11-14
+        17:15:25","type":"buy","rate":"157.34","amount":0.0302,"total":4.751668},{"tradeID":"16788603","date":"2018-11-14
+        17:14:54","type":"buy","rate":"157.58","amount":0.0478,"total":7.532324},{"tradeID":"16788597","date":"2018-11-14
+        17:14:24","type":"buy","rate":"157.87","amount":0.0234,"total":3.694158},{"tradeID":"16788575","date":"2018-11-14
+        17:13:53","type":"buy","rate":"157.9","amount":0.0691,"total":10.91089},{"tradeID":"16788571","date":"2018-11-14
+        17:13:23","type":"sell","rate":"156.99","amount":0.0799,"total":12.543501},{"tradeID":"16788563","date":"2018-11-14
+        17:12:52","type":"buy","rate":"158.52","amount":0.0543,"total":8.607636},{"tradeID":"16788545","date":"2018-11-14
+        17:12:22","type":"buy","rate":"157.86","amount":0.0556,"total":8.777016},{"tradeID":"16788535","date":"2018-11-14
+        17:11:51","type":"buy","rate":"157.21","amount":0.0614,"total":9.652694},{"tradeID":"16788531","date":"2018-11-14
+        17:11:21","type":"sell","rate":"157.44","amount":0.058,"total":9.13152},{"tradeID":"16788508","date":"2018-11-14
+        17:10:50","type":"sell","rate":"158.65","amount":0.0386,"total":6.12389},{"tradeID":"16788504","date":"2018-11-14
+        17:10:20","type":"buy","rate":"157.03","amount":0.0316,"total":4.962148},{"tradeID":"16788494","date":"2018-11-14
+        17:09:49","type":"sell","rate":"157.14","amount":0.0343,"total":5.389902},{"tradeID":"16788483","date":"2018-11-14
+        17:09:19","type":"sell","rate":"158.6","amount":0.0073,"total":1.15778},{"tradeID":"16788467","date":"2018-11-14
+        17:08:49","type":"sell","rate":"157.71","amount":0.071,"total":11.19741},{"tradeID":"16788463","date":"2018-11-14
+        17:08:19","type":"buy","rate":"157.54","amount":0.0633,"total":9.972282},{"tradeID":"16788445","date":"2018-11-14
+        17:07:48","type":"buy","rate":"157.95","amount":0.059,"total":9.31905},{"tradeID":"16788434","date":"2018-11-14
+        17:07:17","type":"sell","rate":"157.77","amount":0.0126,"total":1.987902},{"tradeID":"16788426","date":"2018-11-14
+        17:06:47","type":"buy","rate":"158.18","amount":0.0103,"total":1.629254},{"tradeID":"16788415","date":"2018-11-14
+        17:06:16","type":"sell","rate":"157.73","amount":0.0225,"total":3.548925},{"tradeID":"16788398","date":"2018-11-14
+        17:05:46","type":"buy","rate":"157.84","amount":0.0909,"total":14.347656},{"tradeID":"16788394","date":"2018-11-14
+        17:05:15","type":"sell","rate":"157.4","amount":0.0212,"total":3.33688},{"tradeID":"16788379","date":"2018-11-14
+        17:04:45","type":"sell","rate":"157.63","amount":0.0054,"total":0.851202},{"tradeID":"16788375","date":"2018-11-14
+        17:04:14","type":"buy","rate":"157.57","amount":0.0151,"total":2.379307},{"tradeID":"16788357","date":"2018-11-14
+        17:03:44","type":"buy","rate":"159.32","amount":0.0615,"total":9.79818},{"tradeID":"16788348","date":"2018-11-14
+        17:03:13","type":"buy","rate":"158.54","amount":0.0175,"total":2.77445},{"tradeID":"16788340","date":"2018-11-14
+        17:02:43","type":"buy","rate":"158.61","amount":0.0104,"total":1.649544},{"tradeID":"16788329","date":"2018-11-14
+        17:02:12","type":"buy","rate":"157.81","amount":0.0886,"total":13.981966},{"tradeID":"16788311","date":"2018-11-14
+        17:01:42","type":"sell","rate":"157.66","amount":0.0507,"total":7.993362}],"elapsed":"0.0008ms"}'
+    http_version: 
+  recorded_at: Wed, 14 Nov 2018 09:27:24 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/ukex/integration/market_spec.rb
+++ b/spec/exchanges/ukex/integration/market_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+RSpec.describe 'UKEX integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:eth_gbp_pair) { Cryptoexchange::Models::MarketPair.new(base: 'ETH', target: 'GBP', market: 'ukex') }
+
+  it 'has trade_page_url' do
+    trade_page_url = client.trade_page_url eth_gbp_pair.market, base: eth_gbp_pair.base, target: eth_gbp_pair.target
+    expect(trade_page_url).to eq "https://www.ukex.com/trade/index/market/eth_gbp"
+  end
+
+  it 'fetch pairs' do
+    pairs = client.pairs('ukex')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.market).to eq 'ukex'
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(eth_gbp_pair)
+
+    expect(ticker.base).to eq 'ETH'
+    expect(ticker.target).to eq 'GBP'
+    expect(ticker.market).to eq 'ukex'
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.low).to be_a Numeric
+    expect(ticker.high).to be_a Numeric
+    expect(ticker.bid).to be_a Numeric
+    expect(ticker.ask).to be_a Numeric
+    expect(ticker.change).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+    expect(ticker.timestamp).to be nil
+    expect(ticker.payload).to_not be nil
+  end
+
+  it 'fetch order book' do
+    order_book = client.order_book(eth_gbp_pair)
+
+    expect(order_book.base).to eq 'ETH'
+    expect(order_book.target).to eq 'GBP'
+    expect(order_book.market).to eq 'ukex'
+    expect(order_book.asks).to_not be_empty
+    expect(order_book.bids).to_not be_empty
+    expect(order_book.asks.first.price).to_not be_nil
+    expect(order_book.bids.first.amount).to_not be_nil
+    expect(order_book.bids.first.timestamp).to be_nil
+    expect(order_book.asks.count).to be > 5
+    expect(order_book.bids.count).to be > 5
+    expect(order_book.timestamp).to be nil
+    expect(order_book.payload).to_not be nil
+  end
+
+  it 'fetch trade' do
+    trades = client.trades(eth_gbp_pair)
+    trade = trades.sample
+
+    expect(trades).to_not be_empty
+    expect(trade.base).to eq 'ETH'
+    expect(trade.target).to eq 'GBP'
+    expect(trade.market).to eq 'ukex'
+    expect(trade.trade_id).to_not be_nil
+    expect(['buy', 'sell']).to include trade.type
+    expect(trade.price).to_not be_nil
+    expect(trade.amount).to_not be_nil
+    expect(trade.timestamp).to be_a Numeric
+    expect(2000..Date.today.year).to include(Time.at(trade.timestamp).year)
+    expect(trade.payload).to_not be nil
+  end
+end

--- a/spec/exchanges/ukex/market_spec.rb
+++ b/spec/exchanges/ukex/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Ukex::Market do
+  it { expect(described_class::NAME).to eq 'ukex' }
+  it { expect(described_class::API_URL).to eq 'https://api.ukex.com/api/index' }
+end


### PR DESCRIPTION
- Add Pairs, Tickers, OrderBook, Trades, Trade URL and updated README for UKEX
- Closes: #1134 
- [X] I have added Specs
- [X] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [X] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [X] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [X] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
