### PR TITLE
👽 Update Coinfield API and add order book and trades

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Or install it yourself as:
 | Coineal           | Y       | Y          | Y       |         | Y           |          | coineal           |
 | Coinex            | Y       | Y          | Y       |         | Y           | Y        | coinex            |
 | Coinfalcon        | Y       | Y          | Y       |         | Y           |          | coinfalcon        |
-| Coinfield         | Y       | N          | N       |         | Y           | Y        | coinfield         |
+| Coinfield         | Y       | Y          | Y       |         | Y           | Y        | coinfield         |
 | Coingi            | Y       | Y          | Y       |         | Y           | Y        | coingi            |
 | Coinhouse         | Y       |            |         |         | Y           | Y        | coinhouse         |
 | Coinhub           | Y       | Y          | Y       |         | Y           | Y        | coinhub           |

--- a/lib/cryptoexchange/exchanges/coinfield/market.rb
+++ b/lib/cryptoexchange/exchanges/coinfield/market.rb
@@ -2,7 +2,7 @@ module Cryptoexchange::Exchanges
   module Coinfield
     class Market < Cryptoexchange::Models::Market
       NAME = 'coinfield'
-      API_URL = 'https://platform.coinfield.com/api/v2/'
+      API_URL = 'https://api.coinfield.com/v1'
 
       def self.trade_page_url(args={})
         "https://trade.coinfield.com/pro/trade/#{args[:base]}-#{args[:target]}"

--- a/lib/cryptoexchange/exchanges/coinfield/services/market.rb
+++ b/lib/cryptoexchange/exchanges/coinfield/services/market.rb
@@ -18,35 +18,39 @@ module Cryptoexchange::Exchanges
         end
 
         def adapt_all(output)
-          output.map do |pair, ticker|
-            separator = /(cad|usd|btc)\z/ =~ pair
-            next if separator.nil?
-
-            base    = pair[0..separator -1]
-            target  = pair[separator..-1]
-            market_pair = Cryptoexchange::Models::MarketPair.new(
-              base: base,
-              target: target,
-              market: Coinfield::Market::NAME
-            )
+          output['markets'].map do |ticker|
+            market_pair = split_symbol(ticker['market'])
+            next if market_pair.nil?
             adapt(ticker, market_pair)
-          end
+          end.compact
         end
 
         def adapt(output, market_pair)
           ticker           = Cryptoexchange::Models::Ticker.new
-          ticker.base      = market_pair.base
-          ticker.target    = market_pair.target
+          ticker.base      = market_pair[:base]
+          ticker.target    = market_pair[:target]
           ticker.market    = Coinfield::Market::NAME
-          ticker.ask       = NumericHelper.to_d(output['ticker']['sell'])
-          ticker.bid       = NumericHelper.to_d(output['ticker']['buy'])
-          ticker.high      = NumericHelper.to_d(output['ticker']['high'])
-          ticker.low       = NumericHelper.to_d(output['ticker']['low'])
-          ticker.last      = NumericHelper.to_d(output['ticker']['last'])
-          ticker.volume    = NumericHelper.to_d(output['ticker']['vol'])
-          ticker.timestamp = output['at']
+          ticker.ask       = NumericHelper.to_d(output['ask'])
+          ticker.bid       = NumericHelper.to_d(output['bid'])
+          ticker.high      = NumericHelper.to_d(output['high'])
+          ticker.low       = NumericHelper.to_d(output['low'])
+          ticker.last      = NumericHelper.to_d(output['last'])
+          ticker.volume    = NumericHelper.to_d(output['vol'])
+          ticker.timestamp = Time.parse(output['timestamp']).to_i
           ticker.payload   = output
           ticker
+        end
+
+        private
+
+        def split_symbol(pair)
+          separator = /(XRP|USDC|USD|CAD|EUR|GBP|JPY|AED)\z/i =~ pair
+          return nil if separator.nil?
+
+          {
+            base:   pair[0..(separator -1)],
+            target: pair[separator..-1]
+          }
         end
       end
     end

--- a/lib/cryptoexchange/exchanges/coinfield/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/coinfield/services/order_book.rb
@@ -1,0 +1,45 @@
+module Cryptoexchange::Exchanges
+  module Coinfield
+    module Services
+      class OrderBook < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          base   = market_pair.base.downcase
+          target = market_pair.target.downcase
+          "#{Cryptoexchange::Exchanges::Coinfield::Market::API_URL}/depth/#{base}#{target}"
+        end
+
+        def adapt(output, market_pair)
+          order_book           = Cryptoexchange::Models::OrderBook.new
+          order_book.base      = market_pair.base
+          order_book.target    = market_pair.target
+          order_book.market    = Coinfield::Market::NAME
+          order_book.asks      = adapt_orders output['asks']
+          order_book.bids      = adapt_orders output['bids']
+          order_book.timestamp = Time.parse(output['timestamp']).to_i
+          order_book.payload   = output
+          order_book
+        end
+
+        def adapt_orders(orders)
+          orders.collect do |order_entry|
+            price, amount = order_entry
+            Cryptoexchange::Models::Order.new(price:     price,
+                                              amount:    amount,
+                                              timestamp: nil)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/coinfield/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/coinfield/services/pairs.rb
@@ -10,7 +10,7 @@ module Cryptoexchange::Exchanges
         end
 
         def adapt(output)
