### PR TITLE
change dobitrade api link

### DIFF
--- a/lib/cryptoexchange/exchanges/dobitrade/market.rb
+++ b/lib/cryptoexchange/exchanges/dobitrade/market.rb
@@ -2,7 +2,7 @@ module Cryptoexchange::Exchanges
   module Dobitrade
     class Market < Cryptoexchange::Models::Market
       NAME = 'dobitrade'
-      API_URL = 'https://api.dobiex.io'
+      API_URL = 'https://api.dobiexchange.com'
 
       def self.trade_page_url(args={})
         "https://www.dobiex.io/zh/trade/#{args[:base].downcase}_#{args[:target].downcase}"

--- a/spec/exchanges/dobitrade/market_spec.rb
+++ b/spec/exchanges/dobitrade/market_spec.rb
@@ -2,5 +2,5 @@ require 'spec_helper'
 
 RSpec.describe Cryptoexchange::Exchanges::Dobitrade::Market do
   it { expect(described_class::NAME).to eq 'dobitrade' }
-  it { expect(described_class::API_URL).to eq 'https://api.dobiex.io' }
+  it { expect(described_class::API_URL).to eq 'https://api.dobiexchange.com' }
 end


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [ ] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
