### PR TITLE
Openbit Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Or install it yourself as:
 | OKEx              | Y       | Y          | Y       |         | Y           | Y        | okex              |
 | OmniTrade         | Y       | Y          | Y       | Y       | Y           |          | omnitrade         |
 | Ooobtc            | Y       | Y          | Y       |         | Y           | Y        | ooobtc            |
+| Openbit           | Y       |            |         |         | Y           | Y        | openbit           |
 | Openledger        | Y       | Y          | Y       |         | Y           | Y        | openledger        |
 | OrderBook         | Y       | Y          | Y       |         | Y           | Y        | orderbook         |
 | Ore Bz            | Y       | Y          | Y       |         | Y           | Y        | ore_bz            |

--- a/lib/cryptoexchange/exchanges/openbit/market.rb
+++ b/lib/cryptoexchange/exchanges/openbit/market.rb
@@ -1,0 +1,12 @@
+module Cryptoexchange::Exchanges
+  module Openbit
+    class Market < Cryptoexchange::Models::Market
+      NAME = 'openbit'
+      API_URL = 'https://market.openbit.online'
+
+      def self.trade_page_url(args={})
+        "https://market.openbit.online/trade/index/market/#{args[:base].downcase}_#{args[:target].downcase}"
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/openbit/services/market.rb
+++ b/lib/cryptoexchange/exchanges/openbit/services/market.rb
@@ -1,0 +1,52 @@
+module Cryptoexchange::Exchanges
+  module Openbit
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            false
+          end
+        end
+
+        def fetch
+          output = super(ticker_url)
+          adapt_all(output)
+        end
+
+        def ticker_url
+          "#{Cryptoexchange::Exchanges::Openbit::Market::API_URL}/Mapi/Index/marketInfo"
+        end
+
+        def adapt_all(output)
+          output['data']['market'].map do |pair|
+            raw_pair = pair['name'].match(/(\(.*)\)/).to_s
+            base, target = raw_pair.delete('()').split('/')
+            next unless base && target
+            market_pair  = Cryptoexchange::Models::MarketPair.new(
+              base:   base,
+              target: target,
+              market: Openbit::Market::NAME
+            )
+            adapt(market_pair, pair)
+          end
+        end
+
+        def adapt(market_pair, output)
+          ticker           = Cryptoexchange::Models::Ticker.new
+          ticker.base      = market_pair.base
+          ticker.target    = market_pair.target
+          ticker.market    = Openbit::Market::NAME
+          ticker.last      = NumericHelper.to_d(output['new_price'])
+          ticker.high      = NumericHelper.to_d(output['max_price'])
+          ticker.low       = NumericHelper.to_d(output['min_price'])
+          ticker.bid       = NumericHelper.to_d(output['buy_price'])
+          ticker.ask       = NumericHelper.to_d(output['sell_price'])
+          ticker.volume    = NumericHelper.to_d(output['volume'])
+          ticker.timestamp = nil
+          ticker.payload   = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/openbit/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/openbit/services/pairs.rb
@@ -1,0 +1,25 @@
+module Cryptoexchange::Exchanges
+  module Openbit
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Openbit::Market::API_URL}/Mapi/Index/marketInfo"
+
+        def fetch
+          output = super
+          market_pairs = []
+          output['data']['market'].each do |pair|
+            raw_pair = pair['name'].match(/(\(.*)\)/).to_s
+            base, target = raw_pair.delete('()').split('/')
+            next unless base && target
+            market_pairs << Cryptoexchange::Models::MarketPair.new(
+                              base: base,
+                              target: target,
+                              market: Openbit::Market::NAME
+                            )
+          end
+          market_pairs
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/Openbit/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/Openbit/integration_specs_fetch_pairs.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://market.openbit.online/Mapi/Index/marketInfo
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - market.openbit.online
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 02 Dec 2018 12:52:20 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - PHPSESSID=4ge18hgptm2dut5lgrafmluo1d; path=/
+      - __cfduid=de7642ac79344c4281a61fd4cd609cf261543755140; expires=Mon, 02-Dec-19
+        12:52:20 GMT; path=/; domain=.openbit.online; HttpOnly; Secure
+      X-Powered-By:
+      - PHP/7.1.24
+      - PleskLin
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      - private, must-revalidate
+      Pragma:
+      - no-cache
+      Ms-Author-Via:
+      - DAV
+      Vary:
+      - Accept-Encoding
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 482dee1becdebde8-AMS
+    body:
+      encoding: ASCII-8BIT
+      string: '{"status":1,"data":{"market":[{"id":"29","name":"Hmn(HMN\/BTC)","new_price":3.6e-5,"buy_price":3.0e-6,"sell_price":0,"min_price":2.16e-5,"max_price":7.2000000000000005e-6,"change":65.99,"volume":8},{"id":"28","name":"Nodify(NFY\/BTC)","new_price":9.72e-5,"buy_price":0,"sell_price":0,"min_price":0.00011339999999999999,"max_price":1.62e-5,"change":0,"volume":0.4},{"id":"22","name":"Litecoin(LTC\/BTC)","new_price":0.012745600000000003,"buy_price":0.0053712,"sell_price":0.0015964,"min_price":0.007966,"max_price":0.0095592,"change":-0.09,"volume":0.7400000000000001},{"id":"26","name":"Pws(PWS\/BTC)","new_price":3.0e-6,"buy_price":0,"sell_price":0,"min_price":7.0e-6,"max_price":4.000000000000001e-6,"change":0,"volume":1.6},{"id":"24","name":"Doge(DOGE\/BTC)","new_price":2.0e-7,"buy_price":0,"sell_price":1.6e-6,"min_price":2.0e-6,"max_price":1.6e-6,"change":-163.64,"volume":1534.572},{"id":"18","name":"Openbit(OPN\/BTC)","new_price":0.001152,"buy_price":0.00072,"sell_price":0.0009216000000000001,"min_price":0.0008064,"max_price":0.00023040000000000002,"change":0.03,"volume":17.2884},{"id":"32","name":"Mog(MOGWAI\/BTC)","new_price":0,"buy_price":0,"sell_price":0,"min_price":0,"max_price":0,"change":-0,"volume":0}]}}'
+    http_version: 
+  recorded_at: Sun, 02 Dec 2018 12:52:20 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Openbit/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/Openbit/integration_specs_fetch_ticker.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://market.openbit.online/Mapi/Index/marketInfo
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - market.openbit.online
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 02 Dec 2018 12:52:21 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - PHPSESSID=hiolq09dkqdvmg005no9b9q0om; path=/
+      - __cfduid=d815bdabb05a7b8322806e38edaa01dd11543755140; expires=Mon, 02-Dec-19
+        12:52:20 GMT; path=/; domain=.openbit.online; HttpOnly; Secure
+      X-Powered-By:
+      - PHP/7.1.24
+      - PleskLin
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Cache-Control:
+      - no-store, no-cache, must-revalidate
+      - private, must-revalidate
+      Pragma:
+      - no-cache
+      Ms-Author-Via:
+      - DAV
+      Vary:
+      - Accept-Encoding
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 482dee1ebc7b9c89-AMS
+    body:
+      encoding: ASCII-8BIT
+      string: '{"status":1,"data":{"market":[{"id":"29","name":"Hmn(HMN\/BTC)","new_price":1.4400000000000001e-5,"buy_price":4.2e-6,"sell_price":0,"min_price":2.52e-5,"max_price":2.52e-5,"change":-87.98,"volume":18},{"id":"28","name":"Nodify(NFY\/BTC)","new_price":6.48e-5,"buy_price":0,"sell_price":0,"min_price":0.00011339999999999999,"max_price":3.24e-5,"change":-0,"volume":0.4},{"id":"22","name":"Litecoin(LTC\/BTC)","new_price":0.014338800000000002,"buy_price":0.0026856,"sell_price":0.0143676,"min_price":0.0095592,"max_price":0.0095592,"change":0.08,"volume":1.85},{"id":"26","name":"Pws(PWS\/BTC)","new_price":3.0e-6,"buy_price":0,"sell_price":0,"min_price":1.0000000000000002e-6,"max_price":5.0e-6,"change":0,"volume":0.6},{"id":"24","name":"Doge(DOGE\/BTC)","new_price":1.6e-6,"buy_price":0,"sell_price":1.4e-6,"min_price":2.0e-7,"max_price":1.4e-6,"change":114.55,"volume":1023.0479999999999},{"id":"18","name":"Openbit(OPN\/BTC)","new_price":0.00011520000000000001,"buy_price":0.00036,"sell_price":0.000576,"min_price":0.00011520000000000001,"max_price":0.000576,"change":0.04,"volume":23.0512},{"id":"32","name":"Mog(MOGWAI\/BTC)","new_price":0,"buy_price":0,"sell_price":0,"min_price":0,"max_price":0,"change":-0,"volume":0}]}}'
+    http_version: 
+  recorded_at: Sun, 02 Dec 2018 12:52:21 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/openbit/integration/market_spec.rb
+++ b/spec/exchanges/openbit/integration/market_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+RSpec.describe 'Openbit integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:doge_btc_pair) { Cryptoexchange::Models::MarketPair.new(base: 'DOGE', target: 'BTC', market: 'openbit') }
+
+  it 'has trade_page_url' do
+    trade_page_url = client.trade_page_url doge_btc_pair.market, base: doge_btc_pair.base, target: doge_btc_pair.target
+    expect(trade_page_url).to eq "https://market.openbit.online/trade/index/market/doge_btc"
+  end
+
+  it 'fetch pairs' do
+    pairs = client.pairs('openbit')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.market).to eq 'openbit'
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(doge_btc_pair)
+
+    expect(ticker.base).to eq 'DOGE'
+    expect(ticker.target).to eq 'BTC'
+    expect(ticker.market).to eq 'openbit'
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.low).to be_a Numeric
+    expect(ticker.high).to be_a Numeric
+    expect(ticker.bid).to be_a Numeric
+    expect(ticker.ask).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+    expect(ticker.timestamp).to be nil
+    expect(ticker.payload).to_not be nil
+  end
+  #
+  # it 'fetch order book' do
+  #   order_book = client.order_book(doge_btc_pair)
+  #
+  #   expect(order_book.base).to eq 'DOGE'
+  #   expect(order_book.target).to eq 'BTC'
+  #   expect(order_book.market).to eq 'openbit'
+  #   expect(order_book.asks).to_not be_empty
+  #   expect(order_book.bids).to_not be_empty
+  #   expect(order_book.asks.first.price).to_not be_nil
+  #   expect(order_book.bids.first.amount).to_not be_nil
+  #   expect(order_book.bids.first.timestamp).to be_nil
+  #   expect(order_book.asks.count).to be > 5
+  #   expect(order_book.bids.count).to be > 5
+  #   expect(order_book.timestamp).to be nil
+  #   expect(order_book.payload).to_not be nil
+  # end
+  #
+  # it 'fetch trade' do
+  #   trades = client.trades(doge_btc_pair)
+  #   trade = trades.sample
+  #
+  #   expect(trades).to_not be_empty
+  #   expect(trade.base).to eq 'DOGE'
+  #   expect(trade.target).to eq 'BTC'
+  #   expect(trade.market).to eq 'openbit'
+  #   expect(trade.trade_id).to_not be_nil
+  #   expect(['buy', 'sell']).to include trade.type
+  #   expect(trade.price).to_not be_nil
+  #   expect(trade.amount).to_not be_nil
+  #   expect(trade.timestamp).to be_a Numeric
+  #   expect(2000..Date.today.year).to include(Time.at(trade.timestamp).year)
+  #   expect(trade.payload).to_not be nil
+  # end
+end

--- a/spec/exchanges/openbit/market_spec.rb
+++ b/spec/exchanges/openbit/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Openbit::Market do
+  it { expect(described_class::NAME).to eq 'openbit' }
+  it { expect(described_class::API_URL).to eq 'https://market.openbit.online' }
+end


### PR DESCRIPTION
- Add Pairs, Tickers, Trade URL, and updated README for Openbit
- Closes: #1177 
- [X] I have added Specs
- [X] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [X] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [X] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [X] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