-          output.map do |pair|
+          output['markets'].map do |pair|
             base, target = pair['name'].split('/')
             Cryptoexchange::Models::MarketPair.new(
               base: base,

--- a/lib/cryptoexchange/exchanges/coinfield/services/trades.rb
+++ b/lib/cryptoexchange/exchanges/coinfield/services/trades.rb
@@ -1,0 +1,34 @@
+module Cryptoexchange::Exchanges
+  module Coinfield
+    module Services
+      class Trades < Cryptoexchange::Services::Market
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          base   = market_pair.base.downcase
+          target = market_pair.target.downcase
+          "#{Cryptoexchange::Exchanges::Coinfield::Market::API_URL}/trades/#{base}#{target}"
+        end
+
+        def adapt(output, market_pair)
+          output['trades'].collect do |trade|
+            tr           = Cryptoexchange::Models::Trade.new
+            tr.trade_id  = trade['id']
+            tr.base      = market_pair.base
+            tr.target    = market_pair.target
+            tr.type      = nil
+            tr.price     = NumericHelper.to_d(trade['price'])
+            tr.amount    = NumericHelper.to_d(trade['volume'])
+            tr.timestamp = Time.parse(trade['timestamp']).to_i
+            tr.payload   = trade
+            tr.market    = Coinfield::Market::NAME
+            tr
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/Coinfield/integration_specs_fetch_order_book.yml
+++ b/spec/cassettes/vcr_cassettes/Coinfield/integration_specs_fetch_order_book.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.coinfield.com/v1/depth/btccad
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.coinfield.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 16 Jan 2019 14:56:40 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d7761f9b955aa731d8ea6d4d8dc916e4a1547650599; expires=Thu, 16-Jan-20
+        14:56:39 GMT; path=/; domain=.coinfield.com; HttpOnly; Secure
+      - route=a690befdcc81457b323b225bcb3933a6; Domain=api.coinfield.com; Path=/;
+        HttpOnly
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      X-Dns-Prefetch-Control:
+      - 'off'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      X-Download-Options:
+      - noopen
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Id:
+      - 84a88dd4-15a8-4d64-a65e-9dcd245deaa1
+      X-Runtime:
+      - '0.012052'
+      X-Proxy-Runtime:
+      - 26ms
+      X-Fuse-Cached:
+      - 'false'
+      Etag:
+      - W/"3cc-TdLT9FQSU3LqhcrcbFjHrtDUZLU"
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 49a16e17bbd4a2ba-HKG
+    body:
+      encoding: UTF-8
+      string: '{"market":"btccad","bids":[["4769.9","0.0034"],["4722.99","0.2"],["4720.99","0.2"],["4700.01","0.2"],["4700.0","0.62077"],["4600.0","0.5"],["4577.0","0.2"],["4557.6","0.0013"],["4542.41","0.00911025"],["4505.2","0.0039942"],["4493.94","0.00706725"],["4484.95","0.004761"],["4471.94","0.01212165"],["4464.34","0.00260955"],["4456.75","0.01220535"],["4451.85","0.0081162"],["4440.72","0.0031689"],["4434.95","2.7927"],["4428.49","0.001"],["4427.85","0.0072558"]],"asks":[["5134.66","1.266"],["5125.44","0.0101994"],["5117.76","0.0072186"],["5103.98","0.013716"],["5091.25","0.004998"],["5077.54","0.01512"],["5072.98","0.0095646"],["5061.33","3.9754"],["5054.29","0.0013"],["5048.21","0.0155508"],["5033.61","1.0445"],["5023.6","0.009807"],["5019.56","0.005862"],["5013.9","0.0013"],["5008.54","0.006039"],["5000.0","0.06436946"],["4918.16","0.09975"],["4892.81","0.1027475"],["4863.4","0.2899052"],["4819.67","0.0043"]],"timestamp":"2019-01-16T14:56:40.269Z","took":"26ms"}'
+    http_version: 
+  recorded_at: Wed, 16 Jan 2019 14:56:40 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Coinfield/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/Coinfield/integration_specs_fetch_pairs.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://platform.coinfield.com/api/v2//markets
+    uri: https://api.coinfield.com/v1/markets
     body:
       encoding: UTF-8
       string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Connection:
       - close
       Host:
-      - platform.coinfield.com
+      - api.coinfield.com
       User-Agent:
       - http.rb/3.0.0
   response:
@@ -19,73 +19,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 29 May 2018 16:52:37 GMT
+      - Wed, 16 Jan 2019 14:56:38 GMT
       Content-Type:
-      - application/json
+      - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
       - close
       Set-Cookie:
-      - __cfduid=d4004e8f215fa4d1dc100470f4b5404641527612757; expires=Wed, 29-May-19
-        16:52:37 GMT; path=/; domain=.coinfield.com; HttpOnly; Secure
-      Vary:
-      - Accept-Encoding
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE
-      Access-Control-Allow-Headers:
-      - Origin, X-Requested-With, Content-Type, Accept, Authorization
-      Version:
-      - HTTP/1.1
-      Host:
-      - platform.coinfield.com
-      X-Real-Ip:
-      - 73.97.148.141
-      X-Forwarded-For:
-      - 73.97.148.141
-      X-Forwarded-Host:
-      - platform.coinfield.com
-      X-Forwarded-Port:
-      - '443'
-      X-Forwarded-Proto:
-      - https
-      X-Original-Uri:
-      - "/api/v2//markets"
-      X-Scheme:
-      - https
-      X-Original-Forwarded-For:
-      - 73.97.148.141
-      Accept-Encoding:
-      - gzip
-      Cf-Ipcountry:
-      - US
-      Cf-Visitor:
-      - '{"scheme":"https"}'
-      User-Agent:
-      - http.rb/3.0.0
-      Cf-Connecting-Ip:
-      - 73.97.148.141
-      Etag:
-      - W/"0bfc98bb22ef88ab4b912bb13a35c920"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - dbec4ca6-8fbc-4f06-a9e2-ba4d5c256482
-      X-Runtime:
-      - '0.056467'
+      - __cfduid=dabe712215946db845cbed0b6ff0b75921547650597; expires=Thu, 16-Jan-20
+        14:56:37 GMT; path=/; domain=.coinfield.com; HttpOnly; Secure
+      - route=9ac21c7ed2fa285054b7d9867fe54452; Domain=api.coinfield.com; Path=/;
+        HttpOnly
+      X-Dns-Prefetch-Control:
+      - 'off'
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
+      X-Download-Options:
+      - noopen
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Id:
+      - 69b9f871-72a6-41b2-9cc3-a3e61932d9b1
+      X-Runtime:
+      - '0.011274'
+      X-Proxy-Runtime:
+      - 18ms
+      X-Fuse-Cached:
+      - 'false'
+      Etag:
+      - W/"254c-N9/ohvHqudRF1FbMnfk429orbF4"
+      Vary:
+      - Accept-Encoding
       Expect-Ct:
       - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
       Server:
       - cloudflare
       Cf-Ray:
-      - 422a78f3feab2a85-SEA
+      - 49a16e0d4d0aa2b4-HKG
     body:
-      encoding: ASCII-8BIT
-      string: '[{"id":"btccad","name":"BTC/CAD"},{"id":"xrpcad","name":"XRP/CAD"},{"id":"bchcad","name":"BCH/CAD"},{"id":"ltccad","name":"LTC/CAD"},{"id":"ethcad","name":"ETH/CAD"},{"id":"dashcad","name":"DASH/CAD"},{"id":"ethbtc","name":"ETH/BTC"},{"id":"xrpbtc","name":"XRP/BTC"},{"id":"ltcbtc","name":"LTC/BTC"},{"id":"dashbtc","name":"DASH/BTC"},{"id":"bchbtc","name":"BCH/BTC"},{"id":"btcusd","name":"BTC/USD"},{"id":"xrpusd","name":"XRP/USD"}]'
+      encoding: UTF-8
+      string: '{"markets":[{"id":"btcxrp","name":"BTC/XRP","ask_precision":8,"bid_precision":4,"minimum_volume":"0.001","maximum_volume":"50.0","minimum_funds":"20.0","maximum_funds":"500000.0"},{"id":"ethxrp","name":"ETH/XRP","ask_precision":4,"bid_precision":4,"minimum_volume":"0.1","maximum_volume":"300.0","minimum_funds":"20.0","maximum_funds":"500000.0"},{"id":"xlmxrp","name":"XLM/XRP","ask_precision":4,"bid_precision":4,"minimum_volume":"80.0","maximum_volume":"600000.0","minimum_funds":"20.0","maximum_funds":"400000.0"},{"id":"ltcxrp","name":"LTC/XRP","ask_precision":2,"bid_precision":4,"minimum_volume":"0.1","maximum_volume":"1000.0","minimum_funds":"20.0","maximum_funds":"500000.0"},{"id":"dashxrp","name":"DASH/XRP","ask_precision":3,"bid_precision":4,"minimum_volume":"0.1","maximum_volume":"500.0","minimum_funds":"20.0","maximum_funds":"500000.0"},{"id":"bchxrp","name":"BCH/XRP","ask_precision":3,"bid_precision":4,"minimum_volume":"0.05","maximum_volume":"400.0","minimum_funds":"20.0","maximum_funds":"500000.0"},{"id":"zecxrp","name":"ZEC/XRP","ask_precision":3,"bid_precision":4,"minimum_volume":"0.1","maximum_volume":"500.0","minimum_funds":"20.0","maximum_funds":"500000.0"},{"id":"dashcad","name":"DASH/CAD","ask_precision":4,"bid_precision":2,"minimum_volume":"0.1","maximum_volume":"500.0","minimum_funds":"15.0","maximum_funds":"500000.0"},{"id":"btgxrp","name":"BTG/XRP","ask_precision":2,"bid_precision":4,"minimum_volume":"0.5","maximum_volume":"2000.0","minimum_funds":"20.0","maximum_funds":"500000.0"},{"id":"zrxxrp","name":"ZRX/XRP","ask_precision":1,"bid_precision":4,"minimum_volume":"10.0","maximum_volume":"100000.0","minimum_funds":"20.0","maximum_funds":"500000.0"},{"id":"gntxrp","name":"GNT/XRP","ask_precision":1,"bid_precision":4,"minimum_volume":"10.0","maximum_volume":"100000.0","minimum_funds":"20.0","maximum_funds":"500000.0"},{"id":"repxrp","name":"REP/XRP","ask_precision":3,"bid_precision":4,"minimum_volume":"1.0","maximum_volume":"2000.0","minimum_funds":"20.0","maximum_funds":"500000.0"},{"id":"omgxrp","name":"OMG/XRP","ask_precision":2,"bid_precision":4,"minimum_volume":"3.0","maximum_volume":"5000.0","minimum_funds":"20.0","maximum_funds":"500000.0"},{"id":"saltxrp","name":"SALT/XRP","ask_precision":2,"bid_precision":4,"minimum_volume":"10.0","maximum_volume":"100000.0","minimum_funds":"20.0","maximum_funds":"500000.0"},{"id":"batxrp","name":"BAT/XRP","ask_precision":1,"bid_precision":4,"minimum_volume":"50.0","maximum_volume":"200000.0","minimum_funds":"20.0","maximum_funds":"500000.0"},{"id":"zilxrp","name":"ZIL/XRP","ask_precision":1,"bid_precision":4,"minimum_volume":"300.0","maximum_volume":"999999.0","minimum_funds":"20.0","maximum_funds":"500000.0"},{"id":"xrpcad","name":"XRP/CAD","ask_precision":4,"bid_precision":4,"minimum_volume":"20.0","maximum_volume":"200000.0","minimum_funds":"10.0","maximum_funds":"300000.0"},{"id":"xrpusd","name":"XRP/USD","ask_precision":4,"bid_precision":4,"minimum_volume":"20.0","maximum_volume":"200000.0","minimum_funds":"10.0","maximum_funds":"300000.0"},{"id":"btcusdc","name":"BTC/USDC","ask_precision":8,"bid_precision":2,"minimum_volume":"0.001","maximum_volume":"50.0","minimum_funds":"10.0","maximum_funds":"300000.0"},{"id":"xrpusdc","name":"XRP/USDC","ask_precision":4,"bid_precision":4,"minimum_volume":"20.0","maximum_volume":"200000.0","minimum_funds":"10.0","maximum_funds":"300000.0"},{"id":"xrpeur","name":"XRP/EUR","ask_precision":4,"bid_precision":4,"minimum_volume":"20.0","maximum_volume":"200000.0","minimum_funds":"10.0","maximum_funds":"300000.0"},{"id":"xrpgbp","name":"XRP/GBP","ask_precision":4,"bid_precision":4,"minimum_volume":"20.0","maximum_volume":"200000.0","minimum_funds":"10.0","maximum_funds":"300000.0"},{"id":"btcgbp","name":"BTC/GBP","ask_precision":8,"bid_precision":2,"minimum_volume":"0.001","maximum_volume":"50.0","minimum_funds":"15.0","maximum_funds":"500000.0"},{"id":"ethgbp","name":"ETH/GBP","ask_precision":4,"bid_precision":2,"minimum_volume":"0.1","maximum_volume":"300.0","minimum_funds":"15.0","maximum_funds":"500000.0"},{"id":"xlmgbp","name":"XLM/GBP","ask_precision":4,"bid_precision":4,"minimum_volume":"80.0","maximum_volume":"600000.0","minimum_funds":"15.0","maximum_funds":"500000.0"},{"id":"ltcgbp","name":"LTC/GBP","ask_precision":4,"bid_precision":2,"minimum_volume":"0.1","maximum_volume":"1000.0","minimum_funds":"15.0","maximum_funds":"500000.0"},{"id":"dgbgbp","name":"DGB/GBP","ask_precision":2,"bid_precision":6,"minimum_volume":"300.0","maximum_volume":"999999.0","minimum_funds":"15.0","maximum_funds":"500000.0"},{"id":"xrpaed","name":"XRP/AED","ask_precision":4,"bid_precision":4,"minimum_volume":"20.0","maximum_volume":"200000.0","minimum_funds":"50.0","maximum_funds":"999999.0"},{"id":"xrpjpy","name":"XRP/JPY","ask_precision":4,"bid_precision":2,"minimum_volume":"20.0","maximum_volume":"2000000.0","minimum_funds":"1500.0","maximum_funds":"200000000.0"},{"id":"btceur","name":"BTC/EUR","ask_precision":8,"bid_precision":2,"minimum_volume":"0.001","maximum_volume":"50.0","minimum_funds":"10.0","maximum_funds":"300000.0"},{"id":"etheur","name":"ETH/EUR","ask_precision":4,"bid_precision":2,"minimum_volume":"0.1","maximum_volume":"300.0","minimum_funds":"10.0","maximum_funds":"300000.0"},{"id":"ltceur","name":"LTC/EUR","ask_precision":2,"bid_precision":2,"minimum_volume":"0.1","maximum_volume":"1000.0","minimum_funds":"10.0","maximum_funds":"300000.0"},{"id":"xlmeur","name":"XLM/EUR","ask_precision":4,"bid_precision":4,"minimum_volume":"50.0","maximum_volume":"200000.0","minimum_funds":"10.0","maximum_funds":"300000.0"},{"id":"dgbeur","name":"DGB/EUR","ask_precision":2,"bid_precision":6,"minimum_volume":"300.0","maximum_volume":"9999999.0","minimum_funds":"15.0","maximum_funds":"500000.0"},{"id":"btccad","name":"BTC/CAD","ask_precision":8,"bid_precision":2,"minimum_volume":"0.001","maximum_volume":"50.0","minimum_funds":"10.0","maximum_funds":"300000.0"},{"id":"ethcad","name":"ETH/CAD","ask_precision":4,"bid_precision":2,"minimum_volume":"0.1","maximum_volume":"300.0","minimum_funds":"10.0","maximum_funds":"300000.0"},{"id":"ltccad","name":"LTC/CAD","ask_precision":2,"bid_precision":2,"minimum_volume":"0.1","maximum_volume":"1000.0","minimum_funds":"10.0","maximum_funds":"300000.0"},{"id":"btcusd","name":"BTC/USD","ask_precision":8,"bid_precision":2,"minimum_volume":"0.001","maximum_volume":"50.0","minimum_funds":"10.0","maximum_funds":"300000.0"},{"id":"ethusd","name":"ETH/USD","ask_precision":4,"bid_precision":2,"minimum_volume":"0.1","maximum_volume":"300.0","minimum_funds":"10.0","maximum_funds":"300000.0"},{"id":"ltcusd","name":"LTC/USD","ask_precision":2,"bid_precision":2,"minimum_volume":"0.1","maximum_volume":"1000.0","minimum_funds":"10.0","maximum_funds":"300000.0"},{"id":"xlmcad","name":"XLM/CAD","ask_precision":4,"bid_precision":4,"minimum_volume":"50.0","maximum_volume":"200000.0","minimum_funds":"10.0","maximum_funds":"300000.0"},{"id":"bchcad","name":"BCH/CAD","ask_precision":4,"bid_precision":2,"minimum_volume":"0.05","maximum_volume":"400.0","minimum_funds":"15.0","maximum_funds":"500000.0"},{"id":"dgbcad","name":"DGB/CAD","ask_precision":2,"bid_precision":6,"minimum_volume":"300.0","maximum_volume":"999999.0","minimum_funds":"15.0","maximum_funds":"500000.0"},{"id":"zeccad","name":"ZEC/CAD","ask_precision":4,"bid_precision":2,"minimum_volume":"0.1","maximum_volume":"500.0","minimum_funds":"15.0","maximum_funds":"500000.0"},{"id":"zrxcad","name":"ZRX/CAD","ask_precision":4,"bid_precision":4,"minimum_volume":"10.0","maximum_volume":"100000.0","minimum_funds":"15.0","maximum_funds":"500000.0"},{"id":"xlmusd","name":"XLM/USD","ask_precision":4,"bid_precision":4,"minimum_volume":"50.0","maximum_volume":"200000.0","minimum_funds":"10.0","maximum_funds":"300000.0"},{"id":"dashusd","name":"DASH/USD","ask_precision":4,"bid_precision":2,"minimum_volume":"0.1","maximum_volume":"500.0","minimum_funds":"15.0","maximum_funds":"500000.0"},{"id":"zecusd","name":"ZEC/USD","ask_precision":4,"bid_precision":2,"minimum_volume":"0.1","maximum_volume":"500.0","minimum_funds":"15.0","maximum_funds":"500000.0"},{"id":"dgbusd","name":"DGB/USD","ask_precision":2,"bid_precision":6,"minimum_volume":"300.0","maximum_volume":"999999.0","minimum_funds":"15.0","maximum_funds":"500000.0"},{"id":"bchusd","name":"BCH/USD","ask_precision":4,"bid_precision":2,"minimum_volume":"0.05","maximum_volume":"200.0","minimum_funds":"15.0","maximum_funds":"500000.0"},{"id":"zrxusd","name":"ZRX/USD","ask_precision":4,"bid_precision":4,"minimum_volume":"10.0","maximum_volume":"100000.0","minimum_funds":"15.0","maximum_funds":"500000.0"},{"id":"batusd","name":"BAT/USD","ask_precision":4,"bid_precision":4,"minimum_volume":"50.0","maximum_volume":"200000.0","minimum_funds":"15.0","maximum_funds":"500000.0"},{"id":"btcjpy","name":"BTC/JPY","ask_precision":8,"bid_precision":2,"minimum_volume":"0.001","maximum_volume":"50.0","minimum_funds":"1500.0"},{"id":"loomxrp","name":"LOOM/XRP","ask_precision":4,"bid_precision":4,"minimum_volume":"300.0","maximum_volume":"999999.0","minimum_funds":"20.0","maximum_funds":"500000.0"},{"id":"dgbxrp","name":"DGB/XRP","ask_precision":4,"bid_precision":4,"minimum_volume":"300.0","maximum_volume":"999999.0","minimum_funds":"20.0","maximum_funds":"500000.0"},{"id":"cvcxrp","name":"CVC/XRP","ask_precision":4,"bid_precision":4,"minimum_volume":"300.0","maximum_volume":"999999.0","minimum_funds":"20.0","maximum_funds":"500000.0"}],"timestamp":"2019-01-16T14:56:38.588Z","took":"18ms"}'
     http_version: 
-  recorded_at: Tue, 29 May 2018 16:52:37 GMT
+  recorded_at: Wed, 16 Jan 2019 14:56:38 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Coinfield/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/Coinfield/integration_specs_fetch_ticker.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://platform.coinfield.com/api/v2//tickers
+    uri: https://api.coinfield.com/v1/tickers
     body:
       encoding: UTF-8
       string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Connection:
       - close
       Host:
-      - platform.coinfield.com
+      - api.coinfield.com
       User-Agent:
       - http.rb/3.0.0
   response:
@@ -19,73 +19,53 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 29 May 2018 16:52:37 GMT
+      - Wed, 16 Jan 2019 14:56:39 GMT
       Content-Type:
-      - application/json
+      - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
       - close
       Set-Cookie:
-      - __cfduid=d009ca7bfcf7b500e7093bca2ad9afd241527612757; expires=Wed, 29-May-19
-        16:52:37 GMT; path=/; domain=.coinfield.com; HttpOnly; Secure
-      Vary:
-      - Accept-Encoding
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Allow-Methods:
-      - GET, POST, PUT, PATCH, DELETE
-      Access-Control-Allow-Headers:
-      - Origin, X-Requested-With, Content-Type, Accept, Authorization
-      Version:
-      - HTTP/1.1
-      Host:
-      - platform.coinfield.com
-      X-Real-Ip:
-      - 73.97.148.141
-      X-Forwarded-For:
-      - 73.97.148.141
-      X-Forwarded-Host:
-      - platform.coinfield.com
-      X-Forwarded-Port:
-      - '443'
-      X-Forwarded-Proto:
-      - https
-      X-Original-Uri:
-      - "/api/v2//tickers"
-      X-Scheme:
-      - https
-      X-Original-Forwarded-For:
-      - 73.97.148.141
-      Accept-Encoding:
-      - gzip
-      Cf-Ipcountry:
-      - US
-      Cf-Visitor:
-      - '{"scheme":"https"}'
-      User-Agent:
-      - http.rb/3.0.0
-      Cf-Connecting-Ip:
-      - 73.97.148.141
-      Etag:
-      - W/"186bd43cc5eb25a50628936548964f02"
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      X-Request-Id:
-      - 462a2155-29ec-480b-9c4c-aeeeca2f6ec8
-      X-Runtime:
-      - '0.036594'
+      - __cfduid=d518f106e528480c722f94f708bf3cacb1547650598; expires=Thu, 16-Jan-20
+        14:56:38 GMT; path=/; domain=.coinfield.com; HttpOnly; Secure
+      - route=9ac21c7ed2fa285054b7d9867fe54452; Domain=api.coinfield.com; Path=/;
+        HttpOnly
+      X-Dns-Prefetch-Control:
+      - 'off'
+      X-Frame-Options:
+      - SAMEORIGIN
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
+      X-Download-Options:
+      - noopen
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Id:
+      - b6b59805-9f1e-4c7a-a232-494ddb5893a6
+      X-Runtime:
+      - '0.009212'
+      X-Proxy-Runtime:
+      - 20ms
+      X-Fuse-Cached:
+      - 'false'
+      Etag:
+      - W/"22d8-Ke2KjAfyu+U5HFctjNFHLtAWmDU"
+      Vary:
+      - Accept-Encoding
       Expect-Ct:
       - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
       Server:
       - cloudflare
       Cf-Ray:
-      - 422a78f63b662a5b-SEA
+      - 49a16e122a12a2b4-HKG
     body:
-      encoding: ASCII-8BIT
-      string: '{"btccad":{"at":1527612757,"ticker":{"buy":"9345.0","sell":"10488.0","low":"9345.0","high":"10600.0","last":"9345.0","open":9598.7,"vol":"33.7881"}},"xrpcad":{"at":1527612757,"ticker":{"buy":"0.8","sell":"0.88","low":"0.75","high":"0.88","last":"0.88","open":0.8,"vol":"115336.4307"}},"bchcad":{"at":1527612757,"ticker":{"buy":"1252.89","sell":"1449.9","low":"1159.56","high":"1449.9","last":"1314.05","open":1241.61,"vol":"556.5165"}},"ltccad":{"at":1527612757,"ticker":{"buy":"143.09","sell":"158.41","low":"144.32","high":"162.73","last":"158.52","open":159.95,"vol":"1816.5217"}},"ethcad":{"at":1527612757,"ticker":{"buy":"750.0","sell":"848.0","low":"700.0","high":"849.91","last":"700.0","open":706.72,"vol":"13.8293"}},"dashcad":{"at":1527612757,"ticker":{"buy":"429.0","sell":"488.0","low":"0.0","high":"0.0","last":"429.0","open":429.0,"vol":"0.0"}},"ethbtc":{"at":1527612757,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0","high":"0.0","last":"0.0","open":"0.0","vol":"0.0"}},"xrpbtc":{"at":1527612757,"ticker":{"buy":"0.0","sell":"0.05","low":"0.0","high":"0.0","last":"0.0","open":"0.0","vol":"0.0"}},"ltcbtc":{"at":1527612757,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0","high":"0.0","last":"0.0","open":"0.0","vol":"0.0"}},"dashbtc":{"at":1527612757,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0","high":"0.0","last":"0.0","open":"0.0","vol":"0.0"}},"bchbtc":{"at":1527612757,"ticker":{"buy":"0.0","sell":"0.0","low":"0.0","high":"0.0","last":"0.0","open":"0.0","vol":"0.0"}},"btcusd":{"at":1527612757,"ticker":{"buy":"7300.0","sell":"7850.0","low":"7300.0","high":"7677.39","last":"7300.0","open":7471.27,"vol":"2.4968"}},"xrpusd":{"at":1527612757,"ticker":{"buy":"0.56","sell":"0.78","low":"0.57","high":"0.64","last":"0.58","open":0.59,"vol":"52991.0421"}}}'
+      encoding: UTF-8
+      string: '{"markets":[{"market":"btcxrp","timestamp":"2019-01-16T14:56:39.000Z","bid":10968.0617,"ask":11062.8924,"low":9874.3458,"high":11145.1548,"last":11012.6121,"open":11049.4083,"vol":188.48361263},{"market":"ethxrp","timestamp":"2019-01-16T14:56:39.000Z","bid":372.4623,"ask":373.981,"low":358.416,"high":392.923,"last":372.4515,"open":389.1427,"vol":1635.5797},{"market":"xlmxrp","timestamp":"2019-01-16T14:56:39.000Z","bid":0.3242,"ask":0.3259,"low":0.3212,"high":0.3552,"last":0.3246,"open":0.3257,"vol":1589870.875},{"market":"ltcxrp","timestamp":"2019-01-16T14:56:39.000Z","bid":95.5498,"ask":95.992,"low":88.8698,"high":98.0175,"last":95.7183,"open":97.4862,"vol":2055.53},{"market":"dashxrp","timestamp":"2019-01-16T14:56:39.000Z","bid":214.2842,"ask":214.9939,"low":211.3958,"high":230,"last":214.7839,"open":215.7325,"vol":748.242},{"market":"bchxrp","timestamp":"2019-01-16T14:56:39.000Z","bid":388.1856,"ask":389.8745,"low":387.3231,"high":398.9192,"last":389.1674,"open":395.4755,"vol":935.145},{"market":"zecxrp","timestamp":"2019-01-16T14:56:39.000Z","bid":163.6281,"ask":164.777,"low":163.012,"high":165.9216,"last":164.1571,"open":165.5967,"vol":656.493},{"market":"dashcad","timestamp":"2019-01-16T14:56:39.000Z","bid":92.89,"ask":94.11,"low":88.84,"high":94.96,"last":93.38,"open":94.59,"vol":242.0295},{"market":"btgxrp","timestamp":"2019-01-16T14:56:39.000Z","bid":36.0625,"ask":36.3753,"low":35.9849,"high":36.743,"last":36.1895,"open":36.5677,"vol":125.69},{"market":"zrxxrp","timestamp":"2019-01-16T14:56:39.000Z","bid":0.8612,"ask":0.927,"low":0.855,"high":0.9217,"last":0.9217,"open":0.8679,"vol":108914.2},{"market":"gntxrp","timestamp":"2019-01-16T14:56:39.000Z","bid":0.194,"ask":0.195,"low":0.1881,"high":0.2141,"last":0.1947,"open":0.1926,"vol":811263.64787482},{"market":"repxrp","timestamp":"2019-01-16T14:56:39.000Z","bid":38.6731,"ask":38.7689,"low":29.2866,"high":40.4865,"last":38.6676,"open":31.4602,"vol":9410.38},{"market":"omgxrp","timestamp":"2019-01-16T14:56:39.000Z","bid":3.8125,"ask":3.8383,"low":3.7539,"high":4.0017,"last":3.8319,"open":3.8544,"vol":31225.15},{"market":"saltxrp","timestamp":"2019-01-16T14:56:39.000Z","bid":0.6676,"ask":0.6722,"low":0.6467,"high":0.6805,"last":0.6702,"open":0.6528,"vol":25682.33},{"market":"batxrp","timestamp":"2019-01-16T14:56:39.000Z","bid":0.3784,"ask":0.3801,"low":0.3689,"high":0.4117,"last":0.3782,"open":0.3741,"vol":52972.56335816},{"market":"zilxrp","timestamp":"2019-01-16T14:56:39.000Z","bid":0.0695,"ask":0.07,"low":0.0617,"high":0.0713,"last":0.0698,"open":0.062,"vol":9959334.70659186},{"market":"xrpcad","timestamp":"2019-01-16T14:56:39.000Z","bid":0.4341,"ask":0.4365,"low":0.4241,"high":0.463,"last":0.4352,"open":0.438,"vol":3882172.19177302},{"market":"xrpusd","timestamp":"2019-01-16T14:56:39.000Z","bid":0.3277,"ask":0.3286,"low":0.3139,"high":0.3772,"last":0.328,"open":0.3307,"vol":4570256.1428},{"market":"btcusdc","timestamp":"2019-01-16T14:56:39.000Z","bid":3610.4,"ask":3631.69,"low":3563.45,"high":3667.28,"last":3619.54,"open":3654.01,"vol":31.5666917},{"market":"xrpusdc","timestamp":"2019-01-16T14:56:39.000Z","bid":0.3279,"ask":0.3297,"low":0.3203,"high":0.3326,"last":0.3289,"open":0.3312,"vol":13416.344},{"market":"xrpeur","timestamp":"2019-01-16T14:56:39.000Z","bid":0.2876,"ask":0.2886,"low":0.2726,"high":0.292,"last":0.2882,"open":0.2888,"vol":1867947.003},{"market":"xrpgbp","timestamp":"2019-01-16T14:56:39.000Z","bid":0.255,"ask":0.2556,"low":0.2422,"high":0.259,"last":0.2554,"open":0.2572,"vol":1007451.376},{"market":"btcgbp","timestamp":"2019-01-16T14:56:39.000Z","bid":2809.44,"ask":2820.04,"low":2760.2,"high":2862.44,"last":2812.09,"open":2841.83,"vol":53.6687082},{"market":"ethgbp","timestamp":"2019-01-16T14:56:39.000Z","bid":95.13,"ask":95.68,"low":91.37,"high":100.23,"last":95.38,"open":100.23,"vol":1579.2336},{"market":"xlmgbp","timestamp":"2019-01-16T14:56:39.000Z","bid":0.075,"ask":0.0913,"low":0.0739,"high":0.0901,"last":0.0832,"open":0.0899,"vol":605579.6419},{"market":"ltcgbp","timestamp":"2019-01-16T14:56:39.000Z","bid":24.4,"ask":24.53,"low":23.71,"high":25.14,"last":24.38,"open":24.81,"vol":85.3202},{"market":"dgbgbp","timestamp":"2019-01-16T14:56:39.000Z","bid":0.007472,"ask":0.007612,"low":0.007318,"high":0.007752,"last":0.007535,"open":0.007725,"vol":843917.85},{"market":"xrpaed","timestamp":"2019-01-16T14:56:39.000Z","bid":1.2021,"ask":1.2092,"low":1.1736,"high":1.218,"last":1.2044,"open":1.2152,"vol":164557.098},{"market":"xrpjpy","timestamp":"2019-01-16T14:56:39.000Z","bid":35.65,"ask":35.76,"low":34.69,"high":37.2,"last":35.7,"open":35.72,"vol":659931.4225},{"market":"btceur","timestamp":"2019-01-16T14:56:39.000Z","bid":3163.85,"ask":3180.14,"low":3015.7,"high":3288.19,"last":3171.07,"open":3198.75,"vol":302.73538128},{"market":"etheur","timestamp":"2019-01-16T14:56:39.000Z","bid":107.46,"ask":107.85,"low":103.09,"high":114.34,"last":107.58,"open":112.53,"vol":2230.5648},{"market":"ltceur","timestamp":"2019-01-16T14:56:39.000Z","bid":27.54,"ask":27.66,"low":26.66,"high":28.25,"last":27.6,"open":28.18,"vol":1659.58},{"market":"xlmeur","timestamp":"2019-01-16T14:56:39.000Z","bid":0.0929,"ask":0.0945,"low":0.0887,"high":0.0942,"last":0.0937,"open":0.0937,"vol":763813.755},{"market":"dgbeur","timestamp":"2019-01-16T14:56:39.000Z","bid":0.008287,"ask":0.008599,"low":0.008229,"high":0.008678,"last":0.008499,"open":0.008678,"vol":930192.25},{"market":"btccad","timestamp":"2019-01-16T14:56:39.000Z","bid":4790.17,"ask":4805.82,"low":4723.97,"high":4863.4,"last":4794.88,"open":4835.65,"vol":378.71846107},{"market":"ethcad","timestamp":"2019-01-16T14:56:39.000Z","bid":162.28,"ask":162.95,"low":154.85,"high":170.65,"last":161.73,"open":170.54,"vol":1771.9383},{"market":"ltccad","timestamp":"2019-01-16T14:56:39.000Z","bid":41.62,"ask":41.79,"low":40.23,"high":42.8,"last":41.64,"open":42.71,"vol":2374.27},{"market":"btcusd","timestamp":"2019-01-16T14:56:39.000Z","bid":3609.04,"ask":3621.09,"low":3514.41,"high":3769.03,"last":3614.39,"open":3653.17,"vol":368.36931451},{"market":"ethusd","timestamp":"2019-01-16T14:56:39.000Z","bid":122.25,"ask":122.68,"low":115.32,"high":130.04,"last":123.36,"open":128.6,"vol":3134.0564},{"market":"ltcusd","timestamp":"2019-01-16T14:56:39.000Z","bid":31.39,"ask":31.48,"low":30.38,"high":33.08,"last":31.37,"open":32.19,"vol":4304.46},{"market":"xlmcad","timestamp":"2019-01-16T14:56:39.000Z","bid":0.1401,"ask":0.1425,"low":0.1341,"high":0.1525,"last":0.1414,"open":0.142,"vol":1470205.7356},{"market":"bchcad","timestamp":"2019-01-16T14:56:39.000Z","bid":168.76,"ask":169.7,"low":165.39,"high":173.82,"last":169.51,"open":173.75,"vol":21.2326},{"market":"dgbcad","timestamp":"2019-01-16T14:56:39.000Z","bid":0.01285,"ask":0.012966,"low":0.012474,"high":0.013584,"last":0.012906,"open":0.013181,"vol":2755151.21},{"market":"zeccad","timestamp":"2019-01-16T14:56:39.000Z","bid":71.07,"ask":72.43,"low":69.87,"high":72.33,"last":71.71,"open":72.12,"vol":98.4247},{"market":"zrxcad","timestamp":"2019-01-16T14:56:39.000Z","bid":0.3949,"ask":0.4087,"low":0.3716,"high":0.4002,"last":0.3939,"open":0.3791,"vol":3273.821},{"market":"xlmusd","timestamp":"2019-01-16T14:56:39.000Z","bid":0.1063,"ask":0.1069,"low":0.1032,"high":0.1079,"last":0.1066,"open":0.1076,"vol":1884947.54},{"market":"dashusd","timestamp":"2019-01-16T14:56:39.000Z","bid":70.01,"ask":70.88,"low":67.51,"high":71.63,"last":70.46,"open":71.37,"vol":404.6279},{"market":"zecusd","timestamp":"2019-01-16T14:56:39.000Z","bid":53.6,"ask":54.52,"low":52.68,"high":54.62,"last":54.09,"open":54.62,"vol":148.9311},{"market":"dgbusd","timestamp":"2019-01-16T14:56:39.000Z","bid":0.009605,"ask":0.009771,"low":0.0094,"high":0.009931,"last":0.009693,"open":0.009931,"vol":6398936.44},{"market":"bchusd","timestamp":"2019-01-16T14:56:39.000Z","bid":127.46,"ask":128.14,"low":124.51,"high":131.5,"last":127.48,"open":131.5,"vol":14.7381},{"market":"zrxusd","timestamp":"2019-01-16T14:56:39.000Z","bid":0.2977,"ask":0.3082,"low":0.2728,"high":0.3018,"last":0.2968,"open":0.2869,"vol":4020.914},{"market":"batusd","timestamp":"2019-01-16T14:56:39.000Z","bid":0.1237,"ask":0.1248,"low":0.1187,"high":0.1294,"last":0.1239,"open":0.1233,"vol":9740.665},{"market":"btcjpy","timestamp":"2019-01-16T14:56:39.000Z","bid":392708.86,"ask":393897.64,"low":386482.98,"high":396346.58,"last":393673.18,"open":395693.18,"vol":40.94266015},{"market":"cvcxrp","timestamp":"2019-01-16T14:56:39.000Z","bid":0.1553,"ask":0.1586,"low":0.1491,"high":0.1584,"last":0.157,"open":0.1495,"vol":346020.39},{"market":"dgbxrp","timestamp":"2019-01-16T14:56:39.000Z","bid":0.0293,"ask":0.0296,"low":0.029,"high":0.0305,"last":0.0294,"open":0.0299,"vol":5261586.2233},{"market":"loomxrp","timestamp":"2019-01-16T14:56:39.000Z","bid":0.1391,"ask":0.1398,"low":0.1301,"high":0.1484,"last":0.1395,"open":0.1314,"vol":969591.8256}],"timestamp":"2019-01-16T14:56:39.476Z","took":"20ms"}'
     http_version: 
-  recorded_at: Tue, 29 May 2018 16:52:37 GMT
+  recorded_at: Wed, 16 Jan 2019 14:56:39 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Coinfield/integration_specs_fetch_trade.yml
+++ b/spec/cassettes/vcr_cassettes/Coinfield/integration_specs_fetch_trade.yml
@@ -1,0 +1,71 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.coinfield.com/v1/trades/btccad
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.coinfield.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 16 Jan 2019 14:56:41 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=dc76cf2dfef59581f811914b41cd117971547650600; expires=Thu, 16-Jan-20
+        14:56:40 GMT; path=/; domain=.coinfield.com; HttpOnly; Secure
+      - route=af63b238b8d39e21ebf54fd53f3bcb8b; Domain=api.coinfield.com; Path=/;
+        HttpOnly
+      X-Dns-Prefetch-Control:
+      - 'off'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      X-Download-Options:
+      - noopen
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Request-Id:
+      - 7d1c0c07-39d2-48c9-bd9c-7f350af80382
+      X-Runtime:
+      - '0.008049'
+      X-Proxy-Runtime:
+      - 12ms
+      X-Fuse-Cached:
+      - 'false'
+      Etag:
+      - W/"b64-X9SLPkzfG6zRKw4OwFblY1kAmcQ"
+      Vary:
+      - Accept-Encoding
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 49a16e1c9a8ca2ba-HKG
+    body:
+      encoding: UTF-8
+      string: '{"market":"btccad","trades_hash":"66c523f0bdcbf6289bbb7472fc0d20fa","trades":[{"id":"pd1e3uhh200apmin","price":"4794.88","volume":"0.17119863","total_value":"820.8768870144","timestamp":"2019-01-16T14:56:34.000000Z"},{"id":"pd1e3uhda00apmim","price":"4793.83","volume":"0.17648903","total_value":"846.0584066849","timestamp":"2019-01-16T14:54:34.000000Z"},{"id":"pd1e3uh7400apmil","price":"4789.36","volume":"0.09931914","total_value":"475.6751163504","timestamp":"2019-01-16T14:51:16.000000Z"},{"id":"pd1e3ugsv00apmik","price":"4795.26","volume":"0.21421751","total_value":"1027.2286570026","timestamp":"2019-01-16T14:45:51.000000Z"},{"id":"pd1e3ugpj00apmij","price":"4794.78","volume":"0.26627134","total_value":"1276.7124956052","timestamp":"2019-01-16T14:44:03.000000Z"},{"id":"pd1e3uge500apmii","price":"4795.27","volume":"0.28220737","total_value":"1353.2605351399","timestamp":"2019-01-16T14:37:57.000000Z"},{"id":"pd1e3ug3800apmih","price":"4800.11","volume":"0.6579927","total_value":"3158.437339197","timestamp":"2019-01-16T14:32:08.000000Z"},{"id":"pd1e3ug0a00apmig","price":"4806.53","volume":"0.09879741","total_value":"474.8727150873","timestamp":"2019-01-16T14:30:34.000000Z"},{"id":"pd1e3ufmg00apmif","price":"4805.68","volume":"0.11951833","total_value":"574.3668481144","timestamp":"2019-01-16T14:25:20.000000Z"},{"id":"pd1e3uffh00apmie","price":"4797.58","volume":"0.19037979","total_value":"913.3622729082","timestamp":"2019-01-16T14:21:37.000000Z"},{"id":"pd1e3uf8q00apmid","price":"4794.58","volume":"0.14833832","total_value":"711.2199423056","timestamp":"2019-01-16T14:18:02.000000Z"},{"id":"pd1e3uf3700apmic","price":"4798.18","volume":"0.20633425","total_value":"990.028871665","timestamp":"2019-01-16T14:15:03.000000Z"},{"id":"pd1e3uep100apmib","price":"4808.92","volume":"0.19058303","total_value":"916.4985446276","timestamp":"2019-01-16T14:09:37.000000Z"},{"id":"pd1e3ueit00apmia","price":"4787.07","volume":"0.30179228","total_value":"1444.7007698196","timestamp":"2019-01-16T14:06:21.000000Z"},{"id":"pd1e3ueal00apmi9","price":"4782.74","volume":"0.12092701","total_value":"578.3624478074","timestamp":"2019-01-16T14:01:57.000000Z"},{"id":"pd1e3ue7200apmi8","price":"4786.66","volume":"0.14131834","total_value":"676.4428453444","timestamp":"2019-01-16T14:00:02.000000Z"},{"id":"pd1e3uds800apmi7","price":"4786.72","volume":"0.43267657","total_value":"2071.1015911504","timestamp":"2019-01-16T13:54:16.000000Z"},{"id":"pd1e3udlj00apmi6","price":"4806.56","volume":"0.14636511","total_value":"703.5126831216","timestamp":"2019-01-16T13:50:43.000000Z"},{"id":"pd1e3udf100apmi5","price":"4823.63","volume":"0.23840318","total_value":"1149.9687311434","timestamp":"2019-01-16T13:47:13.000000Z"},{"id":"pd1e3ud4q00apmi4","price":"4809.92","volume":"0.25574485","total_value":"1230.112268912","timestamp":"2019-01-16T13:41:46.000000Z"}],"timestamp":"2019-01-16T14:56:41.072Z","took":"12ms"}'
+    http_version: 
+  recorded_at: Wed, 16 Jan 2019 14:56:41 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/coinfield/integration/market_spec.rb
+++ b/spec/exchanges/coinfield/integration/market_spec.rb
@@ -35,4 +35,34 @@ RSpec.describe 'Coinfield integration specs' do
     expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
     expect(ticker.payload).to_not be nil
   end
+
+  it 'fetch order book' do
+    order_book = client.order_book(btc_cad_pair)
+    expect(order_book.base).to eq 'BTC'
+    expect(order_book.target).to eq 'CAD'
+    expect(order_book.market).to eq 'coinfield'
+    expect(order_book.asks).to_not be_empty
+    expect(order_book.bids).to_not be_empty
+    expect(order_book.asks.first.price).to_not be_nil
+    expect(order_book.bids.first.amount).to_not be_nil
+    expect(order_book.bids.first.timestamp).to be_nil
+    expect(order_book.timestamp).to be_a Numeric
+    expect(order_book.payload).to_not be nil
+  end
+
+  it 'fetch trade' do
+    trades = client.trades(btc_cad_pair)
+    trade = trades.sample
+
+    expect(trades).to_not be_empty
+    expect(trade.trade_id).to_not be_nil
+    expect(trade.base).to eq 'BTC'
+    expect(trade.target).to eq 'CAD'
+    expect(trade.type).to be_nil
+    expect(trade.price).to be_a Numeric
+    expect(trade.amount).to be_a Numeric
+    expect(trade.timestamp).to be_a Numeric
+    expect(trade.payload).to_not be nil
+    expect(trade.market).to eq 'coinfield'
+  end
 end

--- a/spec/exchanges/coinfield/market_spec.rb
+++ b/spec/exchanges/coinfield/market_spec.rb
@@ -2,5 +2,5 @@ require 'spec_helper'
 
 RSpec.describe Cryptoexchange::Exchanges::Coinfield::Market do
   it { expect(described_class::NAME).to eq 'coinfield' }
-  it { expect(described_class::API_URL).to eq 'https://platform.coinfield.com/api/v2/' }
+  it { expect(described_class::API_URL).to eq 'https://api.coinfield.com/v1' }
 end


### PR DESCRIPTION
- What is the purpose of this Pull Request? as title
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")? no 
- [x] I have added Specs
- [x] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [x] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [x] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [x] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

ticker about `btc_cad`
```ruby
{
 "market": "btccad",
 "timestamp": "2019-01-16T14:42:21.000Z",
 "bid": 4787.14,
 "ask": 4807.15,
 "low": 4723.97,
 "high": 4863.4,
 "last": 4795.27,
 "open": 4841.24,
 "vol": 386.95386788
}
```
took `vol` as base volume