### PR TITLE
LocalTrade Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Or install it yourself as:
 | Liqui             | Y       |            |         |         | Y           |          | liqui             |
 | LiteBit.eu        | Y       |            |         |         | Y           |          | litebiteu         |
 | Livecoin          | Y       |            |         |         | Y           |          | livecoin          |
+| LocalTrade        | Y       |            |         |         | Y           | Y        | localtrade        |
 | Luno              | Y       |            |         |         | Y           | Y        | luno              |
 | Lykke             | Y       | Y          | N       |         | Y           |          | lykke             |
 | Maplechange       | Y       | Y          |         |         | Y           | Y        | maplechange       |

--- a/lib/cryptoexchange/exchanges/localtrade/market.rb
+++ b/lib/cryptoexchange/exchanges/localtrade/market.rb
@@ -1,0 +1,12 @@
+module Cryptoexchange::Exchanges
+  module Localtrade
+    class Market < Cryptoexchange::Models::Market
+      NAME = 'localtrade'
+      API_URL = 'https://localtrade.cc/main'
+
+      def self.trade_page_url(args={})
+        "https://localtrade.cc/"
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/localtrade/services/market.rb
+++ b/lib/cryptoexchange/exchanges/localtrade/services/market.rb
@@ -1,0 +1,48 @@
+module Cryptoexchange::Exchanges
+  module Localtrade
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            false
+          end
+        end
+
+        def fetch
+          output = super(ticker_url)
+          adapt_all(output)
+        end
+
+        def ticker_url
+          "#{Cryptoexchange::Exchanges::Localtrade::Market::API_URL}/ticker/"
+        end
+
+        def adapt_all(output)
+          output.map do |pair|
+            base, target = pair[0].split('_')
+            market_pair  = Cryptoexchange::Models::MarketPair.new(
+              base:   base,
+              target: target,
+              market: Localtrade::Market::NAME
+            )
+            adapt(market_pair, pair[1])
+          end
+        end
+
+        def adapt(market_pair, output)
+          ticker           = Cryptoexchange::Models::Ticker.new
+          ticker.base      = market_pair.base
+          ticker.target    = market_pair.target
+          ticker.market    = Localtrade::Market::NAME
+          ticker.last      = NumericHelper.to_d(output['lastPrice'])
+          ticker.high      = NumericHelper.to_d(output['highPrice'])
+          ticker.low       = NumericHelper.to_d(output['lowPrice'])
+          ticker.volume    = NumericHelper.to_d(output['baseVolume'])
+          ticker.timestamp = nil
+          ticker.payload   = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/localtrade/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/localtrade/services/pairs.rb
@@ -1,0 +1,23 @@
+module Cryptoexchange::Exchanges
+  module Localtrade
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Localtrade::Market::API_URL}/ticker/"
+
+        def fetch
+          output = super
+          market_pairs = []
+          output.each do |pair|
+            base, target = pair[0].split('_')
+            market_pairs << Cryptoexchange::Models::MarketPair.new(
+                              base: base,
+                              target: target,
+                              market: Localtrade::Market::NAME
+                            )
+          end
+          market_pairs
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/LocalTrade/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/LocalTrade/integration_specs_fetch_pairs.yml
@@ -1,0 +1,44 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://localtrade.cc/main/ticker/
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - localtrade.cc
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 08 Jan 2019 20:40:48 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - JSESSIONID=334D47773B448B98AB1913CCC172A6AA; Path=/main; Secure; HttpOnly
+      - __cfduid=dd199dcacf038d89de19fb2fb83d9b9001546980047; expires=Wed, 08-Jan-20
+        20:40:47 GMT; path=/; domain=.localtrade.cc; HttpOnly
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 49617b309c04c2bf-FRA
+    body:
+      encoding: UTF-8
+      string: '{"LTC_BTC":{"highPrice":"0.01005600","id":"18","quoteVolume":"303.89204076","baseVolume":"31401.91410000","lowPrice":"0.00933050","lastPrice":"0.00983920"},"ZEC_BTC":{"highPrice":"0.01531300","id":"23","quoteVolume":"1325.77130515","baseVolume":"88402.54100000","lowPrice":"0.01481000","lastPrice":"0.01512700"},"MNC_BTC":{"highPrice":"0.00000000","id":"37","quoteVolume":"0.00000000","baseVolume":"0.00000000","lowPrice":"0.00000000","lastPrice":"0.00000000"},"EDR_BTC":{"highPrice":"0.00000214","id":"3","quoteVolume":"35.82581313","baseVolume":"16934979.56887800","lowPrice":"0.00000206","lastPrice":"0.00000209"},"BTC_IDR":{"highPrice":"4000.00000000","id":"31","quoteVolume":"3.71200000","baseVolume":"0.00092800","lowPrice":"4000.00000000","lastPrice":"4000.00000000"},"ECHT_BTC":{"highPrice":"0.00000000","id":"33","quoteVolume":"0.00000000","baseVolume":"0.00000000","lowPrice":"0.00000000","lastPrice":"0.00000000"},"ETH_USD":{"highPrice":"157.32000000","id":"11","quoteVolume":"37089788.37456231","baseVolume":"241017.73782700","lowPrice":"125.00000000","lastPrice":"154.21000000"},"EDR_LTC":{"highPrice":"0.00029890","id":"4","quoteVolume":"3777.80173036","baseVolume":"17234241.86000000","lowPrice":"0.00020906","lastPrice":"0.00021359"},"ECHT_USD":{"highPrice":"0.00000000","id":"32","quoteVolume":"0.00000000","baseVolume":"0.00000000","lowPrice":"0.00000000","lastPrice":"0.00000000"},"EDR_ETH":{"highPrice":"0.00005761","id":"7","quoteVolume":"3034.49866480","baseVolume":"53592059.40000000","lowPrice":"0.00005539","lastPrice":"0.00005608"},"MNC_ETH":{"highPrice":"0.00000000","id":"38","quoteVolume":"0.00000000","baseVolume":"0.00000000","lowPrice":"0.00000000","lastPrice":"0.00000000"},"ETH_BTC":{"highPrice":"5.14600000","id":"20","quoteVolume":"352.94483562","baseVolume":"9451.83760000","lowPrice":"0.03701400","lastPrice":"0.03735100"},"EDR_IDR":{"highPrice":"128.00000000","id":"30","quoteVolume":"3278440.72735880","baseVolume":"26567.20997870","lowPrice":"121.00000000","lastPrice":"121.00000000"},"MNC_IDR":{"highPrice":"0.00000000","id":"39","quoteVolume":"0.00000000","baseVolume":"0.00000000","lowPrice":"0.00000000","lastPrice":"0.00000000"},"LTC_USD":{"highPrice":"41.94600000","id":"9","quoteVolume":"12959906.61514041","baseVolume":"325091.99490000","lowPrice":"38.22300000","lastPrice":"40.61900000"},"ETH_LTC":{"highPrice":"4.02447758","id":"22","quoteVolume":"137377.39113182","baseVolume":"35482.75770000","lowPrice":"3.74447879","lastPrice":"3.80612322"},"DASH_USD":{"highPrice":"85.33100000","id":"10","quoteVolume":"4077572.91469980","baseVolume":"48626.15390000","lowPrice":"82.01700000","lastPrice":"82.67600000"},"ZEC_USD":{"highPrice":"63.81300000","id":"24","quoteVolume":"1702913.27343200","baseVolume":"27567.07220000","lowPrice":"60.71200000","lastPrice":"62.42100000"},"BTC_USD":{"highPrice":"4198.80000000","id":"8","quoteVolume":"9043601.95826814","baseVolume":"2195.83940000","lowPrice":"4063.70000000","lastPrice":"4129.90000000"},"ECHT_IDR":{"highPrice":"0.00000000","id":"35","quoteVolume":"0.00000000","baseVolume":"0.00000000","lowPrice":"0.00000000","lastPrice":"0.00000000"},"EDR_USD":{"highPrice":"0.00950000","id":"2","quoteVolume":"30370.78293309","baseVolume":"3546984.12693029","lowPrice":"0.00846645","lastPrice":"0.00849693"},"EDR_DASH":{"highPrice":"0.00010508","id":"6","quoteVolume":"766.21455845","baseVolume":"7423010.00000000","lowPrice":"0.00010166","lastPrice":"0.00010412"},"ECHT_ETH":{"highPrice":"0.00000000","id":"34","quoteVolume":"0.00000000","baseVolume":"0.00000000","lowPrice":"0.00000000","lastPrice":"0.00000000"},"MNC_USD":{"highPrice":"0.00000000","id":"36","quoteVolume":"0.00000000","baseVolume":"0.00000000","lowPrice":"0.00000000","lastPrice":"0.00000000"}}'
+    http_version: 
+  recorded_at: Tue, 08 Jan 2019 20:40:48 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/localtrade/integration/market_spec.rb
+++ b/spec/exchanges/localtrade/integration/market_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe 'LocalTrade integration specs' do
     expect(ticker.last).to be_a Numeric
     expect(ticker.low).to be_a Numeric
     expect(ticker.high).to be_a Numeric
