### PR TITLE
Implement exmarkets exchange (pairs, order-book, ticker, trades)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Or install it yourself as:
 | Dobitrade         | Y       | Y          | N       |         | Y           | Y        | dobitrade         |
 | Dragonex          | Y       | Y          | N       |         | Y           | Y        | dragonex          |
 | Dsx               | Y       | Y          | Y       |         | Y           |          | dsx               |
-| Eosex             | Y       | N          | N       |         | Y           | Y        | eosex             | 
+| Eosex             | Y       | N          | N       |         | Y           | Y        | eosex             |
 | Ercdex            | Y       | Y          |         |         | Y           |          | erxdex            |
 | Escodex           | Y       |            |         |         | Y           | Y        | escodex           |
 | EtherDelta        | Y       |            |         |         | Y           |          | ether_delta       |
@@ -199,6 +199,7 @@ Or install it yourself as:
 | Ethex             | Y       | N          | N       |         | Y           | N        | ethex             |
 | Ethfinex          | Y       | Y          | Y       |         | Y           | Y        | ethfinex          |
 | Everbloom         | Y       |            |         |         | Y           |          | everbloom         |
+| ExMarkets         | Y       | Y          | Y       |         | Y           | Y        | exmarkets         |
 | Exmo              | Y       | Y          | Y       |         | Y           | Y        | exmo              |
 | Exrates           | Y       | N          | N       |         | Y           | Y        | exrates           |
 | Extstock          | Y       | Y          | Y       |         | Y           | Y        | extstock          |

