### PR TITLE
Missing trade_page_url to exchanges (Part B) 

### DIFF
--- a/lib/cryptoexchange/exchanges/bit_z/market.rb
+++ b/lib/cryptoexchange/exchanges/bit_z/market.rb
@@ -3,6 +3,10 @@ module Cryptoexchange::Exchanges
     class Market < Cryptoexchange::Models::Market
       NAME = 'bit_z'
       API_URL = "https://apiv2.bitz.com".freeze
+
+      def self.trade_page_url(args={})
+        "https://bitz.com/exchange/#{args[:base].downcase}_#{args[:target].downcase}"
+      end
     end
   end
 end

--- a/lib/cryptoexchange/exchanges/bitbay/market.rb
+++ b/lib/cryptoexchange/exchanges/bitbay/market.rb
@@ -3,6 +3,10 @@ module Cryptoexchange::Exchanges
     class Market < Cryptoexchange::Models::Market
       NAME = 'bitbay'
       API_URL = 'https://bitbay.net/API/Public'
+
+      def self.trade_page_url(args={})
+        "https://bitbay.net/en/exchange-rate"
+      end
     end
   end
 end

--- a/lib/cryptoexchange/exchanges/bitbns/market.rb
+++ b/lib/cryptoexchange/exchanges/bitbns/market.rb
@@ -3,6 +3,10 @@ module Cryptoexchange::Exchanges
     class Market < Cryptoexchange::Models::Market
       NAME = 'bitbns'
       API_URL = 'https://bitbns.com'
+
+      def self.trade_page_url(args={})
+        "https://bitbns.com/trade/#/#{args[:base].downcase}"
+      end
     end
   end
 end

--- a/lib/cryptoexchange/exchanges/bitflyer/market.rb
+++ b/lib/cryptoexchange/exchanges/bitflyer/market.rb
@@ -3,6 +3,10 @@ module Cryptoexchange::Exchanges
     class Market < Cryptoexchange::Models::Market
       NAME = 'bitflyer'
       API_URL = 'https://api.bitflyer.jp/v1'
+
+      def self.trade_page_url(args={})
+        "https://bitflyer.com/en-jp/ex/simpleex"
+      end
     end
   end
 end

--- a/lib/cryptoexchange/exchanges/bitforex/market.rb
+++ b/lib/cryptoexchange/exchanges/bitforex/market.rb
@@ -3,6 +3,10 @@ module Cryptoexchange::Exchanges
     class Market < Cryptoexchange::Models::Market
       NAME = 'bitforex'
       API_URL = 'https://www.bitforex.com/server'
+
+      def self.trade_page_url(args={})
+        "https://www.bitforex.com/trade/spotTrading?commodityCode=#{args[:base].upcase}&currencyCode=#{args[:target].upcase}"
+      end
     end
   end
 end

--- a/lib/cryptoexchange/exchanges/bithumb/market.rb
+++ b/lib/cryptoexchange/exchanges/bithumb/market.rb
@@ -3,6 +3,10 @@ module Cryptoexchange::Exchanges
     class Market < Cryptoexchange::Models::Market
       NAME = 'bithumb'
       API_URL = 'https://api.bithumb.com'
+
+      def self.trade_page_url(args={})
+        "https://www.bithumb.com/trade/order/#{args[:base].upcase}"
+      end
     end
   end
 end

--- a/spec/exchanges/bit_z/integration/market_spec.rb
+++ b/spec/exchanges/bit_z/integration/market_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 RSpec.describe 'BitZ integration specs' do
   let(:client) { Cryptoexchange::Client.new }
-  let(:ltc_btc_pair) { Cryptoexchange::Models::MarketPair.new(base: 'ltc', target: 'btc', market: 'bit_z') }
+  let(:market) { 'bit_z' }
+  let(:ltc_btc_pair) { Cryptoexchange::Models::MarketPair.new(base: 'ltc', target: 'btc', market: market) }
 
   it 'fetch pairs' do
     pairs = client.pairs('bit_z')
@@ -12,6 +13,11 @@ RSpec.describe 'BitZ integration specs' do
     expect(pair.base).to_not be_nil
     expect(pair.target).to_not be_nil
     expect(pair.market).to eq 'bit_z'