-    expect(ticker.change).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be nil
     expect(ticker.payload).to_not be nil

--- a/spec/exchanges/localtrade/integration/market_spec.rb
+++ b/spec/exchanges/localtrade/integration/market_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+RSpec.describe 'LocalTrade integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:btc_usd_pair) { Cryptoexchange::Models::MarketPair.new(base: 'BTC', target: 'USD', market: 'localtrade', inst_id: 49) }
+
+  it 'has trade_page_url' do
+    trade_page_url = client.trade_page_url btc_usd_pair.market, base: btc_usd_pair.base, target: btc_usd_pair.target
+    expect(trade_page_url).to eq "https://localtrade.cc/"
+  end
+
+  it 'fetch pairs' do
+    pairs = client.pairs('localtrade')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.market).to eq 'localtrade'
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(btc_usd_pair)
+
+    expect(ticker.base).to eq 'BTC'
+    expect(ticker.target).to eq 'USD'
+    expect(ticker.market).to eq 'localtrade'
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.low).to be_a Numeric
+    expect(ticker.high).to be_a Numeric
+    expect(ticker.change).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+    expect(ticker.timestamp).to be nil
+    expect(ticker.payload).to_not be nil
+  end
+  #
+  # it 'fetch order book' do
+  #   order_book = client.order_book(btc_usd_pair)
+  #
+  #   expect(order_book.base).to eq 'BTC'
+  #   expect(order_book.target).to eq 'USD'
+  #   expect(order_book.market).to eq 'localtrade'
+  #   expect(order_book.asks).to_not be_empty
+  #   expect(order_book.bids).to_not be_empty
+  #   expect(order_book.asks.first.price).to_not be_nil
+  #   expect(order_book.bids.first.amount).to_not be_nil
+  #   expect(order_book.bids.first.timestamp).to be_nil
+  #   expect(order_book.asks.count).to be > 5
+  #   expect(order_book.bids.count).to be > 5
+  #   expect(order_book.timestamp).to be nil
+  #   expect(order_book.payload).to_not be nil
+  # end
+  #
+  # it 'fetch trade' do
+  #   trades = client.trades(btc_usd_pair)
+  #   trade = trades.sample
+  #
+  #   expect(trades).to_not be_empty
+  #   expect(trade.base).to eq 'BTC'
+  #   expect(trade.target).to eq 'USD'
+  #   expect(trade.market).to eq 'localtrade'
+  #   expect(trade.trade_id).to_not be_nil
+  #   expect(['buy', 'sell']).to include trade.type
+  #   expect(trade.price).to_not be_nil
+  #   expect(trade.amount).to_not be_nil
+  #   expect(trade.timestamp).to be_a Numeric
+  #   expect(2000..Date.today.year).to include(Time.at(trade.timestamp).year)
+  #   expect(trade.payload).to_not be nil
+  # end
+end

--- a/spec/exchanges/localtrade/market_spec.rb
+++ b/spec/exchanges/localtrade/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Localtrade::Market do
+  it { expect(described_class::NAME).to eq 'localtrade' }
+  it { expect(described_class::API_URL).to eq 'https://localtrade.cc/main' }
+end


### PR DESCRIPTION
- Add Pairs, Tickers, Trade URL and updated README for Localtrade.cc
- Closes: #762 
- [X] I have added Specs
- [X] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [X] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [X] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
**- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)** _Unable to verify volume against website - not able to locate on trading page_