--- a/lib/cryptoexchange/exchanges/exmarkets/market.rb
+++ b/lib/cryptoexchange/exchanges/exmarkets/market.rb
@@ -1,0 +1,12 @@
+module Cryptoexchange::Exchanges
+  module Exmarkets
+    class Market < Cryptoexchange::Models::Market
+      NAME = 'exmarkets'
+      API_URL = 'https://exmarkets.com/api/trade/v1'
+
+      def self.trade_page_url(args = {})
+        "https://exmarkets.com/trade/#{args[:base]}-#{args[:target]}".downcase
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/exmarkets/services/market.rb
+++ b/lib/cryptoexchange/exchanges/exmarkets/services/market.rb
@@ -1,0 +1,41 @@
+module Cryptoexchange::Exchanges
+  module Exmarkets
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        URL = "#{Cryptoexchange::Exchanges::Exmarkets::Market::API_URL}/market/ticker"
+
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          base   = market_pair.base
+          target = market_pair.target
+          "#{URL}/#{base}-#{target}".downcase
+        end
+
+        def adapt(output, market_pair)
+          ticker           = Cryptoexchange::Models::Ticker.new
+          ticker.base      = market_pair.base
+          ticker.target    = market_pair.target
+          ticker.market    = Exmarkets::Market::NAME
+          ticker.bid       = NumericHelper.to_d(output['bid'])
+          ticker.ask       = NumericHelper.to_d(output['ask'])
+          ticker.last      = NumericHelper.to_d(output['last'])
+          ticker.high      = NumericHelper.to_d(output['high'])
+          ticker.low       = NumericHelper.to_d(output['low'])
+          ticker.volume    = NumericHelper.to_d(output['volume'])
+          ticker.payload   = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/exmarkets/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/exmarkets/services/order_book.rb
@@ -1,0 +1,49 @@
+module Cryptoexchange::Exchanges
+  module Exmarkets
+    module Services
+      class OrderBook < Cryptoexchange::Services::Market
+        URL = "#{Cryptoexchange::Exchanges::Exmarkets::Market::API_URL}/market/order-book"
+
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(order_book_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def order_book_url(market_pair)
+          base   = market_pair.base
+          target = market_pair.target
+          "#{URL}?market=#{base}-#{target}".downcase
+        end
+
+        def adapt(output, market_pair)
+          order_book = Cryptoexchange::Models::OrderBook.new
+
+          order_book.base      = market_pair.base
+          order_book.target    = market_pair.target
+          order_book.market    = Exmarkets::Market::NAME
+          order_book.asks      = adapt_orders(output['asks'])
+          order_book.bids      = adapt_orders(output['bids'])
+          order_book.timestamp = nil
+          order_book.payload   = output
+          order_book
+        end
+
+        def adapt_orders(orders)
+          orders.collect do |order_entry|
+            Cryptoexchange::Models::Order.new(
+              price:     NumericHelper.to_d(order_entry['price']),
+              amount:    NumericHelper.to_d(order_entry['amount']),
+              timestamp: nil
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/exmarkets/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/exmarkets/services/pairs.rb
@@ -1,0 +1,25 @@
+module Cryptoexchange::Exchanges
+  module Exmarkets
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "https://exmarkets.com/api/v1/general/information"
+
+        def fetch
+          output = super
+          adapt(output)
+        end
+
+        def adapt(output)
+          output['markets'].map do |pair|
+            Cryptoexchange::Models::MarketPair.new(
+              base:   pair['currency'],
+              target: pair['withCurrency'],
+              inst_id: pair['id'],
+              market: Exmarkets::Market::NAME
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/exmarkets/services/trades.rb
+++ b/lib/cryptoexchange/exchanges/exmarkets/services/trades.rb
@@ -1,0 +1,38 @@
+module Cryptoexchange::Exchanges
+  module Exmarkets
+    module Services
+      class Trades < Cryptoexchange::Services::Market
+        URL = "#{Cryptoexchange::Exchanges::Exmarkets::Market::API_URL}/transactions"
+        LIMIT = 50
+
+        def fetch(market_pair)
+          output = super(trades_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def trades_url(market_pair)
+          base   = market_pair.base
+          target = market_pair.target
+
+          "#{URL}?market=#{base}-#{target}&limit=#{LIMIT}".downcase
+        end
+
+        def adapt(output, market_pair)
+          output['transactions'].collect do |transaction|
+            tr = Cryptoexchange::Models::Trade.new
+            tr.trade_id  = transaction['id']
+            tr.base      = market_pair.base
+            tr.target    = market_pair.target
+            tr.market    = Exmarkets::Market::NAME
+            tr.type      = transaction['side']
+            tr.price     = NumericHelper.to_d(transaction['price'])
+            tr.amount    = NumericHelper.to_d(transaction['amount'])
+            tr.timestamp = NumericHelper.to_d(transaction['timestamp'])
+            tr.payload   = transaction
+            tr
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/Exmarkets/integration_specs__order_book_has_correct_pair_fields_assigned.yml
+++ b/spec/cassettes/vcr_cassettes/Exmarkets/integration_specs__order_book_has_correct_pair_fields_assigned.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://exmarkets.com/api/trade/v1/market/order-book?market=eth-btc
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - exmarkets.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 19 Feb 2019 18:30:26 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d99b9b89bd19e6a8024b0a5fdbab9f7d41550601026; expires=Wed, 19-Feb-20
+        18:30:26 GMT; path=/; domain=.exmarkets.com; HttpOnly
+      X-Powered-By:
+      - PHP/7.2.15
+      Cache-Control:
+      - no-cache
+      Allow:
+      - GET
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubdomains; preload
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4abacdff5da9b4fe-VNO
+    body:
+      encoding: ASCII-8BIT
+      string: '{"asks":[{"amount":"5.41300000","price":"0.03697600"},{"amount":"10.00000000","price":"0.03697800"},{"amount":"0.02000000","price":"0.03697900"},{"amount":"69.75400000","price":"0.03698000"},{"amount":"2.00700000","price":"0.03698400"},{"amount":"15.32400000","price":"0.03698500"},{"amount":"27.07400000","price":"0.03698600"},{"amount":"1.79000000","price":"0.03698700"},{"amount":"27.05300000","price":"0.03698900"},{"amount":"0.65200000","price":"0.03699000"}],"bids":[{"amount":"0.55000000","price":"0.03697300"},{"amount":"13.51900000","price":"0.03697100"},{"amount":"4.43100000","price":"0.03696900"},{"amount":"10.00000000","price":"0.03696800"},{"amount":"10.00000000","price":"0.03696400"},{"amount":"0.02000000","price":"0.03695400"},{"amount":"2.00000000","price":"0.03694300"},{"amount":"0.02000000","price":"0.03694200"},{"amount":"190.83700000","price":"0.03694000"},{"amount":"0.54100000","price":"0.03693600"}]}'
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 18:30:26 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Exmarkets/integration_specs__pairs_fetches_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/Exmarkets/integration_specs__pairs_fetches_pairs.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://exmarkets.com/api/v1/general/information
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - exmarkets.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 19 Feb 2019 18:30:25 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=dc183b81a5326a65057caf3ab91d685b31550601025; expires=Wed, 19-Feb-20
+        18:30:25 GMT; path=/; domain=.exmarkets.com; HttpOnly
+      X-Powered-By:
+      - PHP/7.2.15
+      Cache-Control:
+      - no-cache
+      Allow:
+      - GET
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubdomains; preload
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4abacdfc2ad4b50a-VNO
+    body:
+      encoding: ASCII-8BIT
+      string: '{"currencies":[{"id":1,"code":"BTC","sign":"\u0e3f"},{"id":2,"code":"ETH","sign":"\u039e"},{"id":3,"code":"LTC","sign":"\u0141"},{"id":4,"code":"BCH","sign":""},{"id":5,"code":"DASH","sign":""},{"id":8,"code":"BAT","sign":""},{"id":13,"code":"OMG","sign":""},{"id":24,"code":"USDC","sign":""},{"id":25,"code":"UDOO","sign":""},{"id":26,"code":"XRM","sign":""},{"id":27,"code":"USAT","sign":""}],"markets":[{"id":1,"name":"ETH-BTC","slug":"eth-btc","currency":"ETH","withCurrency":"BTC"},{"id":2,"name":"LTC-BTC","slug":"ltc-btc","currency":"LTC","withCurrency":"BTC"},{"id":3,"name":"LTC-ETH","slug":"ltc-eth","currency":"LTC","withCurrency":"ETH"},{"id":6,"name":"DASH-BTC","slug":"dash-btc","currency":"DASH","withCurrency":"BTC"},{"id":7,"name":"DASH-ETH","slug":"dash-eth","currency":"DASH","withCurrency":"ETH"},{"id":21,"name":"OMG-BTC","slug":"omg-btc","currency":"OMG","withCurrency":"BTC"},{"id":23,"name":"OMG-ETH","slug":"omg-eth","currency":"OMG","withCurrency":"ETH"},{"id":44,"name":"BTC-USDC","slug":"btc-usdc","currency":"BTC","withCurrency":"USDC"},{"id":45,"name":"ETH-USDC","slug":"eth-usdc","currency":"ETH","withCurrency":"USDC"},{"id":47,"name":"UDOO-BTC","slug":"udoo-btc","currency":"UDOO","withCurrency":"BTC"},{"id":49,"name":"XRM-ETH","slug":"xrm-eth","currency":"XRM","withCurrency":"ETH"},{"id":50,"name":"USAT-BTC","slug":"usat-btc","currency":"USAT","withCurrency":"BTC"}]}'
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 18:30:25 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Exmarkets/integration_specs__pairs_fills_pair_details_correctly.yml
+++ b/spec/cassettes/vcr_cassettes/Exmarkets/integration_specs__pairs_fills_pair_details_correctly.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://exmarkets.com/api/v1/general/information
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - exmarkets.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 19 Feb 2019 18:30:26 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d84ee39121d20878ffde15b669133ca3e1550601026; expires=Wed, 19-Feb-20
+        18:30:26 GMT; path=/; domain=.exmarkets.com; HttpOnly
+      X-Powered-By:
+      - PHP/7.2.15
+      Cache-Control:
+      - no-cache
+      Allow:
+      - GET
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubdomains; preload
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4abacdfd2c59b4e6-VNO
+    body:
+      encoding: ASCII-8BIT
+      string: '{"currencies":[{"id":1,"code":"BTC","sign":"\u0e3f"},{"id":2,"code":"ETH","sign":"\u039e"},{"id":3,"code":"LTC","sign":"\u0141"},{"id":4,"code":"BCH","sign":""},{"id":5,"code":"DASH","sign":""},{"id":8,"code":"BAT","sign":""},{"id":13,"code":"OMG","sign":""},{"id":24,"code":"USDC","sign":""},{"id":25,"code":"UDOO","sign":""},{"id":26,"code":"XRM","sign":""},{"id":27,"code":"USAT","sign":""}],"markets":[{"id":1,"name":"ETH-BTC","slug":"eth-btc","currency":"ETH","withCurrency":"BTC"},{"id":2,"name":"LTC-BTC","slug":"ltc-btc","currency":"LTC","withCurrency":"BTC"},{"id":3,"name":"LTC-ETH","slug":"ltc-eth","currency":"LTC","withCurrency":"ETH"},{"id":6,"name":"DASH-BTC","slug":"dash-btc","currency":"DASH","withCurrency":"BTC"},{"id":7,"name":"DASH-ETH","slug":"dash-eth","currency":"DASH","withCurrency":"ETH"},{"id":21,"name":"OMG-BTC","slug":"omg-btc","currency":"OMG","withCurrency":"BTC"},{"id":23,"name":"OMG-ETH","slug":"omg-eth","currency":"OMG","withCurrency":"ETH"},{"id":44,"name":"BTC-USDC","slug":"btc-usdc","currency":"BTC","withCurrency":"USDC"},{"id":45,"name":"ETH-USDC","slug":"eth-usdc","currency":"ETH","withCurrency":"USDC"},{"id":47,"name":"UDOO-BTC","slug":"udoo-btc","currency":"UDOO","withCurrency":"BTC"},{"id":49,"name":"XRM-ETH","slug":"xrm-eth","currency":"XRM","withCurrency":"ETH"},{"id":50,"name":"USAT-BTC","slug":"usat-btc","currency":"USAT","withCurrency":"BTC"}]}'
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 18:30:26 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Exmarkets/integration_specs__ticker_assigns_correct_attributes.yml
+++ b/spec/cassettes/vcr_cassettes/Exmarkets/integration_specs__ticker_assigns_correct_attributes.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://exmarkets.com/api/trade/v1/market/ticker/eth-btc
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - exmarkets.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 19 Feb 2019 18:30:26 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d84ee39121d20878ffde15b669133ca3e1550601026; expires=Wed, 19-Feb-20
+        18:30:26 GMT; path=/; domain=.exmarkets.com; HttpOnly
+      X-Powered-By:
+      - PHP/7.2.15
+      Cache-Control:
+      - no-cache
+      Allow:
+      - GET
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubdomains; preload
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4abacdfe4defb4e6-VNO
+    body:
+      encoding: ASCII-8BIT
+      string: '{"last":"0.03697500","high":"0.03792600","low":"0.03660600","volume":"637.80500000","bid":"0.03697300","ask":"0.03697600"}'
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 18:30:26 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Exmarkets/integration_specs__trades_has_correct_pair_fields_assigned.yml
+++ b/spec/cassettes/vcr_cassettes/Exmarkets/integration_specs__trades_has_correct_pair_fields_assigned.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://exmarkets.com/api/trade/v1/transactions?limit=50&market=eth-btc
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - exmarkets.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 19 Feb 2019 18:30:26 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d84ee39121d20878ffde15b669133ca3e1550601026; expires=Wed, 19-Feb-20
+        18:30:26 GMT; path=/; domain=.exmarkets.com; HttpOnly
+      X-Powered-By:
+      - PHP/7.2.15
+      Cache-Control:
+      - no-cache
+      Allow:
+      - GET
+      Strict-Transport-Security:
+      - max-age=15768000; includeSubdomains; preload
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4abace0068e6b4e6-VNO
+    body:
+      encoding: ASCII-8BIT
+      string: '{"transactions":[{"id":6882902,"amount":"0.02000000","price":"0.03697500","side":"SELL","timestamp":1550601015},{"id":6882900,"amount":"-0.02000000","price":"0.03697200","side":"BUY","timestamp":1550600995},{"id":6882896,"amount":"0.93900000","price":"0.03697800","side":"SELL","timestamp":1550600972},{"id":6882866,"amount":"-0.02000000","price":"0.03694200","side":"BUY","timestamp":1550600855},{"id":6882852,"amount":"-0.48000000","price":"0.03697600","side":"BUY","timestamp":1550600802},{"id":6882850,"amount":"-0.02000000","price":"0.03697700","side":"BUY","timestamp":1550600802},{"id":6882846,"amount":"0.02200000","price":"0.03697000","side":"SELL","timestamp":1550600768},{"id":6882844,"amount":"-1.00000000","price":"0.03697100","side":"BUY","timestamp":1550600752},{"id":6882840,"amount":"-0.61200000","price":"0.03697300","side":"BUY","timestamp":1550600746},{"id":6882834,"amount":"0.17900000","price":"0.03695200","side":"SELL","timestamp":1550600723},{"id":6882832,"amount":"2.00000000","price":"0.03695000","side":"SELL","timestamp":1550600717},{"id":6882802,"amount":"-1.00000000","price":"0.03695100","side":"BUY","timestamp":1550600527},{"id":6882786,"amount":"-0.02000000","price":"0.03695200","side":"BUY","timestamp":1550600485},{"id":6882772,"amount":"-0.02000000","price":"0.03695300","side":"BUY","timestamp":1550600418},{"id":6882750,"amount":"-0.02000000","price":"0.03694700","side":"BUY","timestamp":1550600302},{"id":6882714,"amount":"-0.02000000","price":"0.03695400","side":"BUY","timestamp":1550600145},{"id":6882710,"amount":"0.02000000","price":"0.03695400","side":"SELL","timestamp":1550600128},{"id":6882682,"amount":"-2.00000000","price":"0.03693800","side":"BUY","timestamp":1550600058},{"id":6882680,"amount":"1.35400000","price":"0.03695600","side":"SELL","timestamp":1550600048},{"id":6882654,"amount":"-1.50000000","price":"0.03692700","side":"BUY","timestamp":1550599869},{"id":6882616,"amount":"-1.00000000","price":"0.03692300","side":"BUY","timestamp":1550599637},{"id":6882602,"amount":"-0.18000000","price":"0.03699200","side":"BUY","timestamp":1550599520},{"id":6882600,"amount":"-0.02000000","price":"0.03699500","side":"BUY","timestamp":1550599520},{"id":6882582,"amount":"-0.02000000","price":"0.03699400","side":"BUY","timestamp":1550599340},{"id":6882580,"amount":"2.00000000","price":"0.03700000","side":"SELL","timestamp":1550599333},{"id":6882578,"amount":"0.28400000","price":"0.03696000","side":"SELL","timestamp":1550599314},{"id":6882570,"amount":"-0.02000000","price":"0.03700700","side":"BUY","timestamp":1550599287},{"id":6882566,"amount":"-0.96000000","price":"0.03701100","side":"BUY","timestamp":1550599262},{"id":6882556,"amount":"1.78000000","price":"0.03700000","side":"SELL","timestamp":1550599207},{"id":6882554,"amount":"0.22000000","price":"0.03699000","side":"SELL","timestamp":1550599207},{"id":6882536,"amount":"0.02000000","price":"0.03699000","side":"SELL","timestamp":1550599159},{"id":6882526,"amount":"0.02000000","price":"0.03699400","side":"SELL","timestamp":1550599106},{"id":6882510,"amount":"-0.02000000","price":"0.03696200","side":"BUY","timestamp":1550598989},{"id":6882476,"amount":"-0.48700000","price":"0.03694000","side":"BUY","timestamp":1550598873},{"id":6882424,"amount":"0.38600000","price":"0.03694000","side":"SELL","timestamp":1550598503},{"id":6882402,"amount":"-1.00000000","price":"0.03695400","side":"BUY","timestamp":1550598413},{"id":6882386,"amount":"-0.48000000","price":"0.03696500","side":"BUY","timestamp":1550598377},{"id":6882384,"amount":"-0.02000000","price":"0.03696600","side":"BUY","timestamp":1550598377},{"id":6882374,"amount":"-0.02000000","price":"0.03695400","side":"BUY","timestamp":1550598316},{"id":6882372,"amount":"0.02000000","price":"0.03695400","side":"SELL","timestamp":1550598306},{"id":6882354,"amount":"0.02000000","price":"0.03695900","side":"SELL","timestamp":1550598235},{"id":6882352,"amount":"0.02000000","price":"0.03693000","side":"SELL","timestamp":1550598215},{"id":6882332,"amount":"0.02000000","price":"0.03689900","side":"SELL","timestamp":1550598121},{"id":6882330,"amount":"0.02000000","price":"0.03689900","side":"SELL","timestamp":1550598110},{"id":6882312,"amount":"0.02000000","price":"0.03695100","side":"SELL","timestamp":1550598059},{"id":6882308,"amount":"-0.02000000","price":"0.03694700","side":"BUY","timestamp":1550598027},{"id":6882300,"amount":"-0.02000000","price":"0.03695400","side":"BUY","timestamp":1550597978},{"id":6882286,"amount":"-0.02000000","price":"0.03695400","side":"BUY","timestamp":1550597863},{"id":6882284,"amount":"0.21300000","price":"0.03695400","side":"SELL","timestamp":1550597850},{"id":6882264,"amount":"-0.56300000","price":"0.03695600","side":"BUY","timestamp":1550597761}]}'
+    http_version: 
+  recorded_at: Tue, 19 Feb 2019 18:30:26 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/exmarkets/integration/market_spec.rb
+++ b/spec/exchanges/exmarkets/integration/market_spec.rb
@@ -1,0 +1,99 @@
+require 'spec_helper'
+require 'pry'
+
+RSpec.describe 'Exmarkets integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:sample_pair) { Cryptoexchange::Models::MarketPair.new(base: 'ETH', target: 'BTC', market: 'exmarkets') }
+
+
+  describe '.trade_page_url' do
+    let(:trade_page_url) { client.trade_page_url 'exmarkets', base: sample_pair.base, target: sample_pair.target }
+
+    it 'givee correct trade page url' do
+      expect(trade_page_url).to eq "https://exmarkets.com/trade/eth-btc"
+    end
+  end
+
+  describe '#pairs' do
+    let(:pairs) { client.pairs('exmarkets') }
+
+    it 'fetches pairs' do
+      expect(pairs).not_to be_empty
+    end
+
+    it 'fills pair details correctly', :agregate_failures do
+      pair = pairs.first
+      expect(pair.base).to eq 'ETH'
+      expect(pair.target).to eq 'BTC'
+      expect(pair.market).to eq 'exmarkets'
+    end
+  end
+
+  describe '#ticker' do
+    let(:ticker) { client.ticker(sample_pair) }
+    let(:expected_attributes) do
+      {
+        ask: NumericHelper.to_d(0.036976), base: 'ETH', bid: NumericHelper.to_d(0.036973),
+        high: NumericHelper.to_d(0.037926), last: NumericHelper.to_d(0.036975),
+        low: NumericHelper.to_d(0.036606),
+        market: 'exmarkets', target: 'BTC', volume:  NumericHelper.to_d(637.805), payload: {
+          'last'=>'0.03697500', 'high'=>'0.03792600', 'low'=>'0.03660600', 'volume'=>'637.80500000',
+          'bid'=>'0.03697300', 'ask'=>'0.03697600'
+        }
+      }
+    end
+
+    it 'assigns correct attributes' do
+      actual_attributes = expected_attributes.each_key.with_object({}) do |variable_name, data|
+        data[variable_name] = ticker.send(variable_name)
+      end
+
+      expect(actual_attributes).to eq expected_attributes
+    end
+  end
+
+  describe '#order-book' do
+    let(:order_book) { client.order_book(sample_pair) }
+
+    it 'has correct pair fields assigned', :agregate_failures do
+      expect(order_book.base).to eq 'ETH'
+      expect(order_book.target).to eq 'BTC'
+      expect(order_book.market).to eq 'exmarkets'
+    end
+
+    it 'has a list of asks' do
+      expect(order_book.asks).to_not be_empty
+    end
+
+    it 'has a list of bids' do
+      expect(order_book.bids).to_not be_empty
+    end
+
+    it 'has no timestamp' do
+      expect(order_book.timestamp).to be_nil
+    end
+  end
+
+  describe '#trades' do
+    let(:trades) { client.trades(sample_pair) }
+    let(:trade) { trades.sort_by(&:trade_id).first }
+
+    it 'has correct pair fields assigned', :agregate_failures do
+      expect(trade.base).to eq 'ETH'
+      expect(trade.target).to eq 'BTC'
+      expect(trade.market).to eq 'exmarkets'
+    end
+
+    it 'has correct price' do
+      expect(trade.price).to eq NumericHelper.to_d(0.036956)
+    end
+
+    it 'has correct type' do
+      expect(trade.type).to eq 'BUY'
+    end
+
+    it 'has trade_id assigned' do
+      expect(trade.trade_id).to eq 6882264
+    end
+  end
+end

--- a/spec/exchanges/exmarkets/market_spec.rb
+++ b/spec/exchanges/exmarkets/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Exmarkets::Market do
+  it { expect(described_class::NAME).to eq 'exmarkets' }
+  it { expect(described_class::API_URL).to eq 'https://exmarkets.com/api/trade/v1' }
+end


### PR DESCRIPTION
- What is the purpose of this Pull Request?
This pull request adds API endpoints for Exmarkets exchange. 
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
There is no issue for this pull request. It's a feature to support a new exchange.
- [x] I have added Specs
- [x] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [x] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [x] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [x] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exmarkets'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
