### PR TITLE
edit dflow trade url and add spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Or install it yourself as:
 | Ddex              | Y       | Y          | Y       |         | Y           | Y        | ddex              |
 | DEEX              | Y       |            |         |         | Y           |          | deex              |
 | DEx.top           | Y       | Y          | Y       |         | Y           |          | dextop            |
+| Dflow             | Y       |            |         |         | Y           | Y        | dflow             |
 | Digifinex         | Y       |            |         |         | Y           |          | digifinex         |
 | Dobitrade         | Y       | Y          | N       |         | Y           | Y        | dobitrade         |
 | Dragonex          | Y       | Y          | N       |         | Y           | Y        | dragonex          |

--- a/lib/cryptoexchange/exchanges/dflow/market.rb
+++ b/lib/cryptoexchange/exchanges/dflow/market.rb
@@ -1,0 +1,12 @@
+module Cryptoexchange::Exchanges
+  module Dflow
+    class Market
+      NAME = 'dflow'
+      API_URL = 'https://api.dflowx.com/v1'
+
+      def self.trade_page_url
+        "https://dflowx.com/Exchange"
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/dflow/market.rb
+++ b/lib/cryptoexchange/exchanges/dflow/market.rb
@@ -4,7 +4,7 @@ module Cryptoexchange::Exchanges
       NAME = 'dflow'
       API_URL = 'https://api.dflowx.com/v1'
 
-      def self.trade_page_url
+      def self.trade_page_url(args={})
         "https://dflowx.com/Exchange"
       end
     end

--- a/lib/cryptoexchange/exchanges/dflow/services/market.rb
+++ b/lib/cryptoexchange/exchanges/dflow/services/market.rb
@@ -33,7 +33,7 @@ module Cryptoexchange::Exchanges
           ticker.ask       = NumericHelper.to_d(data['sell'])
           ticker.volume    = NumericHelper.to_d(data['vol'])
 
-          ticker.timestamp = data['time'].to_i / 1000
+          ticker.timestamp = nil
           ticker.payload   = output
           ticker
         end

--- a/lib/cryptoexchange/exchanges/dflow/services/market.rb
+++ b/lib/cryptoexchange/exchanges/dflow/services/market.rb
@@ -1,0 +1,43 @@
+module Cryptoexchange::Exchanges
+  module Dflow
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          pair = "#{market_pair.base}#{ market_pair.target}".downcase
+          "#{Cryptoexchange::Exchanges::Dflow::Market::API_URL}/market/ticker?symbol=#{pair}"
+        end
+
+        def adapt(output, market_pair)
+          data = output["data"]["#{market_pair.base}#{ market_pair.target}".downcase]
+
+          ticker           = Cryptoexchange::Models::Ticker.new
+          ticker.base      = market_pair.base
+          ticker.target    = market_pair.target
+          ticker.market    = Dflow::Market::NAME
+
+          ticker.last      = NumericHelper.to_d(data['last'])
+          ticker.high      = NumericHelper.to_d(data['high'])
+          ticker.low       = NumericHelper.to_d(data['low'])
+          ticker.bid       = NumericHelper.to_d(data['buy'])
+          ticker.ask       = NumericHelper.to_d(data['sell'])
+          ticker.volume    = NumericHelper.to_d(data['vol'])
+
+          ticker.timestamp = data['time'].to_i / 1000
+          ticker.payload   = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/dflow/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/dflow/services/pairs.rb
@@ -1,0 +1,26 @@
+module Cryptoexchange::Exchanges
+  module Dflow
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Dflow::Market::API_URL}/market/list"
+
+        def fetch
+          output = super
+          adapt(output)
+        end
+
+        def adapt(output)
+          output['data'].map do |output|
+            base = output["base_coin"]
+            target = output["count_coin"]
+            Cryptoexchange::Models::MarketPair.new(
+              base:   base,
+              target: target,
+              market: Dflow::Market::NAME
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/Dflow/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/Dflow/integration_specs_fetch_pairs.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.dflowx.com/v1/market/list
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.dflowx.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Wed, 20 Feb 2019 03:37:20 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - SCOUTER=z55ip860qavtbd; Max-Age=2147483647; Expires=Mon, 10-Mar-2087 06:51:27
+        GMT; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"code":"0","msg":"suc","data":[{"symbol":"ethusdt","count_coin":"usdt","amount_precision":3,"base_coin":"eth","price_precision":5},{"symbol":"fsnusdt","count_coin":"usdt","amount_precision":2,"base_coin":"fsn","price_precision":4},{"symbol":"ftmusdt","count_coin":"usdt","amount_precision":2,"base_coin":"ftm","price_precision":4},{"symbol":"ablusdt","count_coin":"usdt","amount_precision":2,"base_coin":"abl","price_precision":4},{"symbol":"btcusdt","count_coin":"usdt","amount_precision":4,"base_coin":"btc","price_precision":6},{"symbol":"dflusdt","count_coin":"usdt","amount_precision":2,"base_coin":"dfl","price_precision":4},{"symbol":"ethbtc","count_coin":"btc","amount_precision":4,"base_coin":"eth","price_precision":6},{"symbol":"fsnbtc","count_coin":"btc","amount_precision":6,"base_coin":"fsn","price_precision":8},{"symbol":"ftmbtc","count_coin":"btc","amount_precision":6,"base_coin":"ftm","price_precision":8},{"symbol":"ablbtc","count_coin":"btc","amount_precision":6,"base_coin":"abl","price_precision":8},{"symbol":"bchabcbtc","count_coin":"btc","amount_precision":4,"base_coin":"bchabc","price_precision":6},{"symbol":"bchsvbtc","count_coin":"btc","amount_precision":4,"base_coin":"bchsv","price_precision":6},{"symbol":"bchabcusdt","count_coin":"usdt","amount_precision":3,"base_coin":"bchabc","price_precision":5},{"symbol":"bchsvusdt","count_coin":"usdt","amount_precision":3,"base_coin":"bchsv","price_precision":5},{"symbol":"beebtc","count_coin":"btc","amount_precision":6,"base_coin":"bee","price_precision":8},{"symbol":"beeusdt","count_coin":"usdt","amount_precision":2,"base_coin":"bee","price_precision":4},{"symbol":"springbtc","count_coin":"btc","amount_precision":6,"base_coin":"spring","price_precision":8},{"symbol":"springusdt","count_coin":"usdt","amount_precision":2,"base_coin":"spring","price_precision":4},{"symbol":"c20btc","count_coin":"btc","amount_precision":6,"base_coin":"c20","price_precision":8},{"symbol":"c20usdt","count_coin":"usdt","amount_precision":2,"base_coin":"c20","price_precision":4},{"symbol":"atomusdt","count_coin":"usdt","amount_precision":0,"base_coin":"atom","price_precision":2}]}'
+    http_version: 
+  recorded_at: Wed, 20 Feb 2019 03:37:20 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Dflow/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/Dflow/integration_specs_fetch_ticker.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.dflowx.com/v1/market/ticker?symbol=ethusdt
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.dflowx.com
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.12.2
+      Date:
+      - Wed, 20 Feb 2019 03:37:21 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - SCOUTER=x10hpn49ibud8i; Max-Age=2147483647; Expires=Mon, 10-Mar-2087 06:51:28
+        GMT; Path=/
+    body:
+      encoding: UTF-8
+      string: '{"code":"0","msg":"success","data":{"ethusdt":{"quoteAssetName":"eth","high":147.73640000,"vol":4.48500000,"last":145.0000000000000000,"low":135.34790000,"buy":"139.00000","sell":"145.00000","baseAssetName":"usdt","time":1550617353569}}}'
+    http_version: 
+  recorded_at: Wed, 20 Feb 2019 03:37:21 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/dflow/integration/market_spec.rb
+++ b/spec/exchanges/dflow/integration/market_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe 'Dflow integration specs' do
     expect(pair.market).to eq 'dflow'
   end
 
