### PR TITLE
Stinex Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Or install it yourself as:
 | Singularx         | Y       | N          | N       |         | Y           |          | singularx         |
 | Sistemkoin        | Y       |            |         |         | Y           |          | sistemkoin        |
 | SouthXchange      | Y       | Y          | Y       |         | Y           | Y        | south_xchange     |
+| Stinex            | Y       | Y          | Y       |         | Y           | Y        | stinex            |
 | Stocks Exchange   | Y       |            |         |         | Y           | Y        | stocks_exchange   |
 | Switcheo          | Y       | N          | N       |         | Y           | Y        | switcheo          |
 | Syex              | Y       | N          | N       |         | Y           | Y        | syex              |

--- a/lib/cryptoexchange/exchanges/stinex/market.rb
+++ b/lib/cryptoexchange/exchanges/stinex/market.rb
@@ -1,0 +1,12 @@
+module Cryptoexchange::Exchanges
+  module Stinex
+    class Market < Cryptoexchange::Models::Market
+      NAME = 'stinex'
+      API_URL = 'https://api.stinex.net/api/v2'
+
+      def self.trade_page_url(args={})
+        "https://api.stinex.net/trading/#{args[:base].downcase}#{args[:target].downcase}"
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/stinex/services/market.rb
+++ b/lib/cryptoexchange/exchanges/stinex/services/market.rb
@@ -1,0 +1,38 @@
+module Cryptoexchange::Exchanges
+  module Stinex
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          "#{Cryptoexchange::Exchanges::Stinex::Market::API_URL}/tickers/#{market_pair.base.downcase}#{market_pair.target.downcase}"
+        end
+
+        def adapt(output, market_pair)
+          ticker = Cryptoexchange::Models::Ticker.new
+          ticker.base = market_pair.base
+          ticker.target = market_pair.target
+          ticker.market = Stinex::Market::NAME
+          ticker.ask = NumericHelper.to_d(output['ticker']['sell'])
+          ticker.bid = NumericHelper.to_d(output['ticker']['buy'])
+          ticker.last = NumericHelper.to_d(output['ticker']['last'])
+          ticker.high = NumericHelper.to_d(output['ticker']['high'])
+          ticker.low = NumericHelper.to_d(output['ticker']['low'])
+          ticker.volume = NumericHelper.to_d(output['ticker']['vol'])
+          ticker.timestamp = output['at']
+          ticker.payload = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/stinex/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/stinex/services/order_book.rb
@@ -1,0 +1,44 @@
+module Cryptoexchange::Exchanges
+  module Stinex
+    module Services
+      class OrderBook < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          "#{Cryptoexchange::Exchanges::Stinex::Market::API_URL}/order_book?market=#{market_pair.base.downcase}#{market_pair.target.downcase}"
+        end
+
+        def adapt(output, market_pair)
+          order_book = Cryptoexchange::Models::OrderBook.new
+          timestamp = Time.now.to_i
+
+          order_book.base      = market_pair.base
+          order_book.target    = market_pair.target
+          order_book.market    = Stinex::Market::NAME
+          order_book.asks      = adapt_orders(output['asks'])
+          order_book.bids      = adapt_orders(output['bids'])
+          order_book.timestamp = timestamp
+          order_book.payload   = output
+          order_book
+        end
+
+        def adapt_orders(orders)
+          orders.collect do |order_entry|
+            Cryptoexchange::Models::Order.new(price: order_entry['price'],
+                                              amount: order_entry['volume'],
+                                              timestamp: DateTime.parse(order_entry['created_at']).to_time.to_i)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/stinex/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/stinex/services/pairs.rb
@@ -1,0 +1,23 @@
+module Cryptoexchange::Exchanges
+  module Stinex
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Stinex::Market::API_URL}/markets"
+
+        def fetch
+          output = super
+          market_pairs = []
+          output.each do |pair|
+            base, target = pair['name'].split('/')
+            market_pairs << Cryptoexchange::Models::MarketPair.new(
+                              base: base,
+                              target: target,
+                              market: Stinex::Market::NAME
+                            )
+          end
+          market_pairs
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/Stinex/integration_specs_fetch_order_book.yml
+++ b/spec/cassettes/vcr_cassettes/Stinex/integration_specs_fetch_order_book.yml
@@ -1,0 +1,96 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.stinex.net/api/v2/order_book?market=ethusd
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.stinex.net
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 27 Nov 2018 15:34:09 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=dbf3051165270dc8139970f49ea8c8e6d1543332849; expires=Wed, 27-Nov-19
+        15:34:09 GMT; path=/; domain=.stinex.net; HttpOnly; Secure
+      Vary:
+      - Accept-Encoding
+      - Origin
+      Access-Control-Allow-Origin:
+      - https://trade.stinex.net
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept, Authorization
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Version:
+      - HTTP/1.1
+      Host:
+      - api.stinex.net
+      X-Real-Ip:
+      - 81.168.92.227
+      X-Forwarded-For:
+      - 81.168.92.227
+      X-Forwarded-Host:
+      - api.stinex.net
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/api/v2/order_book?market=ethusd"
+      X-Scheme:
+      - https
+      X-Original-Forwarded-For:
+      - 81.168.92.227
+      Accept-Encoding:
+      - gzip
+      Cf-Ipcountry:
+      - GB
+      Cf-Visitor:
+      - '{"scheme":"https"}'
+      User-Agent:
+      - http.rb/3.0.0
+      Cf-Connecting-Ip:
+      - 81.168.92.227
+      Etag:
+      - W/"ce46d35ddea8e650743dff85234d765e"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 1f11413a-c44f-4697-91be-b580af69c4d8
+      X-Runtime:
+      - '0.026874'
+      Strict-Transport-Security:
+      - max-age=0; includeSubDomains
+      X-Robots-Tag:
+      - noindex
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4805a8461edd96c4-FRA
+    body:
+      encoding: ASCII-8BIT
+      string: '{"asks":[{"id":587,"side":"sell","ord_type":"limit","price":"115.0","avg_price":"115.0","state":"wait","market":"ethusd","created_at":"2018-11-25T13:05:14+01:00","volume":"0.67452092","remaining_volume":"0.23973832","executed_volume":"0.4347826","trades_count":1}],"bids":[{"id":422,"side":"buy","ord_type":"limit","price":"98.0","avg_price":"98.0","state":"wait","market":"ethusd","created_at":"2018-11-20T19:10:12+01:00","volume":"28.0","remaining_volume":"27.6652174","executed_volume":"0.3347826","trades_count":1}]}'
+    http_version: 
+  recorded_at: Tue, 27 Nov 2018 15:34:09 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Stinex/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/Stinex/integration_specs_fetch_pairs.yml
@@ -1,0 +1,96 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.stinex.net/api/v2/markets
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.stinex.net
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 27 Nov 2018 15:34:09 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d9130b44bd4f14becd3535a45c03afb711543332849; expires=Wed, 27-Nov-19
+        15:34:09 GMT; path=/; domain=.stinex.net; HttpOnly; Secure
+      Vary:
+      - Accept-Encoding
+      - Origin
+      Access-Control-Allow-Origin:
+      - https://trade.stinex.net
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept, Authorization
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Version:
+      - HTTP/1.1
+      Host:
+      - api.stinex.net
+      X-Real-Ip:
+      - 81.168.92.227
+      X-Forwarded-For:
+      - 81.168.92.227
+      X-Forwarded-Host:
+      - api.stinex.net
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/api/v2/markets"
+      X-Scheme:
+      - https
+      X-Original-Forwarded-For:
+      - 81.168.92.227
+      Accept-Encoding:
+      - gzip
+      Cf-Ipcountry:
+      - GB
+      Cf-Visitor:
+      - '{"scheme":"https"}'
+      User-Agent:
+      - http.rb/3.0.0
+      Cf-Connecting-Ip:
+      - 81.168.92.227
+      Etag:
+      - W/"1b3be3663e7b61a6e097cb6bfe9f9516"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - c0f8fda7-4a28-41f5-a319-91a902ca8a5c
+      X-Runtime:
+      - '0.031247'
+      Strict-Transport-Security:
+      - max-age=0; includeSubDomains
+      X-Robots-Tag:
+      - noindex
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4805a842ff9d96be-FRA
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"id":"btcusd","name":"BTC/USD"},{"id":"entrcusd","name":"ENTRC/USD"},{"id":"ethusd","name":"ETH/USD"},{"id":"tusdusd","name":"TUSD/USD"},{"id":"entrcbtc","name":"ENTRC/BTC"},{"id":"btctusd","name":"BTC/TUSD"},{"id":"entrctusd","name":"ENTRC/TUSD"},{"id":"ethtusd","name":"ETH/TUSD"},{"id":"entrceth","name":"ENTRC/ETH"},{"id":"cvcentrc","name":"CVC/ENTRC"},{"id":"dententrc","name":"DENT/ENTRC"},{"id":"cvcbtc","name":"CVC/BTC"},{"id":"cvceth","name":"CVC/ETH"},{"id":"hsteth","name":"HST/ETH"},{"id":"dentbtc","name":"DENT/BTC"},{"id":"denteth","name":"DENT/ETH"},{"id":"hotbtc","name":"HOT/BTC"},{"id":"hoteth","name":"HOT/ETH"},{"id":"dgxbtc","name":"DGX/BTC"},{"id":"dgxeth","name":"DGX/ETH"},{"id":"dgxentrc","name":"DGX/ENTRC"},{"id":"elfbtc","name":"ELF/BTC"},{"id":"gnobtc","name":"GNO/BTC"},{"id":"gntbtc","name":"GNT/BTC"},{"id":"hstbtc","name":"HST/BTC"},{"id":"kncbtc","name":"KNC/BTC"},{"id":"knceth","name":"KNC/ETH"},{"id":"mtlbtc","name":"MTL/BTC"},{"id":"mtleth","name":"MTL/ETH"},{"id":"omgeth","name":"OMG/ETH"},{"id":"gnoeth","name":"GNO/ETH"},{"id":"mtlentrc","name":"MTL/ENTRC"},{"id":"elfeth","name":"ELF/ETH"},{"id":"nasbtc","name":"NAS/BTC"},{"id":"naseth","name":"NAS/ETH"},{"id":"nasentrc","name":"NAS/ENTRC"},{"id":"npxseth","name":"NPXS/ETH"},{"id":"nexobtc","name":"NEXO/BTC"},{"id":"nexoeth","name":"NEXO/ETH"},{"id":"nexoentrc","name":"NEXO/ENTRC"},{"id":"paxeth","name":"PAX/ETH"},{"id":"npxsbtc","name":"NPXS/BTC"},{"id":"payeth","name":"PAY/ETH"},{"id":"ppteth","name":"PPT/ETH"},{"id":"paxbtc","name":"PAX/BTC"},{"id":"omgbtc","name":"OMG/BTC"},{"id":"paybtc","name":"PAY/BTC"},{"id":"pptbtc","name":"PPT/BTC"},{"id":"powrbtc","name":"POWR/BTC"},{"id":"powreth","name":"POWR/ETH"},{"id":"probtc","name":"PRO/BTC"},{"id":"proeth","name":"PRO/ETH"},{"id":"qashbtc","name":"QASH/BTC"},{"id":"qasheth","name":"QASH/ETH"},{"id":"qrlbtc","name":"QRL/BTC"},{"id":"qrleth","name":"QRL/ETH"},{"id":"rdnbtc","name":"RDN/BTC"},{"id":"rdneth","name":"RDN/ETH"},{"id":"repeth","name":"REP/ETH"},{"id":"repbtc","name":"REP/BTC"},{"id":"saltbtc","name":"SALT/BTC"},{"id":"sntbtc","name":"SNT/BTC"},{"id":"salteth","name":"SALT/ETH"},{"id":"snteth","name":"SNT/ETH"},{"id":"storjbtc","name":"STORJ/BTC"},{"id":"stormbtc","name":"STORM/BTC"},{"id":"stormeth","name":"STORM/ETH"},{"id":"storjeth","name":"STORJ/ETH"},{"id":"tenbtc","name":"TEN/BTC"},{"id":"teneth","name":"TEN/ETH"},{"id":"tntbtc","name":"TNT/BTC"},{"id":"zileth","name":"ZIL/ETH"},{"id":"tnteth","name":"TNT/ETH"},{"id":"ukgbtc","name":"UKG/BTC"},{"id":"ukgeth","name":"UKG/ETH"},{"id":"uppbtc","name":"UPP/BTC"},{"id":"uppeth","name":"UPP/ETH"},{"id":"zcobtc","name":"ZCO/BTC"},{"id":"zcoeth","name":"ZCO/ETH"},{"id":"zilbtc","name":"ZIL/BTC"},{"id":"zrxbtc","name":"ZRX/BTC"},{"id":"zrxeth","name":"ZRX/ETH"}]'
+    http_version: 
+  recorded_at: Tue, 27 Nov 2018 15:34:09 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Stinex/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/Stinex/integration_specs_fetch_ticker.yml
@@ -1,0 +1,95 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.stinex.net/api/v2/tickers/ethusd
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.stinex.net
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 27 Nov 2018 15:34:09 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '116'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=dbf3051165270dc8139970f49ea8c8e6d1543332849; expires=Wed, 27-Nov-19
+        15:34:09 GMT; path=/; domain=.stinex.net; HttpOnly; Secure
+      Access-Control-Allow-Origin:
+      - https://trade.stinex.net
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept, Authorization
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Vary:
+      - Origin
+      Version:
+      - HTTP/1.1
+      Host:
+      - api.stinex.net
+      X-Real-Ip:
+      - 81.168.92.227
+      X-Forwarded-For:
+      - 81.168.92.227
+      X-Forwarded-Host:
+      - api.stinex.net
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Original-Uri:
+      - "/api/v2/tickers/ethusd"
+      X-Scheme:
+      - https
+      X-Original-Forwarded-For:
+      - 81.168.92.227
+      Accept-Encoding:
+      - gzip
+      Cf-Ipcountry:
+      - GB
+      Cf-Visitor:
+      - '{"scheme":"https"}'
+      User-Agent:
+      - http.rb/3.0.0
+      Cf-Connecting-Ip:
+      - 81.168.92.227
+      Etag:
+      - W/"f3fff855f1fe4ede44058afcbff82266"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - f0ab181d-0d28-4243-afb3-4d2e591436b8
+      X-Runtime:
+      - '0.018394'
+      Strict-Transport-Security:
+      - max-age=0; includeSubDomains
+      X-Robots-Tag:
+      - noindex
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4805a8449d8996c4-FRA
+    body:
+      encoding: ASCII-8BIT
+      string: '{"at":1543332849,"ticker":{"buy":"98.0","sell":"115.0","low":"98.0","high":"115.0","last":"98.0","vol":"0.8695652"}}'
+    http_version: 
+  recorded_at: Tue, 27 Nov 2018 15:34:09 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/stinex/integration/market_spec.rb
+++ b/spec/exchanges/stinex/integration/market_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+RSpec.describe 'Stinex integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:eth_usd_pair) { Cryptoexchange::Models::MarketPair.new(base: 'ETH', target: 'USD', market: 'stinex') }
+
+  it 'fetch pairs' do
+    pairs = client.pairs('stinex')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.market).to eq 'stinex'
+  end
+
+  it 'give trade url' do
+    trade_page_url = client.trade_page_url 'stinex', base: eth_usd_pair.base, target: eth_usd_pair.target
+    expect(trade_page_url).to eq "https://api.stinex.net/trading/ethusd"
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(eth_usd_pair)
+
+    expect(ticker.base).to eq 'ETH'
+    expect(ticker.target).to eq 'USD'
+    expect(ticker.market).to eq 'stinex'
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.ask).to be_a Numeric
+    expect(ticker.bid).to be_a Numeric
+    expect(ticker.low).to be_a Numeric
+    expect(ticker.high).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+    expect(ticker.timestamp).to be_a Numeric
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
+    expect(ticker.payload).to_not be nil
+  end
+
+  it 'fetch order book' do
+    order_book = client.order_book(eth_usd_pair)
+
+    expect(order_book.base).to eq 'ETH'
+    expect(order_book.target).to eq 'USD'
+    expect(order_book.market).to eq 'stinex'
+    expect(order_book.asks).to_not be_empty
+    expect(order_book.bids).to_not be_empty
+    expect(order_book.asks.first.price).to_not be_nil
+    expect(order_book.bids.first.amount).to_not be_nil
+    expect(order_book.bids.first.timestamp).to be_a Numeric
+    expect(order_book.asks.count).to be > 0
+    expect(order_book.bids.count).to be > 0
+    expect(order_book.timestamp).to be_a Numeric
+    expect(2000..Date.today.year).to include(Time.at(order_book.timestamp).year)
+    expect(order_book.payload).to_not be nil
+  end
+
+  # it 'fetch trade' do
+  #   trades = client.trades(eth_usd_pair)
+  #   trade = trades.sample
+  #
+  #   expect(trades).to_not be_empty
+  #   expect(trade.base).to eq 'ETH'
+  #   expect(trade.target).to eq 'USD'
+  #   expect(trade.market).to eq 'stinex'
+  #   expect(trade.trade_id).to_not be_nil
+  #   expect(['buy', 'sell']).to include trade.type
+  #   expect(trade.price).to_not be_nil
+  #   expect(trade.amount).to_not be_nil
+  #   expect(trade.timestamp).to be_a Numeric
+  #   expect(trade.payload).to_not be nil
+  # end
+end

--- a/spec/exchanges/stinex/market_spec.rb
+++ b/spec/exchanges/stinex/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Stinex::Market do
+  it { expect(described_class::NAME).to eq 'stinex' }
+  it { expect(described_class::API_URL).to eq 'https://api.stinex.net/api/v2' }
+end


### PR DESCRIPTION
- Add Pairs, Tickers, OrderBook, Trade URL, and updated README for Stinex
- Closes: #1172 
- [X] I have added Specs
- [X] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [X] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [X] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [X] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
