### PR TITLE
edit dflow trade url and add spec

### DIFF
--- a/lib/cryptoexchange/exchanges/dflow/market.rb
+++ b/lib/cryptoexchange/exchanges/dflow/market.rb
@@ -4,7 +4,7 @@ module Cryptoexchange::Exchanges
       NAME = 'dflow'
       API_URL = 'https://api.dflowx.com/v1'
 
-      def self.trade_page_url
+      def self.trade_page_url(args={})
         "https://dflowx.com/Exchange"
       end
     end

--- a/spec/exchanges/dflow/integration/market_spec.rb
+++ b/spec/exchanges/dflow/integration/market_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe 'Dflow integration specs' do
     expect(pair.market).to eq 'dflow'
   end
 
+  it 'give trade url' do
+    trade_page_url = client.trade_page_url 'dflow', base: "ETH", target: "USDT"
+    expect(trade_page_url).to eq "https://dflowx.com/Exchange"
+  end
+
   it 'fetch ticker' do
     ticker = client.ticker(eth_usdt_pair)
 


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [ ] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