+  it 'give trade url' do
+    trade_page_url = client.trade_page_url 'dflow', base: "ETH", target: "USDT"
+    expect(trade_page_url).to eq "https://dflowx.com/Exchange"
+  end
+
   it 'fetch ticker' do
     ticker = client.ticker(eth_usdt_pair)
 

--- a/spec/exchanges/dflow/integration/market_spec.rb
+++ b/spec/exchanges/dflow/integration/market_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+RSpec.describe 'Dflow integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:eth_usdt_pair) { Cryptoexchange::Models::MarketPair.new(base: 'ETH', target: 'USDT', market: 'dflow') }
+
+  it 'fetch pairs' do
+    pairs = client.pairs('dflow')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.market).to eq 'dflow'
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(eth_usdt_pair)
+
+    expect(ticker.base).to eq 'ETH'
+    expect(ticker.target).to eq 'USDT'
+    expect(ticker.market).to eq 'dflow'
+
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.high).to be_a Numeric
+    expect(ticker.low).to be_a Numeric
+    expect(ticker.bid).to be_a Numeric
+    expect(ticker.ask).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+
+    expect(ticker.timestamp).to be_a Numeric
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
+    expect(ticker.payload).to_not be nil
+  end
+end

--- a/spec/exchanges/dflow/integration/market_spec.rb
+++ b/spec/exchanges/dflow/integration/market_spec.rb
@@ -28,8 +28,7 @@ RSpec.describe 'Dflow integration specs' do
     expect(ticker.ask).to be_a Numeric
     expect(ticker.volume).to be_a Numeric
 
-    expect(ticker.timestamp).to be_a Numeric
-    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
+    expect(ticker.timestamp).to be nil
     expect(ticker.payload).to_not be nil
   end
 end

--- a/spec/exchanges/dflow/market_spec.rb
+++ b/spec/exchanges/dflow/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Dflow::Market do
+  it { expect(described_class::NAME).to eq 'dflow' }
+  it { expect(described_class::API_URL).to eq 'https://api.dflowx.com/v1' }
+end


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [ ] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
