### PR TITLE
BitFex.trade integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Or install it yourself as:
 | Bitebtc           | Y       | Y          | Y       |         | Y           | Y        | bitebtc           |
 | Bitex.la          | Y       | Y          |         |         | Y           |          | bitex             |
 | Bitexlive         | Y       | N          | N       |         | Y           | Y        | bitexlive         |
+| BitFex.Trade      | Y       |            |         |         | Y           | Y        | bitfex            |
 | Bitfinex          | Y       |            |         |         | Y           |          | bitfinex          |
 | Bitflyer          | Y       |            |         |         | Y           |          | bitflyer          |
 | Bitforex          | Y       | N          | N       |         | Y           |          | bitforex          |

--- a/lib/cryptoexchange/exchanges/bitfex/market.rb
+++ b/lib/cryptoexchange/exchanges/bitfex/market.rb
@@ -1,0 +1,12 @@
+module Cryptoexchange::Exchanges
+  module Bitfex
+    class Market < Cryptoexchange::Models::Market
+      NAME = 'bitfex'.freeze
+      API_URL = 'https://bitfex.trade'.freeze
+
+      def self.trade_page_url(args = {})
+        "https://bitfex.trade/en/#{args[:base]}/#{args[:target]}"
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/bitfex/services/market.rb
+++ b/lib/cryptoexchange/exchanges/bitfex/services/market.rb
@@ -1,0 +1,40 @@
+module Cryptoexchange::Exchanges
+  module Bitfex
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          trading_pair_id = "#{market_pair.base}_#{market_pair.target}"
+          "#{Cryptoexchange::Exchanges::Bitfex::Market::API_URL}/api/v1/ticker/#{trading_pair_id}"
+        end
+
+        def adapt(output, market_pair)
+          ticker = Cryptoexchange::Models::Ticker.new
+
+          ticker.base      = market_pair.base
+          ticker.target    = market_pair.target
+          ticker.market    = Bitfex::Market::NAME
+          ticker.last      = NumericHelper.to_d(output['last'])
+          ticker.high      = NumericHelper.to_d(output['high'])
+          ticker.low       = NumericHelper.to_d(output['low'])
+          ticker.ask       = NumericHelper.to_d(output['buy'])
+          ticker.bid       = NumericHelper.to_d(output['sell'])
+          ticker.volume    = NumericHelper.to_d(output['vol'])
+          ticker.timestamp = NumericHelper.to_d(output['updated'])
+          ticker.payload   = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/bitfex/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/bitfex/services/pairs.rb
@@ -1,0 +1,19 @@
+module Cryptoexchange::Exchanges
+  module Bitfex
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Bitfex::Market::API_URL}/api/3/info".freeze
+        def fetch
+          super['pairs'].map do |(pair, _info)|
+            base, target = pair.split('_')
+            Cryptoexchange::Models::MarketPair.new(
+              base: base,
+              target: target,
+              market: Bitfex::Market::NAME
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/Bitfex/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/Bitfex/integration_specs_fetch_pairs.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://bitfex.trade/api/3/info
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - bitfex.trade
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 15 Dec 2018 18:50:47 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Runtime:
+      - '0.003053'
+    body:
+      encoding: UTF-8
+      string: '{"server_time":1544899847,"pairs":{"btc_rur":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"bch_rur":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"bch_btc":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"bch_ltc":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"bch_dash":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"ltc_btc":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"ltc_rur":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"dash_btc":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"dash_rur":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"dash_ltc":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"steep_rur":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"steep_btc":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"steep_ltc":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"steep_bch":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"steep_dash":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"onion_rur":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"onion_btc":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"btc_usd":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"bch_usd":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"ltc_usd":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"dash_usd":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"rth_btc":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"eth_rur":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"eth_btc":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"eth_bch":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"eth_ltc":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"eth_dash":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"eth_usd":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"pcl_eth":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"kwh_eth":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"kwh_btc":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"kwh_ltc":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"kwh_dash":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"ben_btc":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"ben_usd":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"ben_rur":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"ben_eth":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"ben_ltc":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"rth_bch":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"rth_ltc":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"rth_dash":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"rth_eth":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"rth_usd":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"rth_rur":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"odc_btc":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"odc_eth":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"odc_usd":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"acm_btc":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"acm_ltc":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"acm_usd":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"acm_rur":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"yoc_btc":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"odc_rur":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"xem_btc":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"snrc_btc":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"pul_btc":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"rmc_btc":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"flip_btc":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"flip_rur":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"flip_usd":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"sla_usd":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"btcdm_btc":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"btcdm_eth":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"help_eth":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15},"mnc_btc":{"decimal_places":8,"min_price":1e-05,"max_price":999999999,"min_amount":1e-05,"hidden":0,"fee":0.15}}}'
+    http_version: 
+  recorded_at: Sat, 15 Dec 2018 18:50:47 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Bitfex/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/Bitfex/integration_specs_fetch_ticker.yml
@@ -1,0 +1,38 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://bitfex.trade/api/v1/ticker/BTC_RUR
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - bitfex.trade
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 15 Dec 2018 18:50:48 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Runtime:
+      - '0.206846'
+    body:
+      encoding: UTF-8
+      string: '{"success":true,"last":231071.8,"high":234356.29,"low":225366.32,"buy":228219.06,"sell":230120.89,"vol":0.44111686,"updated":1544899848}'
+    http_version: 
+  recorded_at: Sat, 15 Dec 2018 18:50:48 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/bitfex/integration/market_spec.rb
+++ b/spec/exchanges/bitfex/integration/market_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+RSpec.describe 'Bitfex integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:btc_rur_pair) { Cryptoexchange::Models::MarketPair.new(base: 'BTC', target: 'RUR', market: 'bitfex') }
+
+  it 'fetch pairs' do
+    pairs = client.pairs('bitfex')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).not_to be_nil
+    expect(pair.target).not_to be_nil
+    expect(pair.market).to eq 'bitfex'
+  end
+
+  it 'give trade url' do
+    trade_page_url = client.trade_page_url 'bitfex', base: btc_rur_pair.base, target: btc_rur_pair.target
+    expect(trade_page_url).to eq 'https://bitfex.trade/en/BTC/RUR'
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(btc_rur_pair)
+
+    expect(ticker.base).to eq 'BTC'
+    expect(ticker.target).to eq 'RUR'
+    expect(ticker.market).to eq 'bitfex'
+
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.bid).to be_a Numeric
+    expect(ticker.ask).to be_a Numeric
+    expect(ticker.high).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+
+    expect(ticker.timestamp).to be_a Numeric
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
+
+    expect(ticker.payload).to_not be nil
+  end
+end

--- a/spec/exchanges/bitfex/market_spec.rb
+++ b/spec/exchanges/bitfex/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Bitfex::Market do
+  it { expect(described_class::NAME).to eq 'bitfex' }
+  it { expect(described_class::API_URL).to eq 'https://bitfex.trade' }
+end


### PR DESCRIPTION
- [x] I have added Specs
- [x] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [x] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [x] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [x] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'bitfex'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```