### PR TITLE
♻️ update: refactor abcc about distinguish which token is base or target in Pair string

### DIFF
--- a/lib/cryptoexchange/exchanges/abcc/market.rb
+++ b/lib/cryptoexchange/exchanges/abcc/market.rb
@@ -3,9 +3,17 @@ module Cryptoexchange::Exchanges
     class Market < Cryptoexchange::Models::Market
       NAME    = 'abcc'
       API_URL = 'https://api.abcc.com/api/v2'
+      class << self
+        def trade_page_url(args = {})
+          "https://abcc.com/markets/#{args[:base]}#{args[:target]}"
+        end
 
-      def self.trade_page_url(args={})
-        "https://abcc.com/markets/#{args[:base]}#{args[:target]}"
+        def separate_symbol(pair)
+          separator = /(USDT|BTC|ETH)\z/i =~ pair
+          base      = pair[0..separator - 1]
+          target    = pair[separator..-1]
+          [base, target]
+        end
       end
     end
   end

--- a/lib/cryptoexchange/exchanges/abcc/services/market.rb
+++ b/lib/cryptoexchange/exchanges/abcc/services/market.rb
@@ -19,22 +19,15 @@ module Cryptoexchange::Exchanges
 
         def adapt_all(output)
           output.map do |pair, ticker|
-            separator   = /(USDT|BTC|ETH)\z/i =~ pair
-            base        = pair[0..separator - 1]
-            target      = pair[separator..-1]
-            market_pair = Cryptoexchange::Models::MarketPair.new(
-              base:   base,
-              target: target,
-              market: Abcc::Market::NAME
-            )
-            adapt(ticker, market_pair)
+            adapt(pair, ticker)
           end
         end
 
-        def adapt(output, market_pair)
+        def adapt(pair, output)
+          base, target = Abcc::Market.separate_symbol(pair)
           ticker           = Cryptoexchange::Models::Ticker.new
-          ticker.base      = market_pair.base
-          ticker.target    = market_pair.target
+          ticker.base      = base
+          ticker.target    = target
           ticker.market    = Abcc::Market::NAME
           ticker.bid       = NumericHelper.to_d(HashHelper.dig(output, 'ticker', 'buy'))
           ticker.ask       = NumericHelper.to_d(HashHelper.dig(output, 'ticker', 'sell'))

--- a/lib/cryptoexchange/exchanges/abcc/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/abcc/services/pairs.rb
@@ -11,9 +11,7 @@ module Cryptoexchange::Exchanges
 
         def adapt(output)
           output.map do |pair, _ticker|
-            separator = /(USDT|BTC|ETH)\z/i =~ pair
-            base      = pair[0..separator - 1]
-            target    = pair[separator..-1]
+            base, target = Abcc::Market.separate_symbol(pair)
             Cryptoexchange::Models::MarketPair.new(
               base: base,
               target: target,

--- a/spec/exchanges/abcc/market_spec.rb
+++ b/spec/exchanges/abcc/market_spec.rb
@@ -3,4 +3,10 @@ require 'spec_helper'
 RSpec.describe Cryptoexchange::Exchanges::Abcc::Market do
   it { expect(described_class::NAME).to eq 'abcc' }
   it { expect(described_class::API_URL).to eq 'https://api.abcc.com/api/v2' }
+
+  describe 'with the string of a pair' do
+    it 'can separate to base and target' do
+      expect(described_class.separate_symbol('LTCBTC')).to match_array(['LTC', 'BTC'])
+    end
+  end
 end


### PR DESCRIPTION
- What is the purpose of this Pull Request?
 - refactor that moving the token separator in one place, don't need to write twice in pair and market files.
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")? no 
- [x] I have added Specs

if this is a better option for a token separator, I will do other refactors about this
