### PR TITLE
Coinzo Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Or install it yourself as:
 | Cointiger         | Y       | Y          | Y       |         | Y           |          | cointiger         |
 | Coinut (Auth)     | Y       | Y          | Y       | Y       | Y           |          | coinut            |
 | Coinzest          | Y       | Y          |         |         | Y           |          | coinzest          |
+| Coinzo            | Y       | Y          | Y       |         | Y           | Y        | coinzo            |
 | COSS              | Y       |            |         |         | Y           | Y        | coss              |
 | Cpdax             | Y       | Y          | Y       |         | Y           |          | cpdax             |
 | CredoEx           | Y       |            |         |         | Y           |          | credoex           |

--- a/lib/cryptoexchange/exchanges/coinzo/market.rb
+++ b/lib/cryptoexchange/exchanges/coinzo/market.rb
@@ -1,0 +1,12 @@
+module Cryptoexchange::Exchanges
+  module Coinzo
+    class Market < Cryptoexchange::Models::Market
+      NAME = 'coinzo'
+      API_URL = 'https://api.coinzo.com'
+
+      def self.trade_page_url(args={})
+        "https://www.coinzo.com/market/#{args[:base]}-#{args[:target]}"
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/coinzo/services/market.rb
+++ b/lib/cryptoexchange/exchanges/coinzo/services/market.rb
@@ -1,0 +1,49 @@
+module Cryptoexchange::Exchanges
+  module Coinzo
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            false
+          end
+        end
+
+        def fetch
+          output = super(ticker_url)
+          adapt_all(output)
+        end
+
+        def ticker_url
+          "#{Cryptoexchange::Exchanges::Coinzo::Market::API_URL}/tickers"
+        end
+
+        def adapt_all(output)
+          output.map do |pair|
+            base, target = pair[0].split('-')
+            market_pair  = Cryptoexchange::Models::MarketPair.new(
+              base:   base,
+              target: target,
+              market: Coinzo::Market::NAME
+            )
+            adapt(market_pair, pair[1])
+          end
+        end
+
+        def adapt(market_pair, output)
+          ticker           = Cryptoexchange::Models::Ticker.new
+          ticker.base      = market_pair.base
+          ticker.target    = market_pair.target
+          ticker.market    = Coinzo::Market::NAME
+          ticker.last      = NumericHelper.to_d(output['last'])
+          ticker.high      = NumericHelper.to_d(output['high'])
+          ticker.low       = NumericHelper.to_d(output['low'])
+          ticker.volume    = NumericHelper.to_d(output['volume'])
+          ticker.change    = NumericHelper.to_d(output['daily_change_percentage'])
+          ticker.timestamp = nil
+          ticker.payload   = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/coinzo/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/coinzo/services/order_book.rb
@@ -1,0 +1,42 @@
+module Cryptoexchange::Exchanges
+  module Coinzo
+    module Services
+      class OrderBook < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          "#{Cryptoexchange::Exchanges::Coinzo::Market::API_URL}/order-book?pair=#{market_pair.base}-#{market_pair.target}"
+        end
+
+        def adapt(output, market_pair)
+          order_book = Cryptoexchange::Models::OrderBook.new
+
+          order_book.base      = market_pair.base
+          order_book.target    = market_pair.target
+          order_book.market    = Coinzo::Market::NAME
+          order_book.asks      = adapt_orders(output['asks'])
+          order_book.bids      = adapt_orders(output['bids'])
+          order_book.timestamp = nil
+          order_book.payload   = output
+          order_book
+        end
+
+        def adapt_orders(orders)
+          orders.collect do |order_entry|
+            Cryptoexchange::Models::Order.new(price: order_entry['price'],
+                                              amount: order_entry['amount'])
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/coinzo/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/coinzo/services/pairs.rb
@@ -1,0 +1,23 @@
+module Cryptoexchange::Exchanges
+  module Coinzo
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Coinzo::Market::API_URL}/tickers"
+
+        def fetch
+          output = super
+          market_pairs = []
+          output.each do |pair|
+            base, target = pair[0].split('-')
+            market_pairs << Cryptoexchange::Models::MarketPair.new(
+                              base: base,
+                              target: target,
+                              market: Coinzo::Market::NAME
+                            )
+          end
+          market_pairs
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/coinzo/services/trades.rb
+++ b/lib/cryptoexchange/exchanges/coinzo/services/trades.rb
@@ -1,0 +1,31 @@
+module Cryptoexchange::Exchanges
+  module Coinzo
+    module Services
+      class Trades < Cryptoexchange::Services::Market
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          "#{Cryptoexchange::Exchanges::Coinzo::Market::API_URL}/trades?pair=#{market_pair.base}-#{market_pair.target}"
+        end
+
+        def adapt(output, market_pair)
+          output.collect do |trade|
+            tr = Cryptoexchange::Models::Trade.new
+            tr.base      = market_pair.base
+            tr.target    = market_pair.target
+            tr.market    = Coinzo::Market::NAME
+            tr.type      = trade['side'].downcase
+            tr.price     = trade['price']
+            tr.amount    = trade['amount']
+            tr.timestamp = trade['created_at']
+            tr.payload   = trade
+            tr
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/Coinzo/integration_specs_fetch_order_book.yml
+++ b/spec/cassettes/vcr_cassettes/Coinzo/integration_specs_fetch_order_book.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.coinzo.com/order-book?pair=BTC-TRY
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.coinzo.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 20 Jan 2019 17:06:38 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d290893f33d888bda26721f191593fb571548003998; expires=Mon, 20-Jan-20
+        17:06:38 GMT; path=/; domain=.coinzo.com; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 49c321ff1f756b91-LHR
+    body:
+      encoding: UTF-8
+      string: '{"asks":[{"price":19021,"amount":0.00696378,"count":1},{"price":19040,"amount":0.05212014,"count":2},{"price":19043,"amount":0.01911676,"count":1},{"price":19074,"amount":0.02521276,"count":1},{"price":19078,"amount":0.02291569,"count":1},{"price":19089,"amount":0.02092842,"count":1},{"price":19091,"amount":0.01561707,"count":1},{"price":19093,"amount":0.0259058,"count":1},{"price":19108,"amount":0.01098344,"count":1},{"price":19109,"amount":0.02924038,"count":1},{"price":19110,"amount":0.01718673,"count":1},{"price":19112,"amount":0.00420248,"count":1},{"price":19117,"amount":0.00260466,"count":1},{"price":19119,"amount":0.01457553,"count":1},{"price":19135,"amount":0.00663243,"count":1},{"price":19136,"amount":0.00958517,"count":1},{"price":19138,"amount":0.02448851,"count":2},{"price":19139,"amount":0.01277808,"count":1},{"price":19144,"amount":0.00572091,"count":1},{"price":19149,"amount":0.02455624,"count":2},{"price":19158,"amount":0.00139711,"count":1},{"price":19163,"amount":0.01486025,"count":1},{"price":19168,"amount":0.01666406,"count":1},{"price":19174,"amount":0.00340274,"count":1},{"price":19194,"amount":0.02720269,"count":2},{"price":19204,"amount":0.00578463,"count":1},{"price":19208,"amount":0.01975404,"count":1},{"price":19210,"amount":0.02037294,"count":1},{"price":19213,"amount":0.03099923,"count":1},{"price":19214,"amount":0.01500335,"count":1}],"bids":[{"price":19010,"amount":0.02032749,"count":1},{"price":19009,"amount":0.00717252,"count":1},{"price":19008,"amount":0.06284933,"count":3},{"price":19005,"amount":0.0138602,"count":1},{"price":19002,"amount":0.01251955,"count":1},{"price":19001,"amount":0.0278879,"count":2},{"price":18999,"amount":0.01518746,"count":1},{"price":18998,"amount":0.01777829,"count":1},{"price":18997,"amount":0.02803299,"count":1},{"price":18995,"amount":0.02871811,"count":2},{"price":18994,"amount":0.02817292,"count":2},{"price":18993,"amount":0.04266836,"count":2},{"price":18991,"amount":0.01931573,"count":2},{"price":18990,"amount":0.02631251,"count":2},{"price":18987,"amount":0.04673222,"count":2},{"price":18980,"amount":0.02851126,"count":2},{"price":18977,"amount":0.00194352,"count":1},{"price":18976,"amount":0.0297968,"count":1},{"price":18972,"amount":0.02543544,"count":1},{"price":18966,"amount":0.0284345,"count":1},{"price":18964,"amount":0.01939222,"count":1},{"price":18961,"amount":0.0275543,"count":1},{"price":18960,"amount":0.01478752,"count":1},{"price":18953,"amount":0.01641443,"count":1},{"price":18952,"amount":0.02076428,"count":1},{"price":18941,"amount":0.02863026,"count":1},{"price":18939,"amount":0.01130726,"count":1},{"price":18938,"amount":0.00273288,"count":1},{"price":18928,"amount":0.02878737,"count":1},{"price":18923,"amount":0.00542193,"count":1}],"total":{"bid":175694.73390692,"ask":23.66328478}}'
+    http_version: 
+  recorded_at: Sun, 20 Jan 2019 17:06:38 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Coinzo/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/Coinzo/integration_specs_fetch_pairs.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.coinzo.com/tickers
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.coinzo.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 20 Jan 2019 16:56:01 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1575'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d4cf0218d94d3fc5ab1793a063bed156d1548003361; expires=Mon, 20-Jan-20
+        16:56:01 GMT; path=/; domain=.coinzo.com; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 49c312703acabc08-LHR
+    body:
+      encoding: UTF-8
+      string: '{"BTC-TRY":{"low":"19017","high":"19890","last":"19017","volume":"10.36","daily_change":"-850","daily_change_percentage":"-4.27"},"CNZ-TRY":{"low":"0.045714","high":"0.048008","last":"0.045963","volume":"433927.67","daily_change":"-0.001884","daily_change_percentage":"-3.93"},"EOS-BTC":{"low":"0.00064325","high":"0.00067028","last":"0.0006551","volume":"18808.11","daily_change":"-0.00001505","daily_change_percentage":"-2.24"},"EOS-TRY":{"low":"12.393","high":"13.329","last":"12.448","volume":"26055.61","daily_change":"-0.862","daily_change_percentage":"-6.47"},"ETH-BTC":{"low":"0.03309","high":"0.033696","last":"0.033435","volume":"557.33","daily_change":"0.000067","daily_change_percentage":"0.20"},"ETH-TRY":{"low":"629.12","high":"664.49","last":"635.26","volume":"321.56","daily_change":"-27.9","daily_change_percentage":"-4.20"},"HOT-TRY":{"low":"0.0032746","high":"0.0047264","last":"0.0039333","volume":"675868294.42","daily_change":"0.0006587","daily_change_percentage":"20.11"},"NEO-BTC":{"low":"0.0020796","high":"0.0022326","last":"0.002099","volume":"8903.08","daily_change":"-0.0001327","daily_change_percentage":"-5.94"},"NEO-TRY":{"low":"39.595","high":"44.361","last":"39.883","volume":"11855.19","daily_change":"-4.389","daily_change_percentage":"-9.91"},"XRP-BTC":{"low":"0.000088364","high":"0.000089999","last":"0.000089658","volume":"112689.76","daily_change":"0.000000766","daily_change_percentage":"0.86"},"XRP-TRY":{"low":"1.6966","high":"1.7749","last":"1.7016","volume":"36255.83","daily_change":"-0.0651","daily_change_percentage":"-3.68"}}'
+    http_version: 
+  recorded_at: Sun, 20 Jan 2019 16:56:01 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Coinzo/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/Coinzo/integration_specs_fetch_ticker.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.coinzo.com/tickers
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.coinzo.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 20 Jan 2019 17:06:38 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1577'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d94b5612c8d16a26dfd4ceb41d3efaf761548003998; expires=Mon, 20-Jan-20
+        17:06:38 GMT; path=/; domain=.coinzo.com; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 49c321fdbb096aa3-LHR
+    body:
+      encoding: UTF-8
+      string: '{"BTC-TRY":{"low":"19017","high":"19890","last":"19024","volume":"10.58","daily_change":"-848","daily_change_percentage":"-4.26"},"CNZ-TRY":{"low":"0.045714","high":"0.048008","last":"0.045911","volume":"440505.20","daily_change":"-0.001936","daily_change_percentage":"-4.04"},"EOS-BTC":{"low":"0.00064325","high":"0.00067028","last":"0.0006551","volume":"18798.63","daily_change":"-0.00001518","daily_change_percentage":"-2.26"},"EOS-TRY":{"low":"12.393","high":"13.329","last":"12.471","volume":"26056.26","daily_change":"-0.848","daily_change_percentage":"-6.36"},"ETH-BTC":{"low":"0.03309","high":"0.033696","last":"0.033377","volume":"563.70","daily_change":"-0.000025","daily_change_percentage":"-0.07"},"ETH-TRY":{"low":"629.12","high":"664.49","last":"634.22","volume":"323.87","daily_change":"-29.6","daily_change_percentage":"-4.45"},"HOT-TRY":{"low":"0.0032809","high":"0.0047264","last":"0.0039273","volume":"675110858.14","daily_change":"0.0006462","daily_change_percentage":"19.69"},"NEO-BTC":{"low":"0.0020796","high":"0.0021997","last":"0.0020992","volume":"8765.68","daily_change":"-0.0000995","daily_change_percentage":"-4.52"},"NEO-TRY":{"low":"39.595","high":"43.736","last":"39.926","volume":"11700.92","daily_change":"-3.764","daily_change_percentage":"-8.61"},"XRP-BTC":{"low":"0.000088364","high":"0.000089999","last":"0.00008971","volume":"114408.22","daily_change":"0.000000818","daily_change_percentage":"0.92"},"XRP-TRY":{"low":"1.6966","high":"1.7749","last":"1.7016","volume":"36255.83","daily_change":"-0.0651","daily_change_percentage":"-3.68"}}'
+    http_version: 
+  recorded_at: Sun, 20 Jan 2019 17:06:38 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Coinzo/integration_specs_fetch_trade.yml
+++ b/spec/cassettes/vcr_cassettes/Coinzo/integration_specs_fetch_trade.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.coinzo.com/trades?pair=BTC-TRY
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.coinzo.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 20 Jan 2019 17:11:08 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d74cd75d8af8bd82a0635aceba4bc33481548004268; expires=Mon, 20-Jan-20
+        17:11:08 GMT; path=/; domain=.coinzo.com; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 49c328985cb66b8b-LHR
+    body:
+      encoding: UTF-8
+      string: '[{"price":19024,"amount":0.00204515,"side":"SELL","created_at":1548003869},{"price":19024,"amount":0.00014423,"side":"SELL","created_at":1548003869},{"price":19024,"amount":0.01069172,"side":"SELL","created_at":1548003864},{"price":19034,"amount":0.01711389,"side":"SELL","created_at":1548003864},{"price":19034,"amount":0.00217765,"side":"SELL","created_at":1548003862},{"price":19034,"amount":0.02406461,"side":"SELL","created_at":1548003862},{"price":19034,"amount":0.00350296,"side":"SELL","created_at":1548003862},{"price":19034,"amount":0.01057031,"side":"SELL","created_at":1548003860},{"price":19034,"amount":0.00693764,"side":"SELL","created_at":1548003860},{"price":19034,"amount":0.00988418,"side":"SELL","created_at":1548003860},{"price":19072,"amount":0.00876381,"side":"SELL","created_at":1548003630},{"price":19066,"amount":0.00389004,"side":"BUY","created_at":1548003625},{"price":19066,"amount":0.01099626,"side":"BUY","created_at":1548003624},{"price":19066,"amount":0.00459245,"side":"BUY","created_at":1548003620},{"price":19066,"amount":0.01018037,"side":"BUY","created_at":1548003620},{"price":19066,"amount":0.00225991,"side":"BUY","created_at":1548003616},{"price":19043,"amount":0.00200275,"side":"BUY","created_at":1548003616},{"price":19036,"amount":0.01232406,"side":"BUY","created_at":1548003616},{"price":19036,"amount":0.0082312,"side":"BUY","created_at":1548003616},{"price":19036,"amount":0.02085347,"side":"BUY","created_at":1548003614},{"price":19036,"amount":0.0006737,"side":"BUY","created_at":1548003614},{"price":19036,"amount":0.00369656,"side":"BUY","created_at":1548003613},{"price":19036,"amount":0.01292261,"side":"BUY","created_at":1548003613},{"price":19036,"amount":0.01351753,"side":"BUY","created_at":1548003609},{"price":19017,"amount":0.018029,"side":"BUY","created_at":1548003478},{"price":19017,"amount":0.00530158,"side":"SELL","created_at":1548002706},{"price":19017,"amount":0.00675013,"side":"SELL","created_at":1548002706},{"price":19017,"amount":0.02158154,"side":"SELL","created_at":1548002702},{"price":19020,"amount":0.00820128,"side":"SELL","created_at":1548002702},{"price":19020,"amount":0.01356573,"side":"SELL","created_at":1548002698}]'
+    http_version: 
+  recorded_at: Sun, 20 Jan 2019 17:11:08 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/coinzo/integration/market_spec.rb
+++ b/spec/exchanges/coinzo/integration/market_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+RSpec.describe 'Coinzo integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:btc_try_pair) { Cryptoexchange::Models::MarketPair.new(base: 'BTC', target: 'TRY', market: 'coinzo') }
+
+  it 'has trade_page_url' do
+    trade_page_url = client.trade_page_url btc_try_pair.market, base: btc_try_pair.base, target: btc_try_pair.target
+    expect(trade_page_url).to eq "https://www.coinzo.com/market/BTC-TRY"
+  end
+
+  it 'fetch pairs' do
+    pairs = client.pairs('coinzo')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.market).to eq 'coinzo'
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(btc_try_pair)
+
+    expect(ticker.base).to eq 'BTC'
+    expect(ticker.target).to eq 'TRY'
+    expect(ticker.market).to eq 'coinzo'
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.low).to be_a Numeric
+    expect(ticker.high).to be_a Numeric
+    expect(ticker.change).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+    expect(ticker.timestamp).to be nil
+    expect(ticker.payload).to_not be nil
+  end
+
+  it 'fetch order book' do
+    order_book = client.order_book(btc_try_pair)
+
+    expect(order_book.base).to eq 'BTC'
+    expect(order_book.target).to eq 'TRY'
+    expect(order_book.market).to eq 'coinzo'
+    expect(order_book.asks).to_not be_empty
+    expect(order_book.bids).to_not be_empty
+    expect(order_book.asks.first.price).to_not be_nil
+    expect(order_book.bids.first.amount).to_not be_nil
+    expect(order_book.bids.first.timestamp).to be_nil
+    expect(order_book.asks.count).to be > 5
+    expect(order_book.bids.count).to be > 5
+    expect(order_book.timestamp).to be nil
+    expect(order_book.payload).to_not be nil
+  end
+
+  it 'fetch trade' do
+    trades = client.trades(btc_try_pair)
+    trade = trades.sample
+
+    expect(trades).to_not be_empty
+    expect(trade.base).to eq 'BTC'
+    expect(trade.target).to eq 'TRY'
+    expect(trade.market).to eq 'coinzo'
+    expect(['buy', 'sell']).to include trade.type
+    expect(trade.price).to_not be_nil
+    expect(trade.amount).to_not be_nil
+    expect(trade.timestamp).to be_a Numeric
+    expect(2000..Date.today.year).to include(Time.at(trade.timestamp).year)
+    expect(trade.payload).to_not be nil
+  end
+end

--- a/spec/exchanges/coinzo/market_spec.rb
+++ b/spec/exchanges/coinzo/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Coinzo::Market do
+  it { expect(described_class::NAME).to eq 'coinzo' }
+  it { expect(described_class::API_URL).to eq 'https://api.coinzo.com' }
+end


### PR DESCRIPTION
- Add Pairs, Trade URL, OrderBook, Trades, and update README for Coinzo
- Closes: #1236 
- [X] I have added Specs
- [X] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [X] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [X] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [X] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
