### PR TITLE
Cryptoexchange.ws Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Or install it yourself as:
 | CryptoBridge      | Y       |            |         |         | Y           | Y        | crypto_bridge     |
 | CryptoHub         | Y       | N          | N       |         | Y           |          | crypto_hub        |
 | Cryptobulls       | Y       | N          | N       |         | Y           |          | cryptobulls       |
+| Cryptoexchange.ws | Y       | Y          | Y       |         | Y           | Y        | cryptoexchange_ws |
 | Cryptology        | Y       |            |         |         | Y           |          | cryptology        |
 | Cryptonit         | Y       | Y          | Y       |         | Y           | Y        | cryptonit         |
 | Cryptopia         | Y       | Y          | Y       |         | Y           |          | cryptopia         |

--- a/lib/cryptoexchange/exchanges/cryptoexchange_ws/market.rb
+++ b/lib/cryptoexchange/exchanges/cryptoexchange_ws/market.rb
@@ -1,0 +1,12 @@
+module Cryptoexchange::Exchanges
+  module CryptoexchangeWs
+    class Market < Cryptoexchange::Models::Market
+      NAME = 'cryptoexchange_ws'
+      API_URL = 'https://cryptoexchange.ws/en/gateway'
+
+      def self.trade_page_url(args={})
+        "https://cryptoexchange.ws/en"
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/cryptoexchange_ws/services/market.rb
+++ b/lib/cryptoexchange/exchanges/cryptoexchange_ws/services/market.rb
@@ -1,0 +1,51 @@
+module Cryptoexchange::Exchanges
+  module CryptoexchangeWs
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            false
+          end
+        end
+
+        def fetch
+          output = super(ticker_url)
+          adapt_all(output)
+        end
+
+        def ticker_url
+          "#{Cryptoexchange::Exchanges::CryptoexchangeWs::Market::API_URL}/public/returnTicker"
+        end
+
+        def adapt_all(output)
+          output['results'].map do |pair|
+            base, target = pair[0].split('-')
+            market_pair  = Cryptoexchange::Models::MarketPair.new(
+              base:   base,
+              target: target,
+              market: CryptoexchangeWs::Market::NAME
+            )
+            adapt(market_pair, pair[1])
+          end
+        end
+
+        def adapt(market_pair, output)
+          ticker           = Cryptoexchange::Models::Ticker.new
+          ticker.base      = market_pair.base
+          ticker.target    = market_pair.target
+          ticker.market    = CryptoexchangeWs::Market::NAME
+          ticker.last      = NumericHelper.to_d(output['last'])
+          ticker.high      = NumericHelper.to_d(output['high24hr'])
+          ticker.low       = NumericHelper.to_d(output['low24hr'])
+          ticker.bid       = NumericHelper.to_d(output['highestBid'])
+          ticker.ask       = NumericHelper.to_d(output['lowestAsk'])
+          ticker.volume    = NumericHelper.to_d(output['volume24hr'])
+          ticker.change    = NumericHelper.to_d(output['changePrice'])
+          ticker.timestamp = nil
+          ticker.payload   = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/cryptoexchange_ws/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/cryptoexchange_ws/services/order_book.rb
@@ -1,0 +1,42 @@
+module Cryptoexchange::Exchanges
+  module CryptoexchangeWs
+    module Services
+      class OrderBook < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = fetch_using_post(ticker_url(market_pair), {"market": "#{market_pair.base}-#{market_pair.target}", "count": 50})
+          adapt(output['results'], market_pair)
+        end
+
+        def ticker_url(market_pair)
+          "#{Cryptoexchange::Exchanges::CryptoexchangeWs::Market::API_URL}/public/bestOffer"
+        end
+
+        def adapt(output, market_pair)
+          order_book = Cryptoexchange::Models::OrderBook.new
+
+          order_book.base      = market_pair.base
+          order_book.target    = market_pair.target
+          order_book.market    = CryptoexchangeWs::Market::NAME
+          order_book.asks      = adapt_orders(output['ask'])
+          order_book.bids      = adapt_orders(output['bid'])
+          order_book.timestamp = nil
+          order_book.payload   = output
+          order_book
+        end
+
+        def adapt_orders(orders)
+          orders.collect do |order_entry|
+            Cryptoexchange::Models::Order.new(price: order_entry[0],
+                                              amount: order_entry[1])
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/cryptoexchange_ws/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/cryptoexchange_ws/services/pairs.rb
@@ -1,0 +1,23 @@
+module Cryptoexchange::Exchanges
+  module CryptoexchangeWs
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::CryptoexchangeWs::Market::API_URL}/public/returnTicker"
+
+        def fetch
+          output = super
+          market_pairs = []
+          output['results'].each do |pair|
+            base, target = pair[0].split('-')
+            market_pairs << Cryptoexchange::Models::MarketPair.new(
+                              base: base,
+                              target: target,
+                              market: CryptoexchangeWs::Market::NAME
+                            )
+          end
+          market_pairs
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/cryptoexchange_ws/services/trades.rb
+++ b/lib/cryptoexchange/exchanges/cryptoexchange_ws/services/trades.rb
@@ -1,0 +1,31 @@
+module Cryptoexchange::Exchanges
+  module CryptoexchangeWs
+    module Services
+      class Trades < Cryptoexchange::Services::Market
+        def fetch(market_pair)
+          output = fetch_using_post(ticker_url(market_pair), {"market": "#{market_pair.base}-#{market_pair.target}", "count": 50})
+          adapt(output['results'], market_pair)
+        end
+
+        def ticker_url(market_pair)
+          "#{Cryptoexchange::Exchanges::CryptoexchangeWs::Market::API_URL}/public/lastTrades"
+        end
+
+        def adapt(output, market_pair)
+          output.collect do |trade|
+            tr = Cryptoexchange::Models::Trade.new
+            tr.base      = market_pair.base
+            tr.target    = market_pair.target
+            tr.market    = CryptoexchangeWs::Market::NAME
+            tr.type      = trade['type'] == 1 ? 'buy' : 'sell'
+            tr.price     = trade['rate']
+            tr.amount    = trade['nominal']
+            tr.timestamp = trade['time']/1000
+            tr.payload   = trade
+            tr
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/Cryptoexchange/ws/integration_specs_fetch_order_book.yml
+++ b/spec/cassettes/vcr_cassettes/Cryptoexchange/ws/integration_specs_fetch_order_book.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://cryptoexchange.ws/en/gateway/public/bestOffer
+    body:
+      encoding: UTF-8
+      string: '{"market":"ETH-BTC","count":50}'
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=UTF-8
+      Host:
+      - cryptoexchange.ws
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 25 Nov 2018 10:17:45 GMT
+      Server:
+      - Apache/2.4.10 (Debian)
+      Strict-Transport-Security:
+      - max-age=15768000
+      Cache-Control:
+      - no-cache, max-age=0
+      Vary:
+      - Accept-Encoding
+      Expires:
+      - Sun, 25 Nov 2018 10:17:45 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+      Connection:
+      - close
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/html; charset=UTF-8
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"missing_authenticators":[],"infos":[],"warnings":[],"errors":[],"results":{"bid":[[0.02953174,3.0391],[0.02949791,5.2889],[0.02946493,2.9699]],"ask":[[0.02972702,6.5867]],"lastQuote":0.0297051,"rate24h":0.03001027,"current_rates":[]}}'
+    http_version: 
+  recorded_at: Sun, 25 Nov 2018 10:17:45 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Cryptoexchange/ws/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/Cryptoexchange/ws/integration_specs_fetch_pairs.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://cryptoexchange.ws/en/gateway/public/returnTicker
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - cryptoexchange.ws
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 25 Nov 2018 09:38:19 GMT
+      Server:
+      - Apache/2.4.10 (Debian)
+      Strict-Transport-Security:
+      - max-age=15768000
+      Cache-Control:
+      - no-cache, max-age=0
+      Vary:
+      - Accept-Encoding
+      Expires:
+      - Sun, 25 Nov 2018 09:38:19 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+      Connection:
+      - close
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/html; charset=UTF-8
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"missing_authenticators":[],"infos":[],"warnings":[],"errors":[],"results":{"DASH-EUR":{"last":77.2147586,"lowestAsk":76.94896758,"highestBid":75.42522564,"changePrice":0,"changeTrade":3.58253839,"volume24hr":67.9540044,"high24hr":91.25860299,"low24hr":74.48646578},"DOGE-EUR":{"last":0.00187901,"lowestAsk":0.00197739,"highestBid":0.00190175,"changePrice":0,"changeTrade":564062.64727822,"volume24hr":2301076.3992307,"high24hr":0.00217711,"low24hr":0.00184394},"ETH-EUR":{"last":92.42723039,"lowestAsk":91.92779969,"highestBid":91.74412777,"changePrice":0,"changeTrade":9.589564,"volume24hr":95.47397512,"high24hr":108.47821419,"low24hr":91.88957376},"ETH-BTC":{"last":0.02978865,"lowestAsk":0.02980703,"highestBid":0.02958422,"changePrice":0,"changeTrade":37.09365488,"volume24hr":272.58927207,"high24hr":0.03102292,"low24hr":0.0297241},"LTC-EUR":{"last":25.09149535,"lowestAsk":25.09149535,"highestBid":24.56980352,"changePrice":0,"changeTrade":14.43330779,"volume24hr":45.4585875,"high24hr":28.85377254,"low24hr":24.41761297},"BTC-EUR":{"last":3205.04425,"lowestAsk":3237.25575,"highestBid":3184.4179,"changePrice":0,"changeTrade":16.41272935,"volume24hr":52.16596205,"high24hr":3835.58316883,"low24hr":3176.673417},"ITL-EUR":{"last":2.31e-5,"lowestAsk":2.31e-5,"highestBid":2.09e-5,"changePrice":2.2e-6,"changeTrade":215771570.81379,"volume24hr":393789020.72986,"high24hr":2.674e-5,"low24hr":2.09e-5},"DASH-BTC":{"last":0.02353549,"lowestAsk":0.02401107,"highestBid":0.02353549,"changePrice":0,"changeTrade":15.7707045,"volume24hr":133.92092938,"high24hr":0.02498332,"low24hr":0.02305794},"DOGE-BTC":{"last":5.7e-7,"lowestAsk":7.9e-7,"highestBid":5.7e-7,"changePrice":3.0e-8,"changeTrade":68582.75597771,"volume24hr":1093016.784325,"high24hr":5.8e-7,"low24hr":5.1e-7},"LTC-BTC":{"last":0.00770721,"lowestAsk":0.009,"highestBid":0.0077047,"changePrice":0.00015934,"changeTrade":8.3845519,"volume24hr":32.10384632,"high24hr":0.00777161,"low24hr":0.00744931},"ITL-BTC":{"last":0,"lowestAsk":2.0e-8,"highestBid":0,"changePrice":0,"changeTrade":0,"volume24hr":0,"high24hr":0,"low24hr":0},"ITL-DASH":{"last":0,"lowestAsk":9.0e-8,"highestBid":6.0e-8,"changePrice":0,"changeTrade":0,"volume24hr":0,"high24hr":0,"low24hr":0},"ITL-DOGE":{"last":0.00693,"lowestAsk":0.00707,"highestBid":0.00693,"changePrice":0,"changeTrade":0,"volume24hr":5520298.1085364,"high24hr":0.00707,"low24hr":0.00679209},"ITL-ETH":{"last":0,"lowestAsk":1.4e-7,"highestBid":4.0e-8,"changePrice":0,"changeTrade":0,"volume24hr":0,"high24hr":0,"low24hr":0},"ITL-LTC":{"last":0,"lowestAsk":4.5e-7,"highestBid":1.5e-7,"changePrice":0,"changeTrade":0,"volume24hr":0,"high24hr":0,"low24hr":0},"DASH-ETH":{"last":0.82087107,"lowestAsk":0.82199331,"highestBid":0.80894579,"changePrice":0.01314504,"changeTrade":0.36812172,"volume24hr":9.27174276,"high24hr":0.82834539,"low24hr":0.79317344},"DOGE-ETH":{"last":2.047e-5,"lowestAsk":2.116e-5,"highestBid":2.108e-5,"changePrice":1.45e-6,"changeTrade":248696.96924454,"volume24hr":1295482.4246838,"high24hr":2.099e-5,"low24hr":1.847e-5},"DOGE-LTC":{"last":7.797e-5,"lowestAsk":7.932e-5,"highestBid":7.598e-5,"changePrice":6.16e-6,"changeTrade":82757.90869037,"volume24hr":474202.04225587,"high24hr":7.891e-5,"low24hr":6.893e-5},"DOGE-DASH":{"last":2.538e-5,"lowestAsk":2.577e-5,"highestBid":2.477e-5,"changePrice":1.71e-6,"changeTrade":68641.01304472,"volume24hr":885379.98918119,"high24hr":2.618e-5,"low24hr":2.221e-5},"LTC-DASH":{"last":0.32560716,"lowestAsk":0.32640198,"highestBid":0.32430734,"changePrice":0.00906461,"changeTrade":1.11507482,"volume24hr":12.52977963,"high24hr":0.33309584,"low24hr":0.31109626},"LTC-ETH":{"last":0.26577734,"lowestAsk":0.27077819,"highestBid":0.26674675,"changePrice":0.00754552,"changeTrade":1.45520071,"volume24hr":12.03162791,"high24hr":0.2722601,"low24hr":0.25307348},"Ethos-EUR":{"last":0.09637931,"lowestAsk":0,"highestBid":0.09407905,"changePrice":0,"changeTrade":0,"volume24hr":16053.92803368,"high24hr":0.13038879,"low24hr":0.09095291},"Ethos-BTC":{"last":3.001e-5,"lowestAsk":5.1e-5,"highestBid":2.958e-5,"changePrice":0,"changeTrade":0,"volume24hr":2977.48062522,"high24hr":3.316e-5,"low24hr":2.911e-5},"Ethos-ETH":{"last":0.00106667,"lowestAsk":0.00106667,"highestBid":0.00104555,"changePrice":0,"changeTrade":340.69876215,"volume24hr":10746.77243004,"high24hr":0.00120367,"low24hr":0.00100682},"Ethos-DASH":{"last":0.0012603,"lowestAsk":0.00128576,"highestBid":0.0012603,"changePrice":0,"changeTrade":0,"volume24hr":2256.50326842,"high24hr":0.00144563,"low24hr":0.00124432},"Ethos-LTC":{"last":0.0040172,"lowestAsk":0.00394708,"highestBid":0.00386892,"changePrice":0,"changeTrade":183.54896544,"volume24hr":5496.85278009,"high24hr":0.00455427,"low24hr":0.0037382}}}'
+    http_version: 
+  recorded_at: Sun, 25 Nov 2018 09:38:19 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Cryptoexchange/ws/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/Cryptoexchange/ws/integration_specs_fetch_ticker.yml
@@ -1,0 +1,46 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://cryptoexchange.ws/en/gateway/public/returnTicker
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - cryptoexchange.ws
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 25 Nov 2018 09:47:33 GMT
+      Server:
+      - Apache/2.4.10 (Debian)
+      Strict-Transport-Security:
+      - max-age=15768000
+      Cache-Control:
+      - no-cache, max-age=0
+      Vary:
+      - Accept-Encoding
+      Expires:
+      - Sun, 25 Nov 2018 09:47:33 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+      Connection:
+      - close
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/html; charset=UTF-8
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"missing_authenticators":[],"infos":[],"warnings":[],"errors":[],"results":{"DASH-EUR":{"last":76.80521765,"lowestAsk":76.71252709,"highestBid":75.19346715,"changePrice":0,"changeTrade":3.62583812,"volume24hr":68.15141931,"high24hr":91.25860299,"low24hr":74.48646578},"DOGE-EUR":{"last":0.00192253,"lowestAsk":0.00192253,"highestBid":0.00184375,"changePrice":0,"changeTrade":531908.05487964,"volume24hr":2287426.1190176,"high24hr":0.00217711,"low24hr":0.00184394},"ETH-EUR":{"last":91.27401853,"lowestAsk":91.31228341,"highestBid":91.12984129,"changePrice":0,"changeTrade":9.34610223,"volume24hr":95.21091764,"high24hr":108.47821419,"low24hr":91.27401853},"ETH-BTC":{"last":0.02964835,"lowestAsk":0.02980976,"highestBid":0.02966108,"changePrice":0,"changeTrade":34.49886906,"volume24hr":271.51707076,"high24hr":0.03102292,"low24hr":0.02964337},"LTC-EUR":{"last":25.09149535,"lowestAsk":25.09149535,"highestBid":24.47789545,"changePrice":0,"changeTrade":14.32749722,"volume24hr":45.49075276,"high24hr":28.85377254,"low24hr":24.41761297},"BTC-EUR":{"last":3184.4179,"lowestAsk":3237.25575,"highestBid":3195.89025,"changePrice":0,"changeTrade":16.30810038,"volume24hr":52.0687528,"high24hr":3827.99475,"low24hr":3173.07393361},"ITL-EUR":{"last":2.31e-5,"lowestAsk":2.31e-5,"highestBid":2.09e-5,"changePrice":0,"changeTrade":206276698.12449,"volume24hr":388891298.10012,"high24hr":2.674e-5,"low24hr":2.09e-5},"DASH-BTC":{"last":0.02354257,"lowestAsk":0.02402637,"highestBid":0.02353338,"changePrice":0,"changeTrade":15.34261336,"volume24hr":133.59944026,"high24hr":0.02498332,"low24hr":0.02305794},"DOGE-BTC":{"last":5.7e-7,"lowestAsk":7.9e-7,"highestBid":5.7e-7,"changePrice":3.0e-8,"changeTrade":70176.32173742,"volume24hr":1094610.3500847,"high24hr":5.8e-7,"low24hr":5.1e-7},"LTC-BTC":{"last":0.007708,"lowestAsk":0.009,"highestBid":0.00762056,"changePrice":0.00016013,"changeTrade":8.18063879,"volume24hr":32.03984061,"high24hr":0.00777161,"low24hr":0.00744931},"ITL-BTC":{"last":0,"lowestAsk":2.0e-8,"highestBid":0,"changePrice":0,"changeTrade":0,"volume24hr":0,"high24hr":0,"low24hr":0},"ITL-DASH":{"last":0,"lowestAsk":9.0e-8,"highestBid":6.0e-8,"changePrice":0,"changeTrade":0,"volume24hr":0,"high24hr":0,"low24hr":0},"ITL-DOGE":{"last":0.00707,"lowestAsk":0.00707,"highestBid":0.00693,"changePrice":0.00014,"changeTrade":0,"volume24hr":5513274.527609,"high24hr":0.00707,"low24hr":0.00679209},"ITL-ETH":{"last":0,"lowestAsk":1.4e-7,"highestBid":4.0e-8,"changePrice":0,"changeTrade":0,"volume24hr":0,"high24hr":0,"low24hr":0},"ITL-LTC":{"last":0,"lowestAsk":4.5e-7,"highestBid":1.5e-7,"changePrice":0,"changeTrade":0,"volume24hr":0,"high24hr":0,"low24hr":0},"DASH-ETH":{"last":0.80902185,"lowestAsk":0.82207059,"highestBid":0.80902185,"changePrice":0,"changeTrade":0.35235307,"volume24hr":9.25352161,"high24hr":0.82834539,"low24hr":0.79317344},"DOGE-ETH":{"last":2.064e-5,"lowestAsk":2.065e-5,"highestBid":2.057e-5,"changePrice":1.27e-6,"changeTrade":237777.03704433,"volume24hr":1288031.8567744,"high24hr":2.099e-5,"low24hr":1.847e-5},"DOGE-LTC":{"last":7.797e-5,"lowestAsk":7.719e-5,"highestBid":7.491e-5,"changePrice":5.39e-6,"changeTrade":75396.57828595,"volume24hr":470521.37705366,"high24hr":7.891e-5,"low24hr":6.893e-5},"DOGE-DASH":{"last":2.538e-5,"lowestAsk":2.51e-5,"highestBid":2.446e-5,"changePrice":1.71e-6,"changeTrade":68641.01304472,"volume24hr":885379.98918119,"high24hr":2.618e-5,"low24hr":2.221e-5},"LTC-DASH":{"last":0.32640198,"lowestAsk":0.32618327,"highestBid":0.32488115,"changePrice":0.0097396,"changeTrade":1.2573373,"volume24hr":12.6621164,"high24hr":0.33309584,"low24hr":0.31109626},"LTC-ETH":{"last":0.26664254,"lowestAsk":0.27053639,"highestBid":0.26650855,"changePrice":0.00887224,"changeTrade":1.38194083,"volume24hr":12.01343225,"high24hr":0.2722601,"low24hr":0.25307348},"Ethos-EUR":{"last":0.09380307,"lowestAsk":0,"highestBid":0.09391656,"changePrice":0,"changeTrade":0,"volume24hr":15919.11491556,"high24hr":0.13038879,"low24hr":0.09095291},"Ethos-BTC":{"last":3.001e-5,"lowestAsk":5.1e-5,"highestBid":2.965e-5,"changePrice":0,"changeTrade":0,"volume24hr":2938.15633762,"high24hr":3.316e-5,"low24hr":2.911e-5},"Ethos-ETH":{"last":0.00107116,"lowestAsk":0.001072,"highestBid":0.00104994,"changePrice":0,"changeTrade":294.02255519,"volume24hr":10724.29827799,"high24hr":0.00120367,"low24hr":0.00100682},"Ethos-DASH":{"last":0.00128439,"lowestAsk":0.0012875,"highestBid":0.001262,"changePrice":0,"changeTrade":0,"volume24hr":2271.80190268,"high24hr":0.00144563,"low24hr":0.00124432},"Ethos-LTC":{"last":0.0040172,"lowestAsk":0.00395506,"highestBid":0.00387674,"changePrice":0,"changeTrade":124.40253091,"volume24hr":5450.20448384,"high24hr":0.00455427,"low24hr":0.0037382}}}'
+    http_version: 
+  recorded_at: Sun, 25 Nov 2018 09:47:33 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Cryptoexchange/ws/integration_specs_fetch_trade.yml
+++ b/spec/cassettes/vcr_cassettes/Cryptoexchange/ws/integration_specs_fetch_trade.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://cryptoexchange.ws/en/gateway/public/lastTrades
+    body:
+      encoding: UTF-8
+      string: '{"market":"ETH-BTC","count":50}'
+    headers:
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=UTF-8
+      Host:
+      - cryptoexchange.ws
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 25 Nov 2018 10:33:27 GMT
+      Server:
+      - Apache/2.4.10 (Debian)
+      Strict-Transport-Security:
+      - max-age=15768000
+      Cache-Control:
+      - no-cache, max-age=0
+      Vary:
+      - Accept-Encoding
+      Expires:
+      - Sun, 25 Nov 2018 10:33:27 GMT
+      X-Frame-Options:
+      - SAMEORIGIN
+      Connection:
+      - close
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/html; charset=UTF-8
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"missing_authenticators":[],"infos":[],"warnings":[],"errors":[],"results":[{"time":1543141836000,"type":2,"nominal":0.2558284,"rate":0.02974419,"price":0.00760941},{"time":1543141685000,"type":1,"nominal":0.35404838,"rate":0.02989329,"price":0.01058367},{"time":1543141469000,"type":2,"nominal":0.39142551,"rate":0.02961149,"price":0.01159069},{"time":1543141257000,"type":1,"nominal":0.4383275,"rate":0.02974734,"price":0.01303908},{"time":1543141149000,"type":2,"nominal":0.3240834,"rate":0.02959376,"price":0.00959085},{"time":1543140985000,"type":1,"nominal":0.4064452,"rate":0.0297051,"price":0.0120735},{"time":1543140900000,"type":1,"nominal":0.46313067,"rate":0.0297051,"price":0.01375734},{"time":1543140198000,"type":2,"nominal":0.22729686,"rate":0.02960484,"price":0.00672909},{"time":1543140147000,"type":2,"nominal":0.23777535,"rate":0.02961836,"price":0.00704252},{"time":1543140088000,"type":1,"nominal":0.17179896,"rate":0.02978485,"price":0.00511701},{"time":1543140000000,"type":2,"nominal":0.17235412,"rate":0.02961669,"price":0.00510456},{"time":1543139846000,"type":2,"nominal":0.47249741,"rate":0.02963853,"price":0.01400413},{"time":1543139711000,"type":1,"nominal":0.31473033,"rate":0.02978709,"price":0.0093749},{"time":1543139660000,"type":1,"nominal":0.35699045,"rate":0.02981752,"price":0.01064457},{"time":1543139610000,"type":2,"nominal":0.44305826,"rate":0.02964491,"price":0.01313442},{"time":1543139498000,"type":2,"nominal":0.21614108,"rate":0.02964491,"price":0.00640748},{"time":1543139464000,"type":2,"nominal":0.2957608,"rate":0.02964491,"price":0.0087678},{"time":1543139328000,"type":1,"nominal":0.28014312,"rate":0.02980976,"price":0.008351},{"time":1543139294000,"type":2,"nominal":0.2480859,"rate":0.02966108,"price":0.0073585},{"time":1543139260000,"type":1,"nominal":0.44879316,"rate":0.02980976,"price":0.01337842},{"time":1543139087000,"type":2,"nominal":0.37728281,"rate":0.02964835,"price":0.01118581},{"time":1543138945000,"type":1,"nominal":0.18225449,"rate":0.02980703,"price":0.00543247},{"time":1543138785000,"type":2,"nominal":0.22592255,"rate":0.02964337,"price":0.00669711},{"time":1543138750000,"type":2,"nominal":0.21484034,"rate":0.02964337,"price":0.00636859},{"time":1543138645000,"type":1,"nominal":0.19731013,"rate":0.02980703,"price":0.00588123},{"time":1543138131000,"type":2,"nominal":0.46597501,"rate":0.02978865,"price":0.01388077},{"time":1543138077000,"type":2,"nominal":0.37161525,"rate":0.02979579,"price":0.01107257},{"time":1543137924000,"type":2,"nominal":0.27739429,"rate":0.02977398,"price":0.00825913},{"time":1543137870000,"type":1,"nominal":0.15588256,"rate":0.02992322,"price":0.00466451},{"time":1543137818000,"type":1,"nominal":0.34067797,"rate":0.02992425,"price":0.01019453},{"time":1543137604000,"type":1,"nominal":0.41136593,"rate":0.02992092,"price":0.01230845},{"time":1543137552000,"type":1,"nominal":0.46077241,"rate":0.02996753,"price":0.01380821},{"time":1543137400000,"type":1,"nominal":0.33542257,"rate":0.02996753,"price":0.01005179},{"time":1543137326000,"type":2,"nominal":0.41200208,"rate":0.0297241,"price":0.01224639},{"time":1543137169000,"type":1,"nominal":0.16017723,"rate":0.02996753,"price":0.00480012},{"time":1543136997000,"type":2,"nominal":0.34039204,"rate":0.02980339,"price":0.01014484},{"time":1543136948000,"type":1,"nominal":0.31915023,"rate":0.02995884,"price":0.00956137},{"time":1543136806000,"type":1,"nominal":0.49534516,"rate":0.03003374,"price":0.01487707},{"time":1543136745000,"type":2,"nominal":0.48389094,"rate":0.02980339,"price":0.01442159},{"time":1543136615000,"type":1,"nominal":0.47004054,"rate":0.02994542,"price":0.01407556},{"time":1543136264000,"type":1,"nominal":0.29537909,"rate":0.03001503,"price":0.00886581},{"time":1543135979000,"type":1,"nominal":0.29761051,"rate":0.03001503,"price":0.00893279},{"time":1543135862000,"type":2,"nominal":0.21632485,"rate":0.02978983,"price":0.00644428},{"time":1543135768000,"type":1,"nominal":0.15064508,"rate":0.02994018,"price":0.00451034},{"time":1543135544000,"type":2,"nominal":0.22717836,"rate":0.02980023,"price":0.00676997},{"time":1543135457000,"type":2,"nominal":0.26538154,"rate":0.02980062,"price":0.00790853},{"time":1543135164000,"type":1,"nominal":0.16361,"rate":0.0300316,"price":0.00491347},{"time":1543135112000,"type":2,"nominal":0.31427998,"rate":0.02980062,"price":0.00936574},{"time":1543135021000,"type":2,"nominal":0.37847863,"rate":0.02980585,"price":0.01128088},{"time":1543134959000,"type":2,"nominal":0.18527725,"rate":0.02980585,"price":0.00552235}]}'
+    http_version: 
+  recorded_at: Sun, 25 Nov 2018 10:33:27 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/cryptoexchange_ws/integration/market_spec.rb
+++ b/spec/exchanges/cryptoexchange_ws/integration/market_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+RSpec.describe 'Cryptoexchange.ws integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:eth_btc_pair) { Cryptoexchange::Models::MarketPair.new(base: 'ETH', target: 'BTC', market: 'cryptoexchange_ws') }
+
+  it 'has trade_page_url' do
+    trade_page_url = client.trade_page_url eth_btc_pair.market, base: eth_btc_pair.base, target: eth_btc_pair.target
+    expect(trade_page_url).to eq "https://cryptoexchange.ws/en"
+  end
+
+  it 'fetch pairs' do
+    pairs = client.pairs('cryptoexchange_ws')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.market).to eq 'cryptoexchange_ws'
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(eth_btc_pair)
+
+    expect(ticker.base).to eq 'ETH'
+    expect(ticker.target).to eq 'BTC'
+    expect(ticker.market).to eq 'cryptoexchange_ws'
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.low).to be_a Numeric
+    expect(ticker.high).to be_a Numeric
+    expect(ticker.bid).to be_a Numeric
+    expect(ticker.ask).to be_a Numeric
+    expect(ticker.change).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+    expect(ticker.timestamp).to be nil
+    expect(ticker.payload).to_not be nil
+  end
+
+  it 'fetch order book' do
+    order_book = client.order_book(eth_btc_pair)
+
+    expect(order_book.base).to eq 'ETH'
+    expect(order_book.target).to eq 'BTC'
+    expect(order_book.market).to eq 'cryptoexchange_ws'
+    expect(order_book.asks).to_not be_empty
+    expect(order_book.bids).to_not be_empty
+    expect(order_book.asks.first.price).to_not be_nil
+    expect(order_book.bids.first.amount).to_not be_nil
+    expect(order_book.bids.first.timestamp).to be_nil
+    expect(order_book.asks.count).to be > 0
+    expect(order_book.bids.count).to be > 0
+    expect(order_book.timestamp).to be nil
+    expect(order_book.payload).to_not be nil
+  end
+
+  it 'fetch trade' do
+    trades = client.trades(eth_btc_pair)
+    trade = trades.sample
+
+    expect(trades).to_not be_empty
+    expect(trade.base).to eq 'ETH'
+    expect(trade.target).to eq 'BTC'
+    expect(trade.market).to eq 'cryptoexchange_ws'
+    expect(['buy', 'sell']).to include trade.type
+    expect(trade.price).to_not be_nil
+    expect(trade.amount).to_not be_nil
+    expect(trade.timestamp).to be_a Numeric
+    expect(2000..Date.today.year).to include(Time.at(trade.timestamp).year)
+    expect(trade.payload).to_not be nil
+  end
+end

--- a/spec/exchanges/cryptoexchange_ws/market_spec.rb
+++ b/spec/exchanges/cryptoexchange_ws/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::CryptoexchangeWs::Market do
+  it { expect(described_class::NAME).to eq 'cryptoexchange_ws' }
+  it { expect(described_class::API_URL).to eq 'https://cryptoexchange.ws/en/gateway' }
+end


### PR DESCRIPTION
- Add Pairs, Tickers, OrderBook, Trades, Trade URL and updated README for Cryptoexchange.ws
- Closes: #1170 
- [X] I have added Specs
- [X] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [X] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [X] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [X] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
