### PR TITLE
Updated Coinfield APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Or install it yourself as:
 | Coineal           | Y       | Y          | Y       |         | Y           |          | coineal           |
 | Coinex            | Y       | Y          | Y       |         | Y           | Y        | coinex            |
 | Coinfalcon        | Y       | Y          | Y       |         | Y           |          | coinfalcon        |
-| Coinfield         | Y       | N          | N       |         | Y           | Y        | coinfield         |
+| Coinfield         | Y       | Y          | N       |         | Y           | Y        | coinfield         |
 | Coingi            | Y       | Y          | Y       |         | Y           | Y        | coingi            |
 | Coinhouse         | Y       |            |         |         | Y           | Y        | coinhouse         |
 | Coinhub           | Y       | Y          | Y       |         | Y           | Y        | coinhub           |

--- a/lib/cryptoexchange/exchanges/coinfield/market.rb
+++ b/lib/cryptoexchange/exchanges/coinfield/market.rb
@@ -2,7 +2,7 @@ module Cryptoexchange::Exchanges
   module Coinfield
     class Market < Cryptoexchange::Models::Market
       NAME = 'coinfield'
-      API_URL = 'https://platform.coinfield.com/api/v2/'
+      API_URL = 'https://api.coinfield.com/v1'
 
       def self.trade_page_url(args={})
         "https://trade.coinfield.com/pro/trade/#{args[:base]}-#{args[:target]}"

--- a/lib/cryptoexchange/exchanges/coinfield/services/market.rb
+++ b/lib/cryptoexchange/exchanges/coinfield/services/market.rb
@@ -18,18 +18,14 @@ module Cryptoexchange::Exchanges
         end
 
         def adapt_all(output)
-          output.map do |pair, ticker|
-            separator = /(cad|usd|btc)\z/ =~ pair
-            next if separator.nil?
-
-            base    = pair[0..separator -1]
-            target  = pair[separator..-1]
+          output['markets'].map do |pair|
+            base, target = pair['market'].split(/(cad)+(.*)|(usd)+(.*)|(eur)+(.*)|(xrp)+(.*)/).reject(&:empty?)
             market_pair = Cryptoexchange::Models::MarketPair.new(
               base: base,
               target: target,
               market: Coinfield::Market::NAME
             )
-            adapt(ticker, market_pair)
+            adapt(pair, market_pair)
           end
         end
 
@@ -38,13 +34,13 @@ module Cryptoexchange::Exchanges
           ticker.base      = market_pair.base
           ticker.target    = market_pair.target
           ticker.market    = Coinfield::Market::NAME
-          ticker.ask       = NumericHelper.to_d(output['ticker']['sell'])
-          ticker.bid       = NumericHelper.to_d(output['ticker']['buy'])
-          ticker.high      = NumericHelper.to_d(output['ticker']['high'])
-          ticker.low       = NumericHelper.to_d(output['ticker']['low'])
-          ticker.last      = NumericHelper.to_d(output['ticker']['last'])
-          ticker.volume    = NumericHelper.to_d(output['ticker']['vol'])
-          ticker.timestamp = output['at']
+          ticker.ask       = NumericHelper.to_d(output['ask'])
+          ticker.bid       = NumericHelper.to_d(output['bid'])
+          ticker.high      = NumericHelper.to_d(output['high'])
+          ticker.low       = NumericHelper.to_d(output['low'])
+          ticker.last      = NumericHelper.to_d(output['last'])
+          ticker.volume    = NumericHelper.to_d(output['vol'])
+          ticker.timestamp = DateTime.parse(output['timestamp']).to_time.to_i
           ticker.payload   = output
           ticker
         end

--- a/lib/cryptoexchange/exchanges/coinfield/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/coinfield/services/order_book.rb
@@ -1,0 +1,42 @@
+module Cryptoexchange::Exchanges
+  module Coinfield
+    module Services
+      class OrderBook < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          "#{Cryptoexchange::Exchanges::Coinfield::Market::API_URL}/orderbook/#{market_pair.base.downcase}#{market_pair.target.downcase}"
+        end
+
+        def adapt(output, market_pair)
+          order_book = Cryptoexchange::Models::OrderBook.new
+          order_book.base      = market_pair.base
+          order_book.target    = market_pair.target
+          order_book.market    = Coinfield::Market::NAME
+          order_book.asks      = adapt_orders(output['asks'])
+          order_book.bids      = adapt_orders(output['bids'])
+          order_book.timestamp = DateTime.parse(output['timestamp']).to_time.to_i
+          order_book.payload   = output
+          order_book
+        end
+
+        def adapt_orders(orders)
+          orders.collect do |order_entry|
+            Cryptoexchange::Models::Order.new(price: order_entry['price'],
+                                              amount: order_entry['volume'],
+                                              timestamp: DateTime.parse(order_entry['timestamp']).to_time.to_i)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/coinfield/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/coinfield/services/pairs.rb
@@ -10,7 +10,7 @@ module Cryptoexchange::Exchanges
         end
 
         def adapt(output)
