### PR TITLE
Chaince Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Or install it yourself as:
 | CCex              | Y       |            |         |         | Y           |          | ccex              |
 | Cex               | Y       | Y          | Y       |         | Y           |          | cex               |
 | Cfinex            | Y       | Y          | Y       |         | Y           | Y        | cfinex            |
+| Chaince           | Y       |            |         |         | Y           | Y        | chaince           |
 | Chainrift         | Y       | Y          | Y       |         | Y           |          | chainrift         |
 | ChainEX           | Y       | Y          | Y       |         | Y           |          | chainex           |
 | Chaoex            | Y       | Y          | Y       |         | Y           | N        | chaoex            |

--- a/lib/cryptoexchange/exchanges/chaince/market.rb
+++ b/lib/cryptoexchange/exchanges/chaince/market.rb
@@ -1,0 +1,12 @@
+module Cryptoexchange::Exchanges
+  module Chaince
+    class Market < Cryptoexchange::Models::Market
+      NAME = 'chaince'
+      API_URL = 'https://api.chaince.com'
+
+      def self.trade_page_url(args={})
+        "https://chaince.com/trade/#{args[:base].downcase}#{args[:target].downcase}"
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/chaince/services/market.rb
+++ b/lib/cryptoexchange/exchanges/chaince/services/market.rb
@@ -1,0 +1,49 @@
+module Cryptoexchange::Exchanges
+  module Chaince
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            false
+          end
+        end
+
+        def fetch
+          output = super(ticker_url)
+          adapt_all(output)
+        end
+
+        def ticker_url
+          "#{Cryptoexchange::Exchanges::Chaince::Market::API_URL}/tickers"
+        end
+
+        def adapt_all(output)
+          output.map do |pair|
+            base, target = pair[0].split(/(eos)+(.*)|(usdt)+(.*)/).reject(&:empty?)
+            market_pair  = Cryptoexchange::Models::MarketPair.new(
+              base:   base,
+              target: target,
+              market: Chaince::Market::NAME
+            )
+            adapt(market_pair, pair[1])
+          end
+        end
+
+        def adapt(market_pair, output)
+          ticker           = Cryptoexchange::Models::Ticker.new
+          ticker.base      = market_pair.base
+          ticker.target    = market_pair.target
+          ticker.market    = Chaince::Market::NAME
+          ticker.last      = NumericHelper.to_d(output['price'])
+          ticker.high      = NumericHelper.to_d(output['high'])
+          ticker.low       = NumericHelper.to_d(output['low'])
+          ticker.volume    = NumericHelper.to_d(output['volume'])
+          ticker.change    = NumericHelper.to_d(output['change'])
+          ticker.timestamp = nil
+          ticker.payload   = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/chaince/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/chaince/services/order_book.rb
@@ -1,0 +1,42 @@
+module Cryptoexchange::Exchanges
+  module Coinasset
+    module Services
+      class OrderBook < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          "#{Cryptoexchange::Exchanges::Coinasset::Market::API_URL}/order-books?symbol=#{market_pair.base}-#{market_pair.target}"
+        end
+
+        def adapt(output, market_pair)
+          order_book = Cryptoexchange::Models::OrderBook.new
+
+          order_book.base      = market_pair.base
+          order_book.target    = market_pair.target
+          order_book.market    = Coinasset::Market::NAME
+          order_book.asks      = adapt_orders(output['asks'])
+          order_book.bids      = adapt_orders(output['bids'])
+          order_book.timestamp = nil
+          order_book.payload   = output
+          order_book
+        end
+
+        def adapt_orders(orders)
+          orders.collect do |order_entry|
+            Cryptoexchange::Models::Order.new(price: order_entry[0],
+                                              amount: order_entry[1])
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/chaince/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/chaince/services/pairs.rb
@@ -1,0 +1,23 @@
+module Cryptoexchange::Exchanges
+  module Chaince
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Chaince::Market::API_URL}/market/pairs"
+
+        def fetch
+          output = super
+          market_pairs = []
+          output.each do |pair|
+            base, target = pair[1]['full_code'].split('/')
+            market_pairs << Cryptoexchange::Models::MarketPair.new(
+                              base: base,
+                              target: target,
+                              market: Chaince::Market::NAME
+                            )
+          end
+          market_pairs
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/chaince/services/trades.rb
+++ b/lib/cryptoexchange/exchanges/chaince/services/trades.rb
@@ -1,0 +1,32 @@
+module Cryptoexchange::Exchanges
+  module Coinasset
+    module Services
+      class Trades < Cryptoexchange::Services::Market
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          "#{Cryptoexchange::Exchanges::Coinasset::Market::API_URL}/trades?symbol=#{market_pair.base}-#{market_pair.target}"
+        end
+
+        def adapt(output, market_pair)
+          output.collect do |trade|
+            tr = Cryptoexchange::Models::Trade.new
+            tr.trade_id  = trade['reference_id']
+            tr.base      = market_pair.base
+            tr.target    = market_pair.target
+            tr.market    = Coinasset::Market::NAME
+            tr.type      = trade['type']
+            tr.price     = trade['price']
+            tr.amount    = trade['amount']
+            tr.timestamp = trade['time']
+            tr.payload   = trade
+            tr
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/Chaince/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/Chaince/integration_specs_fetch_pairs.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.chaince.com/market/pairs
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.chaince.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 15 Nov 2018 15:57:43 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1403'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d646ff413c603ba915db34c22e638c8e01542297462; expires=Fri, 15-Nov-19
+        15:57:42 GMT; path=/; domain=.chaince.com; HttpOnly
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Accept-Ranges:
+      - bytes
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 47a2ea45accd69e3-LHR
+    body:
+      encoding: UTF-8
+      string: '{"bnteos":{"base_precision":3,"full_code":"BNT/EOS","quote_precision":4},"boideos":{"base_precision":1,"full_code":"BOID/EOS","quote_precision":6},"btceos":{"base_precision":6,"full_code":"BTC/EOS","quote_precision":1},"ceteos":{"base_precision":1,"full_code":"CET/EOS","quote_precision":4},"cetusdt":{"base_precision":1,"full_code":"CET/USDT","quote_precision":4},"ecasheos":{"base_precision":1,"full_code":"ECASH/EOS","quote_precision":5},"eosisheos":{"base_precision":1,"full_code":"EOSISH/EOS","quote_precision":5},"eosusdt":{"base_precision":2,"full_code":"EOS/USDT","quote_precision":2},"etheos":{"base_precision":5,"full_code":"ETH/EOS","quote_precision":1},"horuseos":{"base_precision":1,"full_code":"HORUS/EOS","quote_precision":5},"hvteos":{"base_precision":1,"full_code":"HVT/EOS","quote_precision":5},"iqeos":{"base_precision":1,"full_code":"IQ/EOS","quote_precision":5},"karmaeos":{"base_precision":1,"full_code":"KARMA/EOS","quote_precision":6},"meetoneeos":{"base_precision":1,"full_code":"MEETONE/EOS","quote_precision":5},"octeos":{"base_precision":2,"full_code":"OCT/EOS","quote_precision":4},"pubeos":{"base_precision":1,"full_code":"PUB/EOS","quote_precision":5},"rameos":{"base_precision":3,"full_code":"RAM/EOS","quote_precision":4},"trybeeos":{"base_precision":1,"full_code":"TRYBE/EOS","quote_precision":5},"zkseos":{"base_precision":1,"full_code":"ZKS/EOS","quote_precision":5}}'
+    http_version: 
+  recorded_at: Thu, 15 Nov 2018 15:57:43 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Chaince/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/Chaince/integration_specs_fetch_ticker.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.chaince.com/tickers
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.chaince.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 15 Nov 2018 16:03:53 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1901'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d1563417cdd1ab4ebcd582b4bcf8d5e861542297833; expires=Fri, 15-Nov-19
+        16:03:53 GMT; path=/; domain=.chaince.com; HttpOnly
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Accept-Ranges:
+      - bytes
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 47a2f350cf5569fb-LHR
+    body:
+      encoding: UTF-8
+      string: '{"bnteos":{"change":"-2.44%","high":"0.2460","low":"0.2211","price":"0.2400","volume":"11966.110"},"boideos":{"change":"0.00%","high":"0.000036","low":"0.000032","price":"0.000036","volume":"27686485.6"},"btceos":{"change":"1.65%","high":"1250.0","low":"1210.0","price":"1230.0","volume":"8.614211"},"ceteos":{"change":"-2.63%","high":"0.0039","low":"0.0037","price":"0.0037","volume":"9992896.6"},"cetusdt":{"change":"-13.54%","high":"0.0203","low":"0.0166","price":"0.0166","volume":"1497952.1"},"ecasheos":{"change":"0.00%","high":"0.00000","low":"0.00000","price":"0.00000","volume":"0.0"},"eosisheos":{"change":"-18.60%","high":"0.00258","low":"0.00210","price":"0.00210","volume":"1129417.5"},"eosusdt":{"change":"-7.14%","high":"4.90","low":"4.36","price":"4.55","volume":"172803.12"},"etheos":{"change":"0.00%","high":"40.0","low":"39.1","price":"39.2","volume":"224.37001"},"horuseos":{"change":"8.90%","high":"0.00233","low":"0.00173","price":"0.00208","volume":"2807106.3"},"hvteos":{"change":"-8.88%","high":"0.00230","low":"0.00195","price":"0.00195","volume":"2936024.5"},"iqeos":{"change":"-7.53%","high":"0.00149","low":"0.00132","price":"0.00135","volume":"10957242.3"},"karmaeos":{"change":"10.48%","high":"0.000348","low":"0.000295","price":"0.000348","volume":"17212822.1"},"meetoneeos":{"change":"-2.44%","high":"0.00041","low":"0.00039","price":"0.00040","volume":"11480829.5"},"octeos":{"change":"-7.56%","high":"0.0248","low":"0.0200","price":"0.0220","volume":"190985.13"},"pubeos":{"change":"10.98%","high":"0.00091","low":"0.00082","price":"0.00091","volume":"15202225.8"},"rameos":{"change":"-2.27%","high":"0.0880","low":"0.0860","price":"0.0860","volume":"1039.957"},"trybeeos":{"change":"-8.16%","high":"0.00294","low":"0.00270","price":"0.00270","volume":"688195.6"},"zkseos":{"change":"-27.27%","high":"0.00077","low":"0.00044","price":"0.00056","volume":"1601945.3"}}'
+    http_version: 
+  recorded_at: Thu, 15 Nov 2018 16:03:53 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/chaince/integration/market_spec.rb
+++ b/spec/exchanges/chaince/integration/market_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+RSpec.describe 'Chaince integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:eos_usdt_pair) { Cryptoexchange::Models::MarketPair.new(base: 'EOS', target: 'USDT', market: 'chaince') }
+
+  it 'has trade_page_url' do
+    trade_page_url = client.trade_page_url eos_usdt_pair.market, base: eos_usdt_pair.base, target: eos_usdt_pair.target
+    expect(trade_page_url).to eq "https://chaince.com/trade/eosusdt"
+  end
+
+  it 'fetch pairs' do
+    pairs = client.pairs('chaince')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.market).to eq 'chaince'
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(eos_usdt_pair)
+
+    expect(ticker.base).to eq 'EOS'
+    expect(ticker.target).to eq 'USDT'
+    expect(ticker.market).to eq 'chaince'
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.low).to be_a Numeric
+    expect(ticker.high).to be_a Numeric
+    expect(ticker.change).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+    expect(ticker.timestamp).to be nil
+    expect(ticker.payload).to_not be nil
+  end
+
+  # it 'fetch order book' do
+  #   order_book = client.order_book(eos_usdt_pair)
+  #
+  #   expect(order_book.base).to eq 'EOS'
+  #   expect(order_book.target).to eq 'USDT'
+  #   expect(order_book.market).to eq 'chaince'
+  #   expect(order_book.asks).to_not be_empty
+  #   expect(order_book.bids).to_not be_empty
+  #   expect(order_book.asks.first.price).to_not be_nil
+  #   expect(order_book.bids.first.amount).to_not be_nil
+  #   expect(order_book.bids.first.timestamp).to be_nil
+  #   expect(order_book.asks.count).to be > 5
+  #   expect(order_book.bids.count).to be > 5
+  #   expect(order_book.timestamp).to be nil
+  #   expect(order_book.payload).to_not be nil
+  # end
+  #
+  # it 'fetch trade' do
+  #   trades = client.trades(eos_usdt_pair)
+  #   trade = trades.sample
+  #
+  #   expect(trades).to_not be_empty
+  #   expect(trade.base).to eq 'EOS'
+  #   expect(trade.target).to eq 'USDT'
+  #   expect(trade.market).to eq 'chaince'
+  #   expect(trade.trade_id).to_not be_nil
+  #   expect(['buy', 'sell']).to include trade.type
+  #   expect(trade.price).to_not be_nil
+  #   expect(trade.amount).to_not be_nil
+  #   expect(trade.timestamp).to be_a Numeric
+  #   expect(2000..Date.today.year).to include(Time.at(trade.timestamp).year)
+  #   expect(trade.payload).to_not be nil
+  # end
+end

--- a/spec/exchanges/chaince/market_spec.rb
+++ b/spec/exchanges/chaince/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Chaince::Market do
+  it { expect(described_class::NAME).to eq 'chaince' }
+  it { expect(described_class::API_URL).to eq 'https://api.chaince.com' }
+end


### PR DESCRIPTION
- Add Pairs, Tickers, and updated README for Chaince
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [X] I have added Specs
- [X] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [X] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [X] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [X] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
