### PR TITLE
✨ Implement Mxc ticker and order book

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Or install it yourself as:
 | MaxMaicoin        | Y       | Y          | Y       |         | Y           | Y        | max_maicoin       |
 | MercadoBitcoin    | Y       |            |         |         | User-Defined|          | mercado_bitcoin   |
 | Mercatox          | Y       | N          | N       | N       | Y           |          | mercatox          |
+| Mxc               | Y       | Y          | N       |         | Y           | Y        | mxc               |
 | Myspeedtrade      | Y       | Y          |         |         | Y           |          | myspeedtrade      |
 | Nanex             | Y       | N          | N       | N       | Y           |          | nanex             |
 | Nanu.Exchange     | Y       | Y          | Y       |         | Y           |          | nanu_exchange     |

--- a/lib/cryptoexchange/exchanges/mxc/market.rb
+++ b/lib/cryptoexchange/exchanges/mxc/market.rb
@@ -1,0 +1,12 @@
+module Cryptoexchange::Exchanges
+  module Mxc
+    class Market < Cryptoexchange::Models::Market
+      NAME = 'mxc'
+      API_URL = 'https://www.mxc.com/open/api/v1'
+
+      def self.trade_page_url(args={})
+        "https://www.mxc.com/trade.html?symbol=#{args[:base]}_#{args[:target]}"
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/mxc/services/market.rb
+++ b/lib/cryptoexchange/exchanges/mxc/services/market.rb
@@ -1,0 +1,41 @@
+module Cryptoexchange::Exchanges
+  module Mxc
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(self.ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          base   = market_pair.base
+          target = market_pair.target
+          "#{Cryptoexchange::Exchanges::Mxc::Market::API_URL}/data/ticker?market=#{base}_#{target}"
+        end
+
+        def adapt(output, market_pair)
+          data_ticker      = output['data']
+          ticker           = Cryptoexchange::Models::Ticker.new
+          ticker.base      = market_pair.base
+          ticker.target    = market_pair.target
+          ticker.market    = Mxc::Market::NAME
+          ticker.last      = NumericHelper.to_d(data_ticker['last'])
+          ticker.bid       = NumericHelper.to_d(data_ticker['buy'])
+          ticker.ask       = NumericHelper.to_d(data_ticker['sell'])
+          ticker.high      = NumericHelper.to_d(data_ticker['high'])
+          ticker.low       = NumericHelper.to_d(data_ticker['low'])
+          ticker.volume    = NumericHelper.to_d(data_ticker['volume'])
+          ticker.timestamp = nil
+          ticker.payload   = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/mxc/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/mxc/services/order_book.rb
@@ -1,0 +1,46 @@
+module Cryptoexchange::Exchanges
+  module Mxc
+    module Services
+      class OrderBook < Cryptoexchange::Services::Market
+        COUNT = 20
+
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          base   = market_pair.base
+          target = market_pair.target
+          "#{Cryptoexchange::Exchanges::Mxc::Market::API_URL}/data/depth?depth=#{COUNT}&market=#{base}_#{target}"
+        end
+
+        def adapt(output, market_pair)
+          order_book = Cryptoexchange::Models::OrderBook.new
+
+          order_book.base      = market_pair.base
+          order_book.target    = market_pair.target
+          order_book.market    = Mxc::Market::NAME
+          order_book.asks      = adapt_orders(HashHelper.dig(output, 'data', 'asks'))
+          order_book.bids      = adapt_orders(HashHelper.dig(output, 'data', 'bids'))
+          order_book.timestamp = nil
+          order_book.payload   = output
+          order_book
+        end
+
+        def adapt_orders(orders)
+          orders.collect do |order_entry|
+            Cryptoexchange::Models::Order.new(price:  order_entry['price'],
+                                              amount: order_entry['quantity'])
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/mxc/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/mxc/services/pairs.rb
@@ -1,0 +1,26 @@
+module Cryptoexchange::Exchanges
+  module Mxc
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Mxc::Market::API_URL}/data/markets"
+
+        def fetch
+          output = super
+          adapt(output)
+        end
+
+        def adapt(output)
+          output['data'].map do |pair|
+            base, target = pair.split('_')
+
+            Cryptoexchange::Models::MarketPair.new(
+              base:   base,
+              target: target,
+              market: Mxc::Market::NAME
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/Mxc/integration_specs_fetch_order_book.yml
+++ b/spec/cassettes/vcr_cassettes/Mxc/integration_specs_fetch_order_book.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://www.mxc.com/open/api/v1/data/depth?depth=20&market=BTC_USDT
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - www.mxc.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 28 Nov 2018 07:55:06 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Vary:
+      - Accept-Encoding
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      X-Cdn-Edge:
+      - cb634c7,-
+      Set-Cookie:
+      - __cdnuid=f4c8ef5f8491a399c2c8159475276777; max-age=31536000; path=/; HttpOnly
+      X-Cache:
+      - bypass
+    body:
+      encoding: UTF-8
+      string: '{"code":200,"data":{"asks":[{"price":"4098.87","quantity":"0.09"},{"price":"4099.07","quantity":"0.06"},{"price":"4099.1","quantity":"0.18"},{"price":"4101.33","quantity":"0.45"},{"price":"4101.34","quantity":"0.03375"},{"price":"4101.35","quantity":"0.245486"},{"price":"4101.38","quantity":"0.03"},{"price":"4101.45","quantity":"0.06"},{"price":"4102.05","quantity":"1.38066"},{"price":"4102.22","quantity":"0.04368"},{"price":"4102.5","quantity":"0.08028"},{"price":"4102.56","quantity":"0.6"},{"price":"4102.63","quantity":"0.02541"},{"price":"4102.77","quantity":"0.05268"},{"price":"4102.96","quantity":"0.10497"},{"price":"4103.18","quantity":"0.10992"},{"price":"4103.32","quantity":"0.08991"},{"price":"4103.77","quantity":"0.1506"},{"price":"4105.27","quantity":"0.11718"},{"price":"4105.28","quantity":"1.53867"}],"bids":[{"price":"4091.83","quantity":"0.01584"},{"price":"4091.71","quantity":"0.0003"},{"price":"4090.96","quantity":"0.29202"},{"price":"4090.95","quantity":"0.40629"},{"price":"4090.69","quantity":"0.18"},{"price":"4090.26","quantity":"0.03"},{"price":"4090.17","quantity":"0.12663"},{"price":"4090.03","quantity":"0.015"},{"price":"4089.82","quantity":"0.02634"},{"price":"4089.61","quantity":"0.18"},{"price":"4089.02","quantity":"0.03"},{"price":"4088.78","quantity":"0.06"},{"price":"4088.45","quantity":"0.00816"},{"price":"4088.3","quantity":"0.18"},{"price":"4088.29","quantity":"0.02541"},{"price":"4088.23","quantity":"0.18"},{"price":"4088.16","quantity":"0.87915"},{"price":"4088.1","quantity":"0.77631"},{"price":"4088.06","quantity":"0.05268"},{"price":"4088.05","quantity":"0.1506"}]},"msg":"OK"}'
+    http_version: 
+  recorded_at: Wed, 28 Nov 2018 07:55:06 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Mxc/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/Mxc/integration_specs_fetch_pairs.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://www.mxc.com/open/api/v1/data/markets
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - www.mxc.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 28 Nov 2018 07:55:05 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Vary:
+      - Accept-Encoding
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      X-Cdn-Edge:
+      - cb634c7,-
+      Set-Cookie:
+      - __cdnuid=df715fe93ba65ffee0b31007e3037744; max-age=31536000; path=/; HttpOnly
+      X-Cache:
+      - bypass
+    body:
+      encoding: UTF-8
+      string: '{"code":200,"data":["love_usdt","tusd_usdt","bsv_usdt","eos_usdt","bch_usdt","mx_usdt","pax_usdt","eth_usdt","zil_usdt","swag_usdt","snt_usdt","wicc_usdt","sex_usdt","neo_usdt","ltc_usdt","etc_usdt","btc_usdt","love_eth","knc_eth","tusd_eth","qkc_eth","hqt_eth","lqd_eth","ae_eth","btcc_eth","gmb_eth","mft_eth","omg_eth","ykc_eth","eos_eth","bqt_eth","zrx_eth","hot_eth","ftm_eth","mx_eth","rfr_eth","link_eth","pax_eth","ncash_eth","nex_eth","elf_eth","ycc_eth","hpt_eth","iotx_eth","iost_eth","zil_eth","buc_eth","swag_eth","mana_eth","sex_eth","ruff_eth","loom_eth","love_btc","tusd_btc","omg_btc","eos_btc","pax_btc","eth_btc","snt_btc","sex_btc","ltc_btc","etc_btc"],"msg":"OK"}'
+    http_version: 
+  recorded_at: Wed, 28 Nov 2018 07:55:05 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Mxc/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/Mxc/integration_specs_fetch_ticker.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://www.mxc.com/open/api/v1/data/ticker?market=BTC_USDT
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - www.mxc.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 28 Nov 2018 07:55:05 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Vary:
+      - Accept-Encoding
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=31536000
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      X-Cdn-Edge:
+      - cb634c7,-
+      Set-Cookie:
+      - __cdnuid=79c03dc5f677581c254d4fd232ed2b77; max-age=31536000; path=/; HttpOnly
+      X-Cache:
+      - bypass
+    body:
+      encoding: UTF-8
+      string: '{"code":200,"data":{"volume":"14803.847028","high":"4144.34","low":"3687.87","buy":"4091.83","sell":"4098.87","open":"3839.01","last":"4098"},"msg":"OK"}'
+    http_version: 
+  recorded_at: Wed, 28 Nov 2018 07:55:05 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/mxc/integration/market_spec.rb
+++ b/spec/exchanges/mxc/integration/market_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+RSpec.describe 'Mxc integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:btc_usdt_pair) { Cryptoexchange::Models::MarketPair.new(base: 'BTC', target: 'USDT', market: 'mxc') }
+
+  it 'fetch pairs' do
+    pairs = client.pairs('mxc')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.market).to eq 'mxc'
+  end
+
+  it 'give trade url' do
+    trade_page_url = client.trade_page_url 'mxc', base: btc_usdt_pair.base, target: btc_usdt_pair.target
+    expect(trade_page_url).to eq 'https://www.mxc.com/trade.html?symbol=BTC_USDT'
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(btc_usdt_pair)
+
+    expect(ticker.base).to eq 'BTC'
+    expect(ticker.target).to eq 'USDT'
+    expect(ticker.market).to eq 'mxc'
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.bid).to be_a Numeric
+    expect(ticker.ask).to be_a Numeric
+    expect(ticker.low).to be_a Numeric
+    expect(ticker.high).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+    expect(ticker.timestamp).to be nil
+    expect(ticker.payload).to_not be nil
+  end
+
+  it 'fetch order book' do
+    order_book = client.order_book(btc_usdt_pair)
+
+    expect(order_book.base).to eq 'BTC'
+    expect(order_book.target).to eq 'USDT'
+    expect(order_book.market).to eq 'mxc'
+    expect(order_book.asks).to_not be_empty
+    expect(order_book.bids).to_not be_empty
+    expect(order_book.asks.count).to be > 0
+    expect(order_book.bids.count).to be > 0
+    expect(order_book.timestamp).to be nil
+    expect(order_book.payload).to_not be nil
+  end
+end

--- a/spec/exchanges/mxc/market_spec.rb
+++ b/spec/exchanges/mxc/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Mxc::Market do
+  it { expect(described_class::NAME).to eq 'mxc' }
+  it { expect(described_class::API_URL).to eq 'https://www.mxc.com/open/api/v1' }
+end


### PR DESCRIPTION
- What is the purpose of this Pull Request? as title
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")? closes #1136
- [x] I have added Specs
- [x] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [x] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [x] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [x] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

ticker about `BTC_USDT`
```ruby
{
 "code": 200,
 "data": {
  "volume": "14799.36624",
  "high": "4144.34",
  "low": "3687.87",
  "buy": "4088.13",
  "sell": "4094.36",
  "open": "3845.22",
  "last": "4089.63"
 },
 "msg": "OK"
}
```
took `volume` as base volume