### PR TITLE
Swiftex Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Or install it yourself as:
 | Sistemkoin        | Y       |            |         |         | Y           |          | sistemkoin        |
 | SouthXchange      | Y       | Y          | Y       |         | Y           | Y        | south_xchange     |
 | Stocks Exchange   | Y       |            |         |         | Y           | Y        | stocks_exchange   |
+| Swiftex           | Y       | Y          |         |         | Y           | Y        | swiftex           |
 | Switcheo          | Y       | N          | N       |         | Y           | Y        | switcheo          |
 | Syex              | Y       | N          | N       |         | Y           | Y        | syex              |
 | SZZC              | Y       |            |         |         | Y           |          | szzc              |

--- a/lib/cryptoexchange/exchanges/swiftex/market.rb
+++ b/lib/cryptoexchange/exchanges/swiftex/market.rb
@@ -1,0 +1,12 @@
+module Cryptoexchange::Exchanges
+  module Swiftex
+    class Market < Cryptoexchange::Models::Market
+      NAME = 'swiftex'
+      API_URL = 'https://swiftex.co/api/v2'
+
+      def self.trade_page_url(args={})
+        "https://swiftex.co/markets/#{args[:base].downcase}-#{args[:target].downcase}"
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/swiftex/services/market.rb
+++ b/lib/cryptoexchange/exchanges/swiftex/services/market.rb
@@ -1,0 +1,50 @@
+module Cryptoexchange::Exchanges
+  module Swiftex
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            false
+          end
+        end
+
+        def fetch
+          output = super(ticker_url)
+          adapt_all(output)
+        end
+
+        def ticker_url
+          "#{Cryptoexchange::Exchanges::Swiftex::Market::API_URL}/tickers"
+        end
+
+        def adapt_all(output)
+          output.map do |pair|
+            base, target = pair[0].split('-')
+            market_pair  = Cryptoexchange::Models::MarketPair.new(
+              base:   base.upcase,
+              target: target.upcase,
+              market: Swiftex::Market::NAME
+            )
+            adapt(market_pair, pair[1])
+          end
+        end
+
+        def adapt(market_pair, output)
+          ticker           = Cryptoexchange::Models::Ticker.new
+          ticker.base      = market_pair.base
+          ticker.target    = market_pair.target
+          ticker.market    = Swiftex::Market::NAME
+          ticker.last      = NumericHelper.to_d(output['ticker']['last'])
+          ticker.high      = NumericHelper.to_d(output['ticker']['high'])
+          ticker.low       = NumericHelper.to_d(output['ticker']['low'])
+          ticker.bid       = NumericHelper.to_d(output['ticker']['buy'])
+          ticker.ask       = NumericHelper.to_d(output['ticker']['sell'])
+          ticker.volume    = NumericHelper.to_d(output['ticker']['vol'])
+          ticker.timestamp = output['at']
+          ticker.payload   = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/swiftex/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/swiftex/services/order_book.rb
@@ -1,0 +1,42 @@
+module Cryptoexchange::Exchanges
+  module Swiftex
+    module Services
+      class OrderBook < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          "#{Cryptoexchange::Exchanges::Swiftex::Market::API_URL}/depth.json?market=#{market_pair.base.downcase}-#{market_pair.target.downcase}"
+        end
+
+        def adapt(output, market_pair)
+          order_book = Cryptoexchange::Models::OrderBook.new
+
+          order_book.base      = market_pair.base
+          order_book.target    = market_pair.target
+          order_book.market    = Swiftex::Market::NAME
+          order_book.asks      = adapt_orders(output['asks'])
+          order_book.bids      = adapt_orders(output['bids'])
+          order_book.timestamp = output['timestamp']
+          order_book.payload   = output
+          order_book
+        end
+
+        def adapt_orders(orders)
+          orders.collect do |order_entry|
+            Cryptoexchange::Models::Order.new(price: order_entry[0],
+                                              amount: order_entry[1])
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/swiftex/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/swiftex/services/pairs.rb
@@ -1,0 +1,23 @@
+module Cryptoexchange::Exchanges
+  module Swiftex
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Swiftex::Market::API_URL}/tickers.json"
+
+        def fetch
+          output = super
+          market_pairs = []
+          output.each do |pair|
+            base, target = pair[0].split('-')
+            market_pairs << Cryptoexchange::Models::MarketPair.new(
+                              base: base.upcase,
+                              target: target.upcase,
+                              market: Swiftex::Market::NAME
+                            )
+          end
+          market_pairs
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/Swiftex/integration_specs_fetch_order_book.yml
+++ b/spec/cassettes/vcr_cassettes/Swiftex/integration_specs_fetch_order_book.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://swiftex.co/api/v2/depth.json?market=mynt-btc
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - swiftex.co
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Nov 2018 14:52:20 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '725'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=dc00a2b35cdbf3c0ffdae6754d102c20b1543503140; expires=Fri, 29-Nov-19
+        14:52:20 GMT; path=/; domain=.swiftex.co; HttpOnly; Secure
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Id:
+      - dc070d95-4042-4ad4-9670-8f1f9ef37f1e
+      Etag:
+      - '"c7ef4fc8f7a937ec9350bbfbd5e64d1a"'
+      X-Runtime:
+      - '0.004040'
+      X-Powered-By:
+      - Phusion Passenger 5.3.5
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4815e5c3aae596a0-FRA
+    body:
+      encoding: ASCII-8BIT
+      string: '{"timestamp":1543503140,"asks":[["0.000009","1500.0"],["0.000006","1500.0"],["0.000003","1500.0"],["0.00000195","1500.0"],["0.00000099","100000.0"],["0.00000095","22000.0"],["0.0000009","10000.0"],["0.0000008","10000.0"],["0.0000007","10000.0"],["0.0000006","10000.0"],["0.0000005","10000.0"],["0.00000045","5000.0"],["0.0000004","5000.0"],["0.00000035","5000.0"],["0.0000003","29442.145908"],["0.0000002","40000.0"],["0.0000001","30000.0"],["0.00000009","183273.087"],["0.00000008","296514.62875"],["0.00000007","200879.676172"],["0.00000006","675435.480696"],["0.00000005","781984.801929"],["0.00000004","892319.224852"]],"bids":[["0.00000003","271774.268683"],["0.00000002","671342.004248"],["0.00000001","586855.39864"]]}'
+    http_version: 
+  recorded_at: Thu, 29 Nov 2018 14:52:20 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Swiftex/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/Swiftex/integration_specs_fetch_pairs.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://swiftex.co/api/v2/tickers.json
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - swiftex.co
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Nov 2018 14:52:19 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1077'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d0f43c6aa38393a8a112dc89189ac914d1543503139; expires=Fri, 29-Nov-19
+        14:52:19 GMT; path=/; domain=.swiftex.co; HttpOnly; Secure
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Id:
+      - 423782a1-8539-42e6-b0d8-d106c1b9c09a
+      Etag:
+      - '"4cf64431ef1d945849dee8bb7099d598"'
+      X-Runtime:
+      - '0.011857'
+      X-Powered-By:
+      - Phusion Passenger 5.3.5
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4815e5be6fb0c2c4-FRA
+    body:
+      encoding: ASCII-8BIT
+      string: '{"mynt-btc":{"at":1543503139,"ticker":{"buy":"0.00000003","sell":"0.00000004","low":"0.00000003","high":"0.00000003","last":"0.00000003","vol":"588502.3257"}},"ufo-btc":{"at":1543503139,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0","high":"0.0","last":"0.00000002","vol":"0.0"}},"ltc-btc":{"at":1543503139,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0","high":"0.0","last":"0.0","vol":"0.0"}},"rvn-btc":{"at":1543503139,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0000079","high":"0.0000079","last":"0.0000079","vol":"0.0"}},"mymn-btc":{"at":1543503139,"ticker":{"buy":"0.00000002","sell":"0.00000003","low":"0.00000002","high":"0.00000002","last":"0.00000002","vol":"0.0"}},"cpr-btc":{"at":1543503139,"ticker":{"buy":"0.0","sell":"0.00000001","low":"0.0","high":"0.0","last":"0.00000001","vol":"0.0"}},"dgb-btc":{"at":1543503139,"ticker":{"buy":"0.0","sell":"0.0","low":"0.00000308","high":"0.00000308","last":"0.00000308","vol":"19833.24556"}},"vls-btc":{"at":1543503139,"ticker":{"buy":"0.0","sell":"0.00004","low":"0.00002","high":"0.00002","last":"0.00002","vol":"0.0"}}}'
+    http_version: 
+  recorded_at: Thu, 29 Nov 2018 14:52:19 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Swiftex/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/Swiftex/integration_specs_fetch_ticker.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://swiftex.co/api/v2/tickers
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - swiftex.co
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 29 Nov 2018 14:52:20 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1077'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=dd272a6b55dd786e69150780978eab5171543503140; expires=Fri, 29-Nov-19
+        14:52:20 GMT; path=/; domain=.swiftex.co; HttpOnly; Secure
+      Status:
+      - 200 OK
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Id:
+      - 11ae5148-6688-4793-b16a-ab8aaf6f2e82
+      Etag:
+      - '"161e42db37e29819d796b25a37504079"'
+      X-Runtime:
+      - '0.009919'
+      X-Powered-By:
+      - Phusion Passenger 5.3.5
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4815e5c1098cc2c9-FRA
+    body:
+      encoding: ASCII-8BIT
+      string: '{"mynt-btc":{"at":1543503140,"ticker":{"buy":"0.00000003","sell":"0.00000004","low":"0.00000003","high":"0.00000003","last":"0.00000003","vol":"588502.3257"}},"ufo-btc":{"at":1543503140,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0","high":"0.0","last":"0.00000002","vol":"0.0"}},"ltc-btc":{"at":1543503140,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0","high":"0.0","last":"0.0","vol":"0.0"}},"rvn-btc":{"at":1543503140,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0000079","high":"0.0000079","last":"0.0000079","vol":"0.0"}},"mymn-btc":{"at":1543503140,"ticker":{"buy":"0.00000002","sell":"0.00000003","low":"0.00000002","high":"0.00000002","last":"0.00000002","vol":"0.0"}},"cpr-btc":{"at":1543503140,"ticker":{"buy":"0.0","sell":"0.00000001","low":"0.0","high":"0.0","last":"0.00000001","vol":"0.0"}},"dgb-btc":{"at":1543503140,"ticker":{"buy":"0.0","sell":"0.0","low":"0.00000308","high":"0.00000308","last":"0.00000308","vol":"19833.24556"}},"vls-btc":{"at":1543503140,"ticker":{"buy":"0.0","sell":"0.00004","low":"0.00002","high":"0.00002","last":"0.00002","vol":"0.0"}}}'
+    http_version: 
+  recorded_at: Thu, 29 Nov 2018 14:52:20 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/swiftex/integration/market_spec.rb
+++ b/spec/exchanges/swiftex/integration/market_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+RSpec.describe 'Swiftex integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:mynt_btc_pair) { Cryptoexchange::Models::MarketPair.new(base: 'MYNT', target: 'BTC', market: 'swiftex') }
+
+  it 'has trade_page_url' do
+    trade_page_url = client.trade_page_url mynt_btc_pair.market, base: mynt_btc_pair.base, target: mynt_btc_pair.target
+    expect(trade_page_url).to eq "https://swiftex.co/markets/mynt-btc"
+  end
+
+  it 'fetch pairs' do
+    pairs = client.pairs('swiftex')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.market).to eq 'swiftex'
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(mynt_btc_pair)
+
+    expect(ticker.base).to eq 'MYNT'
+    expect(ticker.target).to eq 'BTC'
+    expect(ticker.market).to eq 'swiftex'
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.low).to be_a Numeric
+    expect(ticker.high).to be_a Numeric
+    expect(ticker.bid).to be_a Numeric
+    expect(ticker.ask).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+    expect(ticker.timestamp).to be_a Numeric
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
+    expect(ticker.payload).to_not be nil
+  end
+
+  it 'fetch order book' do
+    order_book = client.order_book(mynt_btc_pair)
+
+    expect(order_book.base).to eq 'MYNT'
+    expect(order_book.target).to eq 'BTC'
+    expect(order_book.market).to eq 'swiftex'
+    expect(order_book.asks).to_not be_empty
+    expect(order_book.bids).to_not be_empty
+    expect(order_book.asks.first.price).to_not be_nil
+    expect(order_book.bids.first.amount).to_not be_nil
+    expect(order_book.bids.first.timestamp).to be_nil
+    expect(order_book.asks.count).to be > 1
+    expect(order_book.bids.count).to be > 1
+    expect(order_book.timestamp).to be_a Numeric
+    expect(order_book.payload).to_not be nil
+  end
+
+  # it 'fetch trade' do
+  #   trades = client.trades(mynt_btc_pair)
+  #   trade = trades.sample
+  #
+  #   expect(trades).to_not be_empty
+  #   expect(trade.base).to eq 'MYNT'
+  #   expect(trade.target).to eq 'BTC'
+  #   expect(trade.market).to eq 'swiftex'
+  #   expect(trade.trade_id).to_not be_nil
+  #   expect(['buy', 'sell']).to include trade.type
+  #   expect(trade.price).to_not be_nil
+  #   expect(trade.amount).to_not be_nil
+  #   expect(trade.timestamp).to be_a Numeric
+  #   expect(2000..Date.today.year).to include(Time.at(trade.timestamp).year)
+  #   expect(trade.payload).to_not be nil
+  # end
+end

--- a/spec/exchanges/swiftex/market_spec.rb
+++ b/spec/exchanges/swiftex/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Swiftex::Market do
+  it { expect(described_class::NAME).to eq 'swiftex' }
+  it { expect(described_class::API_URL).to eq 'https://swiftex.co/api/v2' }
+end


### PR DESCRIPTION
- Add Pairs, Tickers, OrderBook, Trade URL and updated README for Swiftex
- Closes: #1178 
- [X] I have added Specs
- [X] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [X] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [X] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [X] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
