### PR TITLE
BitStorage Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Or install it yourself as:
 | Bitso             | Y       |            |         |         | Y           |          | bitso             |
 | Bitstamp          | Y       | Y          | Y       |         | User-Defined|          | bitstamp          |
 | Bitsten           | Y       | Y          | N       |         | Y           | Y        | bitsten           |
+| Bitstorage        | Y       | Y          | Y       |         | Y           | Y        | bitstorage        |
 | Bittrex           | Y       |            |         |         | Y           | Y        | bittrex           |
 | Bkex              | Y       | N          | N       |         | Y           | Y        | bkex              |
 | Bleutrade         | Y       |            |         |         | Y           |          | bleutrade         |

--- a/lib/cryptoexchange/exchanges/bitstorage/market.rb
+++ b/lib/cryptoexchange/exchanges/bitstorage/market.rb
@@ -1,0 +1,12 @@
+module Cryptoexchange::Exchanges
+  module Bitstorage
+    class Market < Cryptoexchange::Models::Market
+      NAME = 'bitstorage'
+      API_URL = 'https://bitstorage.finance/api'
+
+      def self.trade_page_url(args={})
+        "https://bitstorage.finance/market/#{args[:base]}-#{args[:target]}"
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/bitstorage/services/market.rb
+++ b/lib/cryptoexchange/exchanges/bitstorage/services/market.rb
@@ -1,0 +1,51 @@
+module Cryptoexchange::Exchanges
+  module Bitstorage
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            false
+          end
+        end
+
+        def fetch
+          output = super(ticker_url)
+          adapt_all(output)
+        end
+
+        def ticker_url
+          "#{Cryptoexchange::Exchanges::Bitstorage::Market::API_URL}/ticker"
+        end
+
+        def adapt_all(output)
+          output.map do |pair|
+            base, target = pair['pairs'].split('_')
+            market_pair  = Cryptoexchange::Models::MarketPair.new(
+              base:   base,
+              target: target,
+              market: Bitstorage::Market::NAME
+            )
+            adapt(market_pair, pair)
+          end
+        end
+
+        def adapt(market_pair, output)
+          ticker           = Cryptoexchange::Models::Ticker.new
+          ticker.base      = market_pair.base
+          ticker.target    = market_pair.target
+          ticker.market    = Bitstorage::Market::NAME
+          ticker.last      = NumericHelper.to_d(output['last_price'])
+          ticker.high      = NumericHelper.to_d(output['high'])
+          ticker.low       = NumericHelper.to_d(output['low'])
+          ticker.bid       = NumericHelper.to_d(output['bid'])
+          ticker.ask       = NumericHelper.to_d(output['ask'])
+          ticker.volume    = NumericHelper.to_d(output['24H_volume'])
+          ticker.change    = NumericHelper.to_d(output['change'])
+          ticker.timestamp = nil
+          ticker.payload   = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/bitstorage/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/bitstorage/services/order_book.rb
@@ -1,0 +1,43 @@
+module Cryptoexchange::Exchanges
+  module Bitstorage
+    module Services
+      class OrderBook < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          "#{Cryptoexchange::Exchanges::Bitstorage::Market::API_URL}/order-book?market=#{market_pair.base}&currency=#{market_pair.target}"
+        end
+
+        def adapt(output, market_pair)
+          order_book = Cryptoexchange::Models::OrderBook.new
+
+          order_book.base      = market_pair.base
+          order_book.target    = market_pair.target
+          order_book.market    = Bitstorage::Market::NAME
+          order_book.asks      = output['order-book']['ask'].empty? ? ['Nil'] : adapt_orders(output['order-book']['ask'])
+          order_book.bids      = output['order-book']['bid'].empty? ? ['Nil'] : adapt_orders(output['order-book']['bid'])
+          order_book.timestamp = nil
+          order_book.payload   = output
+          order_book
+        end
+
+        def adapt_orders(orders)
+          orders.collect do |order_entry|
+            Cryptoexchange::Models::Order.new(price: order_entry['price'],
+                                              amount: order_entry['order_amount'],
+                                              timestamp: order_entry['timestamp'])
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/bitstorage/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/bitstorage/services/pairs.rb
@@ -1,0 +1,23 @@
+module Cryptoexchange::Exchanges
+  module Bitstorage
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Bitstorage::Market::API_URL}/ticker"
+
+        def fetch
+          output = super
+          market_pairs = []
+          output.each do |pair|
+            base, target = pair['pairs'].split('_')
+            market_pairs << Cryptoexchange::Models::MarketPair.new(
+                              base: base,
+                              target: target,
+                              market: Bitstorage::Market::NAME
+                            )
+          end
+          market_pairs
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/bitstorage/services/trades.rb
+++ b/lib/cryptoexchange/exchanges/bitstorage/services/trades.rb
@@ -1,0 +1,32 @@
+module Cryptoexchange::Exchanges
+  module Bitstorage
+    module Services
+      class Trades < Cryptoexchange::Services::Market
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          "#{Cryptoexchange::Exchanges::Bitstorage::Market::API_URL}/transactions?market=#{market_pair.base}&currency=#{market_pair.target}"
+        end
+
+        def adapt(output, market_pair)
+          output['transactions']['data'].collect do |trade|
+            tr = Cryptoexchange::Models::Trade.new
+            tr.trade_id  = trade['id']
+            tr.base      = market_pair.base
+            tr.target    = market_pair.target
+            tr.market    = Bitstorage::Market::NAME
+            tr.type      = trade['maker_type']
+            tr.price     = trade['price']
+            tr.amount    = trade['amount']
+            tr.timestamp = trade['timestamp']
+            tr.payload   = trade
+            tr
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/BitStorage/integration_specs_fetch_order_book.yml
+++ b/spec/cassettes/vcr_cassettes/BitStorage/integration_specs_fetch_order_book.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://bitstorage.finance/api/order-book?currency=USD&market=BTC
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - bitstorage.finance
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 05 Feb 2019 03:19:16 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '167'
+      Connection:
+      - close
+      Set-Cookie:
+      - PHPSESSID=7hmvb63selno6rq8gil18cb4u7; path=/; HttpOnly
+      - PHPSESSID=b0e9dog10o79t211f4h6bqk0f3; path=/; HttpOnly
+      - PHPSESSID=fiegqjibc6f3a8saavrn0vbeu3; path=/; HttpOnly
+      - __cfduid=db162cbddcb67139fe2c9a898f0cbf77f1549336755; expires=Wed, 05-Feb-20
+        03:19:15 GMT; path=/; domain=.bitstorage.finance; HttpOnly; Secure
+      X-Frame-Options:
+      - SAMEORIGIN
+      Access-Control-Allow-Origin:
+      - "*"
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      Access-Control-Allow-Methods:
+      - GET,POST,OPTIONS,DELETE,PUT
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4a423c04a90894b7-NRT
+    body:
+      encoding: UTF-8
+      string: '{"order-book":{"market":"BTC","currency":"USD","bid":[{"price":3600,"order_amount":0.00027,"order_value":0.97,"converted_from":null,"timestamp":1548447843}],"ask":[]}}'
+    http_version: 
+  recorded_at: Tue, 05 Feb 2019 03:19:16 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/BitStorage/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/BitStorage/integration_specs_fetch_pairs.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://bitstorage.finance/api/ticker
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - bitstorage.finance
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 05 Feb 2019 02:44:03 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '2243'
+      Connection:
+      - close
+      Set-Cookie:
+      - PHPSESSID=901ii9fjam8g2dpsjg81keu4h6; path=/; HttpOnly
+      - PHPSESSID=sguhg9luqq959anp5a1t3hp6a1; path=/; HttpOnly
+      - PHPSESSID=uorst4i27cq90u9jkjvda3e1v3; path=/; HttpOnly
+      - __cfduid=d21e321a5bdfb913acda510ff5dd65edd1549334640; expires=Wed, 05-Feb-20
+        02:44:00 GMT; path=/; domain=.bitstorage.finance; HttpOnly; Secure
+      X-Frame-Options:
+      - SAMEORIGIN
+      Access-Control-Allow-Origin:
+      - "*"
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      Access-Control-Allow-Methods:
+      - GET,POST,OPTIONS,DELETE,PUT
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4a42085febd294ab-NRT
+    body:
+      encoding: UTF-8
+      string: '[{"pairs":"NXB_BTC","bid":5.0e-8,"ask":7.0e-8,"high":7.0e-8,"low":5.0e-8,"last_price":5.0e-8,"change":-16,"24H_volume":0.00995784},{"pairs":"AYWA_BTC","bid":2.0e-8,"ask":1.7e-7,"high":5.0e-8,"low":5.0e-8,"last_price":5.0e-8,"change":0,"24H_volume":0},{"pairs":"ESBC_BTC","bid":5.04e-6,"ask":5.94e-6,"high":5.93e-6,"low":5.04e-6,"last_price":5.89e-6,"change":15,"24H_volume":1.25191232},{"pairs":"SUNP_BTC","bid":2.0e-8,"ask":2.0e-8,"high":1.0e-8,"low":1.0e-8,"last_price":1.0e-8,"change":-50,"24H_volume":6.33e-6},{"pairs":"SICC_BTC","bid":3.0e-8,"ask":4.0e-6,"high":4.42e-6,"low":4.42e-6,"last_price":4.42e-6,"change":-3,"24H_volume":0},{"pairs":"DOGE_BTC","bid":5.2e-7,"ask":5.8e-7,"high":5.8e-7,"low":5.2e-7,"last_price":5.4e-7,"change":-1,"24H_volume":0.94608925},{"pairs":"LTC_BTC","bid":0.00769,"ask":0.00769,"high":0.00769,"low":0.00769,"last_price":0.00769,"change":0,"24H_volume":0},{"pairs":"NXB_LTC","bid":4.56e-5,"ask":4.56e-5,"high":0,"low":0,"last_price":4.56e-5,"change":-10,"24H_volume":0},{"pairs":"SICC_DOGE","bid":5750.93,"ask":5750.93,"high":7.62068966,"low":7.62068966,"last_price":0,"change":0,"24H_volume":0},{"pairs":"NXB_DOGE","bid":1.2,"ask":1.2,"high":0,"low":0,"last_price":1.2,"change":0,"24H_volume":0},{"pairs":"SICC_DOGE","bid":5750.93,"ask":5750.93,"high":7.62068966,"low":7.62068966,"last_price":0,"change":0,"24H_volume":0},{"pairs":"NXB_USD","bid":0.01,"ask":0.01,"high":0,"low":0,"last_price":0.02,"change":0,"24H_volume":0},{"pairs":"BTC_USD","bid":3600,"ask":3600,"high":450268500,"low":450268500,"last_price":8250,"change":0,"24H_volume":0},{"pairs":"NXB_RUB","bid":0.03,"ask":0.48,"high":0,"low":0,"last_price":0.48,"change":2,"24H_volume":0},{"pairs":"NXB_EUR","bid":0.1,"ask":0.1,"high":0,"low":0,"last_price":10,"change":0,"24H_volume":0},{"pairs":"ESBC_DOGE","bid":5,"ask":5,"high":0,"low":0,"last_price":6,"change":-25,"24H_volume":0},{"pairs":"ESBC_RUB","bid":0.8,"ask":0.8,"high":0,"low":0,"last_price":0.8,"change":0,"24H_volume":0},{"pairs":"FNO_BTC","bid":8.2e-7,"ask":8.5e-7,"high":8.5e-7,"low":8.2e-7,"last_price":8.5e-7,"change":3,"24H_volume":0.02579373},{"pairs":"TUBE_BTC","bid":6.15e-6,"ask":6.5e-6,"high":6.49e-6,"low":6.16e-6,"last_price":6.44e-6,"change":0,"24H_volume":0.10826178}]'
+    http_version: 
+  recorded_at: Tue, 05 Feb 2019 02:44:03 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/BitStorage/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/BitStorage/integration_specs_fetch_ticker.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://bitstorage.finance/api/ticker
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - bitstorage.finance
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 05 Feb 2019 03:09:38 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '2254'
+      Connection:
+      - close
+      Set-Cookie:
+      - PHPSESSID=55j3jvrmfic56ar3qe028e9cp1; path=/; HttpOnly
+      - PHPSESSID=gtveaiotuebuk73jdpbkqhkbn1; path=/; HttpOnly
+      - PHPSESSID=qnc5a74i9hnfpebn489tal5pd0; path=/; HttpOnly
+      - __cfduid=dd65b7f268f16b228e90a19e0449236501549336173; expires=Wed, 05-Feb-20
+        03:09:33 GMT; path=/; domain=.bitstorage.finance; HttpOnly; Secure
+      X-Frame-Options:
+      - SAMEORIGIN
+      Access-Control-Allow-Origin:
+      - "*"
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      Access-Control-Allow-Methods:
+      - GET,POST,OPTIONS,DELETE,PUT
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4a422dcb0a31949f-NRT
+    body:
+      encoding: UTF-8
+      string: '[{"pairs":"NXB_BTC","bid":5.0e-8,"ask":7.0e-8,"high":7.0e-8,"low":5.0e-8,"last_price":7.0e-8,"change":16,"24H_volume":0.0100719},{"pairs":"AYWA_BTC","bid":2.0e-8,"ask":1.7e-7,"high":5.0e-8,"low":5.0e-8,"last_price":5.0e-8,"change":0,"24H_volume":0},{"pairs":"ESBC_BTC","bid":5.04e-6,"ask":5.94e-6,"high":5.93e-6,"low":5.04e-6,"last_price":5.49e-6,"change":4,"24H_volume":1.27770927},{"pairs":"SUNP_BTC","bid":1.0e-8,"ask":2.0e-8,"high":1.0e-8,"low":1.0e-8,"last_price":1.0e-8,"change":-50,"24H_volume":6.33e-6},{"pairs":"SICC_BTC","bid":3.0e-8,"ask":4.0e-6,"high":4.42e-6,"low":4.42e-6,"last_price":4.42e-6,"change":-3,"24H_volume":0},{"pairs":"DOGE_BTC","bid":5.2e-7,"ask":5.8e-7,"high":5.8e-7,"low":5.2e-7,"last_price":5.3e-7,"change":0,"24H_volume":0.96131627},{"pairs":"LTC_BTC","bid":0.00769,"ask":0.00769,"high":0.00769,"low":0.00769,"last_price":0.00769,"change":0,"24H_volume":0},{"pairs":"NXB_LTC","bid":4.56e-5,"ask":4.56e-5,"high":0,"low":0,"last_price":4.56e-5,"change":-10,"24H_volume":0},{"pairs":"SICC_DOGE","bid":5750.93,"ask":5750.93,"high":7.62068966,"low":7.62068966,"last_price":0,"change":0,"24H_volume":0},{"pairs":"NXB_DOGE","bid":1.2,"ask":1.2,"high":0,"low":0,"last_price":1.2,"change":0,"24H_volume":0},{"pairs":"SICC_DOGE","bid":5750.93,"ask":5750.93,"high":7.62068966,"low":7.62068966,"last_price":0,"change":0,"24H_volume":0},{"pairs":"NXB_USD","bid":0.01,"ask":0.01,"high":0,"low":0,"last_price":0.02,"change":0,"24H_volume":0},{"pairs":"BTC_USD","bid":3600,"ask":3600,"high":450268500,"low":450268500,"last_price":8250,"change":0,"24H_volume":0},{"pairs":"NXB_RUB","bid":0.03,"ask":0.48,"high":0,"low":0,"last_price":0.48,"change":2,"24H_volume":0},{"pairs":"NXB_EUR","bid":0.1,"ask":0.1,"high":0,"low":0,"last_price":10,"change":0,"24H_volume":0},{"pairs":"ESBC_DOGE","bid":5,"ask":5,"high":8.68965517,"low":0,"last_price":6,"change":-25,"24H_volume":0},{"pairs":"ESBC_RUB","bid":0.8,"ask":0.8,"high":3.0e-7,"low":0,"last_price":0.8,"change":0,"24H_volume":0},{"pairs":"FNO_BTC","bid":8.2e-7,"ask":8.5e-7,"high":8.5e-7,"low":8.2e-7,"last_price":8.3e-7,"change":0,"24H_volume":0.02613775},{"pairs":"TUBE_BTC","bid":6.15e-6,"ask":6.5e-6,"high":6.49e-6,"low":6.16e-6,"last_price":6.33e-6,"change":-2,"24H_volume":0.10957261}]'
+    http_version: 
+  recorded_at: Tue, 05 Feb 2019 03:09:38 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/BitStorage/integration_specs_fetch_trade.yml
+++ b/spec/cassettes/vcr_cassettes/BitStorage/integration_specs_fetch_trade.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://bitstorage.finance/api/transactions?currency=USD&market=BTC
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - bitstorage.finance
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 05 Feb 2019 03:28:13 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '699'
+      Connection:
+      - close
+      Set-Cookie:
+      - PHPSESSID=e7n83bh4vs5dvt9ig14saju5a1; path=/; HttpOnly
+      - PHPSESSID=u73seqgp7k6leoq39oe1k7g2v0; path=/; HttpOnly
+      - PHPSESSID=vnr3ua60fbdprn8m5gm9l7hg25; path=/; HttpOnly
+      - __cfduid=d9cc43f2297baaf609a9490617b2d96eb1549337292; expires=Wed, 05-Feb-20
+        03:28:12 GMT; path=/; domain=.bitstorage.finance; HttpOnly; Secure
+      X-Frame-Options:
+      - SAMEORIGIN
+      Access-Control-Allow-Origin:
+      - "*"
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Pragma:
+      - no-cache
+      Access-Control-Allow-Methods:
+      - GET,POST,OPTIONS,DELETE,PUT
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4a42491eef1a946f-NRT
+    body:
+      encoding: UTF-8
+      string: '{"transactions":{"market":"BTC","currency":"USD","data":[{"id":449,"date":"2018-07-24
+        12:04:18","timestamp":1532423058,"btc":2.14e-5,"maker_type":"sell","price":8250,"amount":0.17655,"currency":"USD","market":"BTC"},{"id":241,"date":"2018-05-20
+        14:43:12","timestamp":1526816592,"btc":2.405e-5,"maker_type":"sell","price":8250,"amount":0.1984125,"currency":"USD","market":"BTC"},{"id":127,"date":"2018-05-08
+        07:34:10","timestamp":1525754050,"btc":0.00048167,"maker_type":"buy","price":9130,"amount":4.3976471,"currency":"USD","market":"BTC"},{"id":84,"date":"2018-05-04
+        19:25:21","timestamp":1525451121,"btc":1.0e-5,"maker_type":"sell","price":9130,"amount":0.0913,"currency":"USD","market":"BTC"}]}}'
+    http_version: 
+  recorded_at: Tue, 05 Feb 2019 03:28:13 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/bitstorage/integration/market_spec.rb
+++ b/spec/exchanges/bitstorage/integration/market_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+RSpec.describe 'BitStorage integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:btc_usd_pair) { Cryptoexchange::Models::MarketPair.new(base: 'BTC', target: 'USD', market: 'bitstorage') }
+
+  it 'has trade_page_url' do
+    trade_page_url = client.trade_page_url btc_usd_pair.market, base: btc_usd_pair.base, target: btc_usd_pair.target
+    expect(trade_page_url).to eq "https://bitstorage.finance/market/BTC-USD"
+  end
+
+  it 'fetch pairs' do
+    pairs = client.pairs('bitstorage')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.market).to eq 'bitstorage'
+  end
+
+    it 'fetch ticker' do
+      ticker = client.ticker(btc_usd_pair)
+
+      expect(ticker.base).to eq 'BTC'
+      expect(ticker.target).to eq 'USD'
+      expect(ticker.market).to eq 'bitstorage'
+      expect(ticker.last).to be_a Numeric
+      expect(ticker.low).to be_a Numeric
+      expect(ticker.high).to be_a Numeric
+      expect(ticker.bid).to be_a Numeric
+      expect(ticker.ask).to be_a Numeric
+      expect(ticker.change).to be_a Numeric
+      expect(ticker.volume).to be_a Numeric
+      expect(ticker.timestamp).to be nil
+      expect(ticker.payload).to_not be nil
+    end
+
+  it 'fetch order book' do
+    order_book = client.order_book(btc_usd_pair)
+
+    expect(order_book.base).to eq 'BTC'
+    expect(order_book.target).to eq 'USD'
+    expect(order_book.market).to eq 'bitstorage'
+    expect(order_book.asks).to_not be_empty
+    expect(order_book.bids).to_not be_empty
+    expect(order_book.asks.count).to be > 0
+    expect(order_book.bids.count).to be > 0
+    expect(order_book.timestamp).to be nil
+    expect(order_book.payload).to_not be nil
+  end
+
+  it 'fetch trade' do
+    trades = client.trades(btc_usd_pair)
+    trade = trades.sample
+
+    expect(trades).to_not be_empty
+    expect(trade.base).to eq 'BTC'
+    expect(trade.target).to eq 'USD'
+    expect(trade.market).to eq 'bitstorage'
+    expect(trade.trade_id).to_not be_nil
+    expect(['buy', 'sell']).to include trade.type
+    expect(trade.price).to_not be_nil
+    expect(trade.amount).to_not be_nil
+    expect(trade.timestamp).to be_a Numeric
+    expect(2000..Date.today.year).to include(Time.at(trade.timestamp).year)
+    expect(trade.payload).to_not be nil
+  end
+end

--- a/spec/exchanges/bitstorage/market_spec.rb
+++ b/spec/exchanges/bitstorage/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Bitstorage::Market do
+  it { expect(described_class::NAME).to eq 'bitstorage' }
+  it { expect(described_class::API_URL).to eq 'https://bitstorage.finance/api' }
+end


### PR DESCRIPTION
- Add Pairs, Tickers, OrderBook, Trade URL, Trades and update README for BitStorage
- Closes: #1239 
- [X] I have added Specs
- [X] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [X] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [X] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [X] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below) checked NXB_BTC pair.

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'bitstorage'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