-          output.map do |pair|
+          output['markets'].map do |pair|
             base, target = pair['name'].split('/')
             Cryptoexchange::Models::MarketPair.new(
               base: base,

--- a/spec/cassettes/vcr_cassettes/Coinfield/integration_specs_fetch_order_book.yml
+++ b/spec/cassettes/vcr_cassettes/Coinfield/integration_specs_fetch_order_book.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.coinfield.com/v1/orderbook/btccad
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.coinfield.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.15.3
+      Date:
+      - Thu, 15 Nov 2018 14:34:10 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '4546'
+      Connection:
+      - close
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Set-Cookie:
+      - route=5178343a232338acb8d6a95576f31ee1; Domain=api.coinfield.com; Path=/;
+        HttpOnly
+      X-Dns-Prefetch-Control:
+      - 'off'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      X-Download-Options:
+      - noopen
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Id:
+      - 515eaae8-76c2-4364-bfe6-1f3a24095240
+      X-Runtime:
+      - '0.015900'
+      X-Proxy-Runtime:
+      - 22ms
+      X-Fuse-Cached:
+      - 'false'
+      Etag:
+      - W/"11c2-MolYZiG80B0jJ+KSbuOCbPKMLnU"
+    body:
+      encoding: UTF-8
+      string: '{"market":"btccad","total_asks":1.2045036,"total_bids":7.250672399999999,"bids_hash":"f2ab5114f67e86ba58ec33a504231b6d","asks_hash":"421ae87010e52ac15bb929905e23bf6c","bids":[{"id":"pd211dur0v10024pi4","price":"7101.73","volume":"0.0045","timestamp":"2018-11-15T14:34:09.000000Z"},{"id":"pd211duqpvf0024mt9","price":"6920.0","volume":"0.1467","timestamp":"2018-11-15T12:34:55.000000Z"},{"id":"pd211dur0hj0024pap","price":"6864.76","volume":"0.016539","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd211dur0hj0024pah","price":"6851.03","volume":"0.0151836","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd211dur0hj0024pb2","price":"6838.02","volume":"0.0145194","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd211dur0hj0024paq","price":"6824.34","volume":"2.0942","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd211dur0hj0024pb6","price":"6818.2","volume":"0.0136968","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd211dur0hj0024paj","price":"6800.47","volume":"0.5136","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd211dur0ud0024pht","price":"6798.26","volume":"0.0013","timestamp":"2018-11-15T14:33:49.000000Z"},{"id":"pd211dur0hj0024pav","price":"6780.75","volume":"0.0081504","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd211dur0hj0024pba","price":"6767.19","volume":"0.0150606","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd211dur0hj0024pao","price":"6748.24","volume":"2.5775","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd211dur0hj0024pag","price":"6736.09","volume":"0.007434","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd211dur0hj0024pb4","price":"6719.93","volume":"0.0137382","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd211dur0hj0024pak","price":"6713.88","volume":"0.0085254","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd211dur0hj0024pas","price":"6702.47","volume":"1.7407","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd211dur0hj0024pal","price":"6685.71","volume":"0.011793","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd211dur0hj0024pam","price":"6666.32","volume":"0.014736","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd211dur0hj0024pb5","price":"6652.32","volume":"0.0168762","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd211dur0hj0024pat","price":"6636.36","volume":"0.0159198","timestamp":"2018-11-15T14:26:59.000000Z"}],"asks":[{"id":"pd111dur0ug0024phv","price":"7106.62","volume":"0.0043","timestamp":"2018-11-15T14:33:52.000000Z"},{"id":"pd111dur0um0024pi2","price":"7106.62","volume":"0.004","timestamp":"2018-11-15T14:33:58.000000Z"},{"id":"pd111dur0hj0024pbt","price":"7362.86","volume":"0.0066678","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd111dur0hj0024pc4","price":"7372.43","volume":"0.0103836","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd111dur0hj0024pc5","price":"7379.07","volume":"0.0080112","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd111dur0hj0024pc8","price":"7385.71","volume":"0.0157422","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd111dur0hj0024pc7","price":"7401.22","volume":"0.0050358","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd111dur0hj0024pc9","price":"7423.42","volume":"0.0093024","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd111dur0hj0024pcb","price":"7439.75","volume":"0.006066","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd111dur0uk0024pi0","price":"7447.31","volume":"0.0014","timestamp":"2018-11-15T14:33:56.000000Z"},{"id":"pd111dur0hj0024pca","price":"7456.12","volume":"0.0074244","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd111dur0so0024phg","price":"7464.55","volume":"0.0014","timestamp":"2018-11-15T14:32:56.000000Z"},{"id":"pd111dur0hj0024pck","price":"7468.8","volume":"0.0087894","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd111dur0hj0024pcj","price":"7485.23","volume":"0.0107124","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd111dur0hj0024pce","price":"7503.19","volume":"0.0126648","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd111dur0hj0024pcd","price":"7511.45","volume":"0.2734","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd111dur0hj0024pcg","price":"7531.73","volume":"0.3326","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd111dur0hj0024pcc","price":"7543.03","volume":"0.4626","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd111dur0hj0024pcq","price":"7553.59","volume":"0.0078426","timestamp":"2018-11-15T14:26:59.000000Z"},{"id":"pd111dur0hj0024pcf","price":"7566.43","volume":"0.016161","timestamp":"2018-11-15T14:26:59.000000Z"}],"timestamp":"2018-11-15T14:34:10.405Z","took":"22ms"}'
+    http_version: 
+  recorded_at: Thu, 15 Nov 2018 14:34:10 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Coinfield/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/Coinfield/integration_specs_fetch_pairs.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://platform.coinfield.com/api/v2//markets
+    uri: https://api.coinfield.com/v1/markets
     body:
       encoding: UTF-8
       string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Connection:
       - close
       Host:
-      - platform.coinfield.com
+      - api.coinfield.com
       User-Agent:
       - http.rb/3.0.0
   response:
@@ -18,74 +18,49 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Server:
+      - nginx/1.15.3
       Date:
-      - Tue, 29 May 2018 16:52:37 GMT
+      - Thu, 15 Nov 2018 12:41:24 GMT
       Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
+      - application/json; charset=utf-8
+      Content-Length:
+      - '4944'
       Connection:
       - close
-      Set-Cookie:
-      - __cfduid=d4004e8f215fa4d1dc100470f4b5404641527612757; expires=Wed, 29-May-19
-        16:52:37 GMT; path=/; domain=.coinfield.com; HttpOnly; Secure
       Vary:
       - Accept-Encoding
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE
-      Access-Control-Allow-Headers:
-      - Origin, X-Requested-With, Content-Type, Accept, Authorization
-      Version:
-      - HTTP/1.1
-      Host:
-      - platform.coinfield.com
-      X-Real-Ip:
-      - 73.97.148.141
-      X-Forwarded-For:
-      - 73.97.148.141
-      X-Forwarded-Host:
-      - platform.coinfield.com
-      X-Forwarded-Port:
-      - '443'
-      X-Forwarded-Proto:
-      - https
-      X-Original-Uri:
-      - "/api/v2//markets"
-      X-Scheme:
-      - https
-      X-Original-Forwarded-For:
-      - 73.97.148.141
-      Accept-Encoding:
-      - gzip
-      Cf-Ipcountry:
-      - US
-      Cf-Visitor:
-      - '{"scheme":"https"}'
-      User-Agent:
-      - http.rb/3.0.0
-      Cf-Connecting-Ip:
-      - 73.97.148.141
-      Etag:
-      - W/"0bfc98bb22ef88ab4b912bb13a35c920"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - dbec4ca6-8fbc-4f06-a9e2-ba4d5c256482
-      X-Runtime:
-      - '0.056467'
+      - Accept-Encoding
+      Set-Cookie:
+      - route=a9adbc921b481c341b1a2081337871aa; Domain=api.coinfield.com; Path=/;
+        HttpOnly
+      X-Dns-Prefetch-Control:
+      - 'off'
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
-      Server:
-      - cloudflare
-      Cf-Ray:
-      - 422a78f3feab2a85-SEA
+      X-Download-Options:
+      - noopen
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Id:
+      - ''
+      X-Runtime:
+      - '0'
+      X-Proxy-Runtime:
+      - 0ms
+      X-Fuse-Cached:
+      - 'true'
+      Etag:
+      - W/"1350-Z73eKVYX8ToCwZ/GdDqwvnaw3Ig"
     body:
-      encoding: ASCII-8BIT
-      string: '[{"id":"btccad","name":"BTC/CAD"},{"id":"xrpcad","name":"XRP/CAD"},{"id":"bchcad","name":"BCH/CAD"},{"id":"ltccad","name":"LTC/CAD"},{"id":"ethcad","name":"ETH/CAD"},{"id":"dashcad","name":"DASH/CAD"},{"id":"ethbtc","name":"ETH/BTC"},{"id":"xrpbtc","name":"XRP/BTC"},{"id":"ltcbtc","name":"LTC/BTC"},{"id":"dashbtc","name":"DASH/BTC"},{"id":"bchbtc","name":"BCH/BTC"},{"id":"btcusd","name":"BTC/USD"},{"id":"xrpusd","name":"XRP/USD"}]'
+      encoding: UTF-8
+      string: '{"markets":[{"id":"btcxrp","name":"BTC/XRP","ask_precision":8,"bid_precision":4,"minimum_volume":"0.001","maximum_volume":"50.0","minimum_funds":"20.0","maximum_funds":"500000.0"},{"id":"ethxrp","name":"ETH/XRP","ask_precision":4,"bid_precision":4,"minimum_volume":"0.1","maximum_volume":"300.0","minimum_funds":"20.0","maximum_funds":"500000.0"},{"id":"dashxrp","name":"DASH/XRP","ask_precision":3,"bid_precision":4,"minimum_volume":"0.1","maximum_volume":"500.0","minimum_funds":"20.0","maximum_funds":"500000.0"},{"id":"ltcxrp","name":"LTC/XRP","ask_precision":2,"bid_precision":4,"minimum_volume":"0.1","maximum_volume":"1000.0","minimum_funds":"20.0","maximum_funds":"500000.0"},{"id":"bchxrp","name":"BCH/XRP","ask_precision":3,"bid_precision":4,"minimum_volume":"0.05","maximum_volume":"200.0","minimum_funds":"20.0","maximum_funds":"500000.0"},{"id":"zecxrp","name":"ZEC/XRP","ask_precision":3,"bid_precision":4,"minimum_volume":"0.1","maximum_volume":"500.0","minimum_funds":"20.0","maximum_funds":"500000.0"},{"id":"btgxrp","name":"BTG/XRP","ask_precision":2,"bid_precision":4,"minimum_volume":"0.5","maximum_volume":"2000.0","minimum_funds":"20.0","maximum_funds":"500000.0"},{"id":"zrxxrp","name":"ZRX/XRP","ask_precision":1,"bid_precision":4,"minimum_volume":"10.0","maximum_volume":"100000.0","minimum_funds":"20.0","maximum_funds":"500000.0"},{"id":"gntxrp","name":"GNT/XRP","ask_precision":1,"bid_precision":4,"minimum_volume":"10.0","maximum_volume":"100000.0","minimum_funds":"20.0","maximum_funds":"500000.0"},{"id":"repxrp","name":"REP/XRP","ask_precision":3,"bid_precision":4,"minimum_volume":"1.0","maximum_volume":"2000.0","minimum_funds":"20.0","maximum_funds":"500000.0"},{"id":"omgxrp","name":"OMG/XRP","ask_precision":2,"bid_precision":4,"minimum_volume":"3.0","maximum_volume":"5000.0","minimum_funds":"20.0","maximum_funds":"500000.0"},{"id":"saltxrp","name":"SALT/XRP","ask_precision":2,"bid_precision":4,"minimum_volume":"10.0","maximum_volume":"100000.0","minimum_funds":"20.0","maximum_funds":"500000.0"},{"id":"batxrp","name":"BAT/XRP","ask_precision":1,"bid_precision":4,"minimum_volume":"50.0","maximum_volume":"200000.0","minimum_funds":"20.0","maximum_funds":"500000.0"},{"id":"zilxrp","name":"ZIL/XRP","ask_precision":1,"bid_precision":4,"minimum_volume":"300.0","maximum_volume":"999999.0","minimum_funds":"20.0","maximum_funds":"500000.0"},{"id":"xrpcad","name":"XRP/CAD","ask_precision":4,"bid_precision":4,"minimum_volume":"20.0","maximum_volume":"200000.0","minimum_funds":"10.0","maximum_funds":"300000.0"},{"id":"xrpusd","name":"XRP/USD","ask_precision":4,"bid_precision":4,"minimum_volume":"20.0","maximum_volume":"200000.0","minimum_funds":"10.0","maximum_funds":"300000.0"},{"id":"xrpeur","name":"XRP/EUR","ask_precision":4,"bid_precision":4,"minimum_volume":"20.0","maximum_volume":"200000.0","minimum_funds":"10.0","maximum_funds":"300000.0"},{"id":"xrpgbp","name":"XRP/GBP","ask_precision":4,"bid_precision":4,"minimum_volume":"20.0","maximum_volume":"200000.0","minimum_funds":"10.0","maximum_funds":"300000.0"},{"id":"xrpaed","name":"XRP/AED","ask_precision":4,"bid_precision":4,"minimum_volume":"20.0","maximum_volume":"200000.0","minimum_funds":"50.0","maximum_funds":"999999.0"},{"id":"xrpjpy","name":"XRP/JPY","ask_precision":4,"bid_precision":2,"minimum_volume":"20.0","maximum_volume":"200000.0","minimum_funds":"1500.0"},{"id":"btceur","name":"BTC/EUR","ask_precision":8,"bid_precision":2,"minimum_volume":"0.001","maximum_volume":"50.0","minimum_funds":"10.0","maximum_funds":"300000.0"},{"id":"etheur","name":"ETH/EUR","ask_precision":4,"bid_precision":2,"minimum_volume":"0.1","maximum_volume":"300.0","minimum_funds":"10.0","maximum_funds":"300000.0"},{"id":"ltceur","name":"LTC/EUR","ask_precision":2,"bid_precision":2,"minimum_volume":"0.1","maximum_volume":"1000.0","minimum_funds":"10.0","maximum_funds":"300000.0"},{"id":"btccad","name":"BTC/CAD","ask_precision":8,"bid_precision":2,"minimum_volume":"0.001","maximum_volume":"50.0","minimum_funds":"10.0","maximum_funds":"300000.0"},{"id":"ethcad","name":"ETH/CAD","ask_precision":4,"bid_precision":2,"minimum_volume":"0.1","maximum_volume":"300.0","minimum_funds":"10.0","maximum_funds":"300000.0"},{"id":"ltccad","name":"LTC/CAD","ask_precision":2,"bid_precision":2,"minimum_volume":"0.1","maximum_volume":"1000.0","minimum_funds":"10.0","maximum_funds":"300000.0"},{"id":"btcusd","name":"BTC/USD","ask_precision":8,"bid_precision":2,"minimum_volume":"0.001","maximum_volume":"50.0","minimum_funds":"10.0","maximum_funds":"300000.0"},{"id":"ethusd","name":"ETH/USD","ask_precision":4,"bid_precision":2,"minimum_volume":"0.1","maximum_volume":"300.0","minimum_funds":"10.0","maximum_funds":"300000.0"},{"id":"ltcusd","name":"LTC/USD","ask_precision":2,"bid_precision":2,"minimum_volume":"0.1","maximum_volume":"1000.0","minimum_funds":"10.0","maximum_funds":"300000.0"}],"timestamp":"2018-11-15T12:41:24.249Z","took":"0ms"}'
     http_version: 
-  recorded_at: Tue, 29 May 2018 16:52:37 GMT
+  recorded_at: Thu, 15 Nov 2018 12:41:24 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Coinfield/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/Coinfield/integration_specs_fetch_ticker.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://platform.coinfield.com/api/v2//tickers
+    uri: https://api.coinfield.com/v1/tickers
     body:
       encoding: UTF-8
       string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Connection:
       - close
       Host:
-      - platform.coinfield.com
+      - api.coinfield.com
       User-Agent:
       - http.rb/3.0.0
   response:
@@ -18,74 +18,49 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Server:
+      - nginx/1.15.3
       Date:
-      - Tue, 29 May 2018 16:52:37 GMT
+      - Thu, 15 Nov 2018 14:27:29 GMT
       Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
+      - application/json; charset=utf-8
+      Content-Length:
+      - '4680'
       Connection:
       - close
-      Set-Cookie:
-      - __cfduid=d009ca7bfcf7b500e7093bca2ad9afd241527612757; expires=Wed, 29-May-19
-        16:52:37 GMT; path=/; domain=.coinfield.com; HttpOnly; Secure
       Vary:
       - Accept-Encoding
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE
-      Access-Control-Allow-Headers:
-      - Origin, X-Requested-With, Content-Type, Accept, Authorization
-      Version:
-      - HTTP/1.1
-      Host:
-      - platform.coinfield.com
-      X-Real-Ip:
-      - 73.97.148.141
-      X-Forwarded-For:
-      - 73.97.148.141
-      X-Forwarded-Host:
-      - platform.coinfield.com
-      X-Forwarded-Port:
-      - '443'
-      X-Forwarded-Proto:
-      - https
-      X-Original-Uri:
-      - "/api/v2//tickers"
-      X-Scheme:
-      - https
-      X-Original-Forwarded-For:
-      - 73.97.148.141
-      Accept-Encoding:
-      - gzip
-      Cf-Ipcountry:
-      - US
-      Cf-Visitor:
-      - '{"scheme":"https"}'
-      User-Agent:
-      - http.rb/3.0.0
-      Cf-Connecting-Ip:
-      - 73.97.148.141
-      Etag:
-      - W/"186bd43cc5eb25a50628936548964f02"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 462a2155-29ec-480b-9c4c-aeeeca2f6ec8
-      X-Runtime:
-      - '0.036594'
+      - Accept-Encoding
+      Set-Cookie:
+      - route=86fc89a7345d090d4ca6789c195dabe7; Domain=api.coinfield.com; Path=/;
+        HttpOnly
+      X-Dns-Prefetch-Control:
+      - 'off'
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
-      Server:
-      - cloudflare
-      Cf-Ray:
-      - 422a78f63b662a5b-SEA
+      X-Download-Options:
+      - noopen
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Id:
+      - a4f95ddd-a673-4280-8fb8-9bb0548dcc84
+      X-Runtime:
+      - '0.007505'
+      X-Proxy-Runtime:
+      - 28ms
+      X-Fuse-Cached:
+      - 'false'
+      Etag:
+      - W/"1248-bF2BXlrZ247Aq1ltNSybXn0Yxog"
     body:
-      encoding: ASCII-8BIT
-      string: '{"btccad":{"at":1527612757,"ticker":{"buy":"9345.0","sell":"10488.0","low":"9345.0","high":"10600.0","last":"9345.0","open":9598.7,"vol":"33.7881"}},"xrpcad":{"at":1527612757,"ticker":{"buy":"0.8","sell":"0.88","low":"0.75","high":"0.88","last":"0.88","open":0.8,"vol":"115336.4307"}},"bchcad":{"at":1527612757,"ticker":{"buy":"1252.89","sell":"1449.9","low":"1159.56","high":"1449.9","last":"1314.05","open":1241.61,"vol":"556.5165"}},"ltccad":{"at":1527612757,"ticker":{"buy":"143.09","sell":"158.41","low":"144.32","high":"162.73","last":"158.52","open":159.95,"vol":"1816.5217"}},"ethcad":{"at":1527612757,"ticker":{"buy":"750.0","sell":"848.0","low":"700.0","high":"849.91","last":"700.0","open":706.72,"vol":"13.8293"}},"dashcad":{"at":1527612757,"ticker":{"buy":"429.0","sell":"488.0","low":"0.0","high":"0.0","last":"429.0","open":429.0,"vol":"0.0"}},"ethbtc":{"at":1527612757,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0","high":"0.0","last":"0.0","open":"0.0","vol":"0.0"}},"xrpbtc":{"at":1527612757,"ticker":{"buy":"0.0","sell":"0.05","low":"0.0","high":"0.0","last":"0.0","open":"0.0","vol":"0.0"}},"ltcbtc":{"at":1527612757,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0","high":"0.0","last":"0.0","open":"0.0","vol":"0.0"}},"dashbtc":{"at":1527612757,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0","high":"0.0","last":"0.0","open":"0.0","vol":"0.0"}},"bchbtc":{"at":1527612757,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0","high":"0.0","last":"0.0","open":"0.0","vol":"0.0"}},"btcusd":{"at":1527612757,"ticker":{"buy":"7300.0","sell":"7850.0","low":"7300.0","high":"7677.39","last":"7300.0","open":7471.27,"vol":"2.4968"}},"xrpusd":{"at":1527612757,"ticker":{"buy":"0.56","sell":"0.78","low":"0.57","high":"0.64","last":"0.58","open":0.59,"vol":"52991.0421"}}}'
+      encoding: UTF-8
+      string: '{"markets":[{"market":"btcxrp","timestamp":"2018-11-15T14:27:29.000Z","bid":12298.6949,"ask":12315.2709,"low":11981.4609,"high":13637.6022,"last":12313.7546,"open":12599.1684,"vol":584.69191041},{"market":"ethxrp","timestamp":"2018-11-15T14:27:29.000Z","bid":378.2662,"ask":392.4117,"low":375.7096,"high":418.8738,"last":392.19,"open":402.0647,"vol":1608.3017},{"market":"dashxrp","timestamp":"2018-11-15T14:27:29.000Z","bid":300.0986,"ask":301.3371,"low":298.4274,"high":331.961,"last":298.4274,"open":314.3018,"vol":1048.716},{"market":"ltcxrp","timestamp":"2018-11-15T14:27:29.000Z","bid":94.9947,"ask":95.3443,"low":91.9556,"high":102.2896,"last":95.3079,"open":97.6708,"vol":1672.30950085},{"market":"bchxrp","timestamp":"2018-11-15T14:27:29.000Z","bid":956.1276,"ask":956.2969,"low":913.4438,"high":1017.9158,"last":956.2123,"open":975.5053,"vol":669.731},{"market":"zecxrp","timestamp":"2018-11-15T14:27:29.000Z","bid":234.7585,"ask":235.1108,"low":231.1318,"high":265.4467,"last":234.9495,"open":246.3965,"vol":2081.207},{"market":"btgxrp","timestamp":"2018-11-15T14:27:29.000Z","bid":58.4224,"ask":58.5252,"low":54.424,"high":61.0377,"last":58.5971,"open":55.5483,"vol":11408.37},{"market":"zrxxrp","timestamp":"2018-11-15T14:27:29.000Z","bid":1.1679,"ask":1.17,"low":1.1397,"high":1.2669,"last":1.1697,"open":1.2186,"vol":2292115.4},{"market":"gntxrp","timestamp":"2018-11-15T14:27:29.000Z","bid":0.2761,"ask":0.2779,"low":0.2667,"high":0.3045,"last":0.277,"open":0.2924,"vol":8987294.6},{"market":"repxrp","timestamp":"2018-11-15T14:27:29.000Z","bid":24.135,"ask":24.1413,"low":23.3665,"high":27.3932,"last":24.1031,"open":25.3699,"vol":86800.685},{"market":"omgxrp","timestamp":"2018-11-15T14:27:29.000Z","bid":5.899,"ask":5.9091,"low":5.74,"high":6.4747,"last":5.9041,"open":6.1517,"vol":362467.07633246},{"market":"saltxrp","timestamp":"2018-11-15T14:27:29.000Z","bid":1.0627,"ask":1.0714,"low":1.0275,"high":1.1887,"last":1.0668,"open":1.1871,"vol":2936661.1},{"market":"batxrp","timestamp":"2018-11-15T14:27:29.000Z","bid":0.4315,"ask":0.4322,"low":0.4236,"high":0.4706,"last":0.4322,"open":0.4651,"vol":2715137.8},{"market":"zilxrp","timestamp":"2018-11-15T14:27:29.000Z","bid":0.0575,"ask":0.0578,"low":0.0562,"high":0.065,"last":0.0576,"open":0.0638,"vol":10380546.8},{"market":"xrpcad","timestamp":"2018-11-15T14:27:29.000Z","bid":0.577,"ask":0.5777,"low":0.5396,"high":0.6471,"last":0.591,"open":0.6458,"vol":2981374.14705052},{"market":"xrpusd","timestamp":"2018-11-15T14:27:29.000Z","bid":0.4372,"ask":0.4378,"low":0.4036,"high":0.502,"last":0.4374,"open":0.49,"vol":5830378.9067},{"market":"xrpeur","timestamp":"2018-11-15T14:27:29.000Z","bid":0.3847,"ask":0.3852,"low":0.3538,"high":0.4358,"last":0.3847,"open":0.4312,"vol":3472914.4889},{"market":"xrpgbp","timestamp":"2018-11-15T14:27:29.000Z","bid":0.3367,"ask":0.3369,"low":0.3112,"high":0.3888,"last":0.3367,"open":0.3773,"vol":2460718.7241},{"market":"xrpaed","timestamp":"2018-11-15T14:27:29.000Z","bid":1.6046,"ask":1.6068,"low":1.4765,"high":1.8151,"last":1.6059,"open":1.7994,"vol":1128889.468},{"market":"xrpjpy","timestamp":"2018-11-15T14:27:29.000Z","bid":49.67,"ask":49.74,"low":45.76,"high":55.87,"last":49.7,"open":55.82,"vol":2338098.0696},{"market":"btceur","timestamp":"2018-11-15T14:27:29.000Z","bid":4742.5,"ask":4744.17,"low":4666.68,"high":5510.66,"last":4742.76,"open":5446.67,"vol":413.7509},{"market":"etheur","timestamp":"2018-11-15T14:27:29.000Z","bid":151.03,"ask":151.21,"low":145.85,"high":173.83,"last":151.14,"open":173.7,"vol":1271.0441},{"market":"ltceur","timestamp":"2018-11-15T14:27:29.000Z","bid":36.7,"ask":36.72,"low":35.55,"high":42.64,"last":36.7,"open":42.31,"vol":1389.68},{"market":"btccad","timestamp":"2018-11-15T14:27:29.000Z","bid":7093.11,"ask":7120.99,"low":6912.28,"high":8210.67,"last":7114.07,"open":8167.62,"vol":408.30848135},{"market":"ethcad","timestamp":"2018-11-15T14:27:29.000Z","bid":226.54,"ask":226.8,"low":218.56,"high":263.05,"last":226.69,"open":260.64,"vol":1163.985},{"market":"ltccad","timestamp":"2018-11-15T14:27:29.000Z","bid":55.04,"ask":55.07,"low":52.92,"high":63.09,"last":55.03,"open":63.09,"vol":1123.09775036},{"market":"btcusd","timestamp":"2018-11-15T14:27:29.000Z","bid":5389.2,"ask":5389.6,"low":5332.69,"high":6232.3,"last":5390.49,"open":6189.5,"vol":796.8611},{"market":"ethusd","timestamp":"2018-11-15T14:27:29.000Z","bid":171.61,"ask":171.91,"low":165.7,"high":197.68,"last":171.01,"open":197.48,"vol":1492.4593},{"market":"ltcusd","timestamp":"2018-11-15T14:27:29.000Z","bid":41.69,"ask":41.74,"low":40.37,"high":48.85,"last":41.74,"open":48.04,"vol":2868.18}],"timestamp":"2018-11-15T14:27:29.217Z","took":"28ms"}'
     http_version: 
-  recorded_at: Tue, 29 May 2018 16:52:37 GMT
+  recorded_at: Thu, 15 Nov 2018 14:27:29 GMT
 recorded_with: VCR 4.0.0

--- a/spec/exchanges/coinfield/integration/market_spec.rb
+++ b/spec/exchanges/coinfield/integration/market_spec.rb
@@ -35,4 +35,21 @@ RSpec.describe 'Coinfield integration specs' do
     expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
+
+  it 'fetch order book' do
+    order_book = client.order_book(btc_cad_pair)
+
+    expect(order_book.base).to eq 'BTC'
+    expect(order_book.target).to eq 'CAD'
+    expect(order_book.market).to eq 'coinfield'
+    expect(order_book.asks).to_not be_empty
+    expect(order_book.bids).to_not be_empty
+    expect(order_book.asks.first.price).to_not be_nil
+    expect(order_book.bids.first.amount).to_not be_nil
+    expect(order_book.bids.first.timestamp).to_not be_nil
+    expect(order_book.asks.count).to be > 10
+    expect(order_book.bids.count).to be > 10
+    expect(order_book.timestamp).to be_a Numeric
+    expect(order_book.payload).to_not be nil
+  end
 end

--- a/spec/exchanges/coinfield/market_spec.rb
+++ b/spec/exchanges/coinfield/market_spec.rb
@@ -2,5 +2,5 @@ require 'spec_helper'
 
 RSpec.describe Cryptoexchange::Exchanges::Coinfield::Market do
   it { expect(described_class::NAME).to eq 'coinfield' }
-  it { expect(described_class::API_URL).to eq 'https://platform.coinfield.com/api/v2/' }
+  it { expect(described_class::API_URL).to eq 'https://api.coinfield.com/v1' }
 end


### PR DESCRIPTION
- Updated Pairs, Tickers, README and added OrderBook for Coinfield
- Closes: #1135 
- [X] I have added Specs
- [X] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [X] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [X] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