+  end
+
+  it 'give trade url' do
+    trade_page_url = client.trade_page_url market, base: ltc_btc_pair.base, target: ltc_btc_pair.target
+    expect(trade_page_url).to eq "https://bitz.com/exchange/ltc_btc"
   end
 
   it 'fetch ticker' do

--- a/spec/exchanges/bitbay/integration/market_spec.rb
+++ b/spec/exchanges/bitbay/integration/market_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe 'Bitbay integration specs' do
     expect(pair.market).to eq 'bitbay'
   end
 
+  it 'give trade url' do
+    trade_page_url = client.trade_page_url btc_usd_pair.market
+    expect(trade_page_url).to eq "https://bitbay.net/en/exchange-rate"
+  end
+
   it 'fetch ticker' do
     ticker = client.ticker(btc_usd_pair)
 

--- a/spec/exchanges/bitbns/integration/market_spec.rb
+++ b/spec/exchanges/bitbns/integration/market_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe 'BitBNS integration specs' do
     expect(pair.market).to eq 'bitbns'
   end
 
+  it 'give trade url' do
+    trade_page_url = client.trade_page_url btc_inr_pair.market, base: btc_inr_pair.base, target: btc_inr_pair.target
+    expect(trade_page_url).to eq "https://bitbns.com/trade/#/btc"
+  end
+
   it 'fetch ticker' do
     ticker = client.ticker(btc_inr_pair)
 

--- a/spec/exchanges/bitflyer/integration/market_spec.rb
+++ b/spec/exchanges/bitflyer/integration/market_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe 'Bitflyer integration specs' do
     expect(pair.market).to eq 'bitflyer'
   end
 
+  it 'give trade url' do
+    trade_page_url = client.trade_page_url btc_jpy_pair.market, base: btc_jpy_pair.base, target: btc_jpy_pair.target
+    expect(trade_page_url).to eq "https://bitflyer.com/en-jp/ex/simpleex"
+  end
+
   it 'fetch ticker' do
     ticker = client.ticker(btc_jpy_pair)
 

--- a/spec/exchanges/bitforex/integration/market_spec.rb
+++ b/spec/exchanges/bitforex/integration/market_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 RSpec.describe 'Bitforex integration specs' do
   let(:client) { Cryptoexchange::Client.new }
-  let(:btc_usdt_pair) { Cryptoexchange::Models::MarketPair.new(base: 'BTC', target: 'USDT', market: 'bitforex') }
+  let(:market) { 'bitforex' }
+  let(:btc_usdt_pair) { Cryptoexchange::Models::MarketPair.new(base: 'BTC', target: 'USDT', market: market) }
 
   it 'fetch pairs' do
     pairs = client.pairs('bitforex')
@@ -12,6 +13,11 @@ RSpec.describe 'Bitforex integration specs' do
     expect(pair.base).to_not be nil
     expect(pair.target).to_not be nil
     expect(pair.market).to eq 'bitforex'
+  end
+
+  it 'give trade url' do
+    trade_page_url = client.trade_page_url market, base: btc_usdt_pair.base, target: btc_usdt_pair.target
+    expect(trade_page_url).to eq 'https://www.bitforex.com/trade/spotTrading?commodityCode=BTC&currencyCode=USDT'
   end
 
   it 'fetch ticker' do

--- a/spec/exchanges/bithumb/integration/market_spec.rb
+++ b/spec/exchanges/bithumb/integration/market_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe 'Bithumb integration specs' do
     expect(pair.market).to eq 'bithumb'
   end
 
+  it 'give trade url' do
+    trade_page_url = client.trade_page_url btc_krw_pair.market, base: btc_krw_pair.base, target: btc_krw_pair.target
+    expect(trade_page_url).to eq "https://www.bithumb.com/trade/order/BTC"
+  end
+
   it 'fetch ticker' do
     ticker = client.ticker(btc_krw_pair)
 


### PR DESCRIPTION
- Add remaining trade URLs for exchanges listed in PR #995 

- [X] Bitbay
- [X]  BitBNS
- [X]  Bitflyer
- [X]  Bithumb

- Closes #991 

