### PR TITLE
Financex exchange intergration

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Or install it yourself as:
 | FatBTC            | Y       | Y          | Y       |         | Y           |          | fatbtc            |
 | Fcoin             | Y       | Y          | Y       |         | Y           | Y        | fcoin             |
 | Fex               | Y       | N          | N       |         | Y           |          | fex               |
+| Financex          | Y       | N          | N       |         | Y           | Y        | financex           |
 | Fisco             | Y       | Y          | Y       |         | Y           | Y        | fisco             |
 | Forkdelta         | Y       | N          | N       |         | Y           | Y        | forkdelta         |
 | Freiexchange      | Y       | Y          |         |         | User-Defined| Y        | freiexchange      |

--- a/lib/cryptoexchange/exchanges/financex/market.rb
+++ b/lib/cryptoexchange/exchanges/financex/market.rb
@@ -1,0 +1,8 @@
+module Cryptoexchange::Exchanges
+  module Financex
+    class Market
+      NAME = 'financex'
+      API_URL = 'https://market-watch.financex.io/api/v1/market-watch/ticker'
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/financex/services/market.rb
+++ b/lib/cryptoexchange/exchanges/financex/services/market.rb
@@ -1,0 +1,50 @@
+module Cryptoexchange::Exchanges
+  module Financex
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            false
+          end
+        end
+
+        def fetch
+          response = super(ticker_url)
+          adapt_all(response)
+        end
+
+        def ticker_url
+          "#{Cryptoexchange::Exchanges::Financex::Market::API_URL}"
+        end
+
+        def adapt_all(response)
+          response.map do |ticker|
+            target, base = ticker[0].split('_')
+            market_pair = Cryptoexchange::Models::MarketPair.new(
+              base: base,
+              target: target,
+              market: Financex::Market::NAME
+            )
+            adapt(ticker, market_pair)
+          end
+        end
+
+        def adapt(output, market_pair)
+          ticker           = Cryptoexchange::Models::Ticker.new
+          ticker.base      = market_pair.base
+          ticker.target    = market_pair.target
+          ticker.market    = Financex::Market::NAME
+          ticker.low       = NumericHelper.to_d(output[1]['Low24hr'])
+          ticker.high      = NumericHelper.to_d(output[1]['High24hr'])
+          ticker.last      = NumericHelper.to_d(output[1]['last'])
+          ticker.bid       = NumericHelper.to_d(output[1]['highestBid'])
+          ticker.ask       = NumericHelper.to_d(output[1]['lowestAsk'])
+          ticker.volume    = NumericHelper.to_d(output[1]['BaseVolume'])
+          ticker.timestamp = nil
+          ticker.payload   = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/financex/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/financex/services/pairs.rb
@@ -1,0 +1,28 @@
+module Cryptoexchange::Exchanges
+  module Financex
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Financex::Market::API_URL}"
+
+        def fetch
+          response = super
+          adapt(response)
+        end
+
+        def adapt(response)
+          market_pairs = []
+          response.keys.each do |pair|
+            target, base = pair.split("_")
+            market_pairs << Cryptoexchange::Models::MarketPair.new(
+              base: base,
+              target: target,
+              market: Financex::Market::NAME
+            )
+          end
+          market_pairs
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/Financex/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/Financex/integration_specs_fetch_pairs.yml
@@ -1,0 +1,43 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://market-watch.financex.io/api/v1/market-watch/ticker
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - market-watch.financex.io
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 Feb 2019 09:43:18 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=dea1964020261541cfb8f1c9e5666fcfd1551174197; expires=Wed, 26-Feb-20
+        09:43:17 GMT; path=/; domain=.financex.io; HttpOnly; Secure
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4af1777119e2a2c0-HKG
+    body:
+      encoding: UTF-8
+      string: '{"BTC_ETC":{"last":0.00110853,"lowestAsk":0.00113174,"highestBid":0.00110608,"percentChange":-0.80179688,"BaseVolume":167.11953636,"QuoteVolume":0.18633636,"isFrozen":0,"High24hr":0.00113646,"Low24hr":0.00108989},"BTC_SET":{"last":0.00002000,"lowestAsk":0.0,"highestBid":0.0,"percentChange":0.0,"BaseVolume":0.0,"QuoteVolume":0.0,"isFrozen":0,"High24hr":0.00002000,"Low24hr":0.00002000},"BTC_OMG":{"last":0.00034101,"lowestAsk":0.00034444,"highestBid":0.00034193,"percentChange":-0.53957884,"BaseVolume":1367.63852273,"QuoteVolume":0.47023680,"isFrozen":0,"High24hr":0.00035014,"Low24hr":0.00033724},"BTC_FNX":{"last":0.00000156,"lowestAsk":0.00000156,"highestBid":0.0,"percentChange":0.0,"BaseVolume":0.0,"QuoteVolume":0.0,"isFrozen":0,"High24hr":0.00000156,"Low24hr":0.00000156},"BTC_ZIL":{"last":0.00000450,"lowestAsk":0.00000454,"highestBid":0.00000448,"percentChange":-1.96078431,"BaseVolume":49248.36509368,"QuoteVolume":0.22200201,"isFrozen":0,"High24hr":0.00000459,"Low24hr":0.00000438},"BTC_LTC":{"last":0.01181576,"lowestAsk":0.01186872,"highestBid":0.01178190,"percentChange":0.07792278,"BaseVolume":64.70260805,"QuoteVolume":0.76600235,"isFrozen":0,"High24hr":0.01197610,"Low24hr":0.01172037},"BTC_ZRX":{"last":0.00006388,"lowestAsk":0.00006402,"highestBid":0.00006310,"percentChange":3.53322528,"BaseVolume":13844.01150071,"QuoteVolume":0.86474510,"isFrozen":0,"High24hr":0.00006489,"Low24hr":0.00006106},"BTC_BAT":{"last":0.00004446,"lowestAsk":0.00004453,"highestBid":0.00004426,"percentChange":17.27776312,"BaseVolume":23457.67895933,"QuoteVolume":0.96946664,"isFrozen":0,"High24hr":0.00005059,"Low24hr":0.00003701},"BTC_ETH":{"last":0.03577055,"lowestAsk":0.03579586,"highestBid":0.03549651,"percentChange":-0.15508242,"BaseVolume":225.75041294,"QuoteVolume":8.11636293,"isFrozen":0,"High24hr":0.03619925,"Low24hr":0.03535384},"BTC_ZEC":{"last":0.01357416,"lowestAsk":0.01366362,"highestBid":0.01353397,"percentChange":0.49067655,"BaseVolume":36.84251811,"QuoteVolume":0.50040906,"isFrozen":0,"High24hr":0.01377298,"Low24hr":0.01347210},"FNX_ETH":{"last":17000.0,"lowestAsk":0.0,"highestBid":17000.00000000,"percentChange":0.0,"BaseVolume":0.0,"QuoteVolume":0.0,"isFrozen":0,"High24hr":17000.0,"Low24hr":17000.0},"FNX_BTC":{"last":400000.0,"lowestAsk":0.0,"highestBid":400000.00000000,"percentChange":0.0,"BaseVolume":0.0,"QuoteVolume":0.0,"isFrozen":0,"High24hr":400000.0,"Low24hr":400000.0},"IDR_FNX":{"last":62.0,"lowestAsk":75.00000000,"highestBid":50.00000000,"percentChange":6.89655172,"BaseVolume":1118738.0,"QuoteVolume":70226626.0,"isFrozen":0,"High24hr":74.0,"Low24hr":51.0},"IDR_ETH":{"last":1928078.0,"lowestAsk":1937471.00000000,"highestBid":1927584.00000000,"percentChange":-2.77116192,"BaseVolume":355.20062386,"QuoteVolume":697596359.35007700,"isFrozen":0,"High24hr":2001387.0,"Low24hr":1907542.0},"IDR_BTC":{"last":54099929.0,"lowestAsk":54206693.00000000,"highestBid":54049687.00000000,"percentChange":-1.64094035,"BaseVolume":40.57772438,"QuoteVolume":2217982768.85325000,"isFrozen":0,"High24hr":55197454.0,"Low24hr":53891700.0},"IDR_LTC":{"last":639067.0,"lowestAsk":642717.00000000,"highestBid":637092.00000000,"percentChange":-1.90204127,"BaseVolume":193.11352084,"QuoteVolume":125231679.0653,"isFrozen":0,"High24hr":659407.0,"Low24hr":635800.0},"IDR_SET":{"last":850.0,"lowestAsk":850.00000000,"highestBid":652.00000000,"percentChange":20.39660057,"BaseVolume":2097099.19056688,"QuoteVolume":1578473087.09204000,"isFrozen":0,"High24hr":949.0,"Low24hr":650.0},"IDR_ETC":{"last":60089.0,"lowestAsk":60703.00000000,"highestBid":60370.00000000,"percentChange":-1.23438527,"BaseVolume":170.99793151,"QuoteVolume":10434568.45996450,"isFrozen":0,"High24hr":62089.0,"Low24hr":59788.0},"USDC_BTC":{"last":3790.0639,"lowestAsk":3798.42654000,"highestBid":3789.76653000,"percentChange":-0.62586323,"BaseVolume":9.12216402,"QuoteVolume":34697.12009841,"isFrozen":0,"High24hr":3831.14541000,"Low24hr":3764.52418000},"USDC_ETH":{"last":135.10889000,"lowestAsk":135.76603000,"highestBid":135.32790000,"percentChange":-1.60613232,"BaseVolume":120.52909616,"QuoteVolume":16484.96171703,"isFrozen":0,"High24hr":137.97302000,"Low24hr":134.70615000},"USDC_LTC":{"last":44.73242000,"lowestAsk":45.01788000,"highestBid":44.79423000,"percentChange":-1.17346025,"BaseVolume":35.92113462,"QuoteVolume":1618.44454840,"isFrozen":0,"High24hr":45.75167000,"Low24hr":44.2631},"USDC_SET":{"last":0.02795841,"lowestAsk":0.0,"highestBid":0.0,"percentChange":0.0,"BaseVolume":0.0,"QuoteVolume":0.0,"isFrozen":0,"High24hr":0.02795841,"Low24hr":0.02795841},"USDC_ETC":{"last":4.22994000,"lowestAsk":4.25167000,"highestBid":4.23846000,"percentChange":0.07807620,"BaseVolume":194.36450126,"QuoteVolume":825.62275071,"isFrozen":0,"High24hr":4.3110,"Low24hr":4.1800},"VND_ZEC":{"last":1201200.0,"lowestAsk":1206283.00000000,"highestBid":1194640.00000000,"percentChange":-0.88863586,"BaseVolume":50.82527572,"QuoteVolume":61174737.86420950,"isFrozen":0,"High24hr":1223478.0,"Low24hr":1181500.0},"VND_SET":{"last":1075.0,"lowestAsk":2751.00000000,"highestBid":0.0,"percentChange":0.0,"BaseVolume":0.0,"QuoteVolume":0.0,"isFrozen":0,"High24hr":1075.0,"Low24hr":1075.0},"VND_ETC":{"last":98494.0,"lowestAsk":100000.00000000,"highestBid":97580.00000000,"percentChange":-0.33392698,"BaseVolume":168.36781480,"QuoteVolume":16692421.62337910,"isFrozen":0,"High24hr":101518.0,"Low24hr":96680.0},"VND_LTC":{"last":1043946.0,"lowestAsk":1051219.00000000,"highestBid":1041183.00000000,"percentChange":-0.48179218,"BaseVolume":310.38850032,"QuoteVolume":325550993.26677200,"isFrozen":0,"High24hr":1071888.0,"Low24hr":1032050.0},"VND_BTC":{"last":88313000.0,"lowestAsk":88525000.00000000,"highestBid":88185000.00000000,"percentChange":-1.08333091,"BaseVolume":70.94313974,"QuoteVolume":6289216364.07016000,"isFrozen":0,"High24hr":89544600.0,"Low24hr":87734480.0},"VND_ZIL":{"last":399.0,"lowestAsk":400.00000000,"highestBid":395.00000000,"percentChange":-0.49875312,"BaseVolume":117517.67815696,"QuoteVolume":47096251.79692330,"isFrozen":0,"High24hr":411.0,"Low24hr":393.0},"VND_BAT":{"last":3931.0,"lowestAsk":3947.00000000,"highestBid":3893.00000000,"percentChange":14.60641399,"BaseVolume":31688.50036025,"QuoteVolume":116692769.18744000,"isFrozen":0,"High24hr":4585.0,"Low24hr":3286.0},"VND_ETH":{"last":3163000.0,"lowestAsk":3161400.00000000,"highestBid":3146800.00000000,"percentChange":-1.87379785,"BaseVolume":621.77988240,"QuoteVolume":1981460950.58923000,"isFrozen":0,"High24hr":3225510.0,"Low24hr":3145809.0},"VND_FNX":{"last":102.0,"lowestAsk":106.00000000,"highestBid":100.00000000,"percentChange":-5.55555556,"BaseVolume":2530987.0,"QuoteVolume":262784535.0,"isFrozen":0,"High24hr":111.0,"Low24hr":100.0},"VND_USDC":{"last":22661.0,"lowestAsk":23895.00000000,"highestBid":22390.00000000,"percentChange":0.0,"BaseVolume":0.0,"QuoteVolume":0.0,"isFrozen":0,"High24hr":22661.0,"Low24hr":22661.0},"VND_ZRX":{"last":5636.0,"lowestAsk":5665.00000000,"highestBid":5636.00000000,"percentChange":1.13045039,"BaseVolume":14330.84547256,"QuoteVolume":79223374.38968500,"isFrozen":0,"High24hr":5779.0,"Low24hr":5367.0},"VND_OMG":{"last":30459.0,"lowestAsk":30411.00000000,"highestBid":30175.00000000,"percentChange":-1.26422250,"BaseVolume":1442.52727613,"QuoteVolume":43905598.20572420,"isFrozen":0,"High24hr":30973.0,"Low24hr":29697.0}}'
+    http_version: 
+  recorded_at: Tue, 26 Feb 2019 09:43:18 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Financex/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/Financex/integration_specs_fetch_ticker.yml
@@ -1,0 +1,43 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://market-watch.financex.io/api/v1/market-watch/ticker
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - market-watch.financex.io
+      User-Agent:
+      - http.rb/3.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 Feb 2019 09:43:18 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=de57d861eef1b17895463920ba40aabe91551174198; expires=Wed, 26-Feb-20
+        09:43:18 GMT; path=/; domain=.financex.io; HttpOnly; Secure
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4af1777349ba32e3-HKG
+    body:
+      encoding: UTF-8
+      string: '{"BTC_ETC":{"last":0.00110853,"lowestAsk":0.00113174,"highestBid":0.00110608,"percentChange":-0.80179688,"BaseVolume":167.11953636,"QuoteVolume":0.18633636,"isFrozen":0,"High24hr":0.00113646,"Low24hr":0.00108989},"BTC_SET":{"last":0.00002000,"lowestAsk":0.0,"highestBid":0.0,"percentChange":0.0,"BaseVolume":0.0,"QuoteVolume":0.0,"isFrozen":0,"High24hr":0.00002000,"Low24hr":0.00002000},"BTC_OMG":{"last":0.00034101,"lowestAsk":0.00034444,"highestBid":0.00034193,"percentChange":-0.53957884,"BaseVolume":1367.63852273,"QuoteVolume":0.47023680,"isFrozen":0,"High24hr":0.00035014,"Low24hr":0.00033724},"BTC_FNX":{"last":0.00000156,"lowestAsk":0.00000156,"highestBid":0.0,"percentChange":0.0,"BaseVolume":0.0,"QuoteVolume":0.0,"isFrozen":0,"High24hr":0.00000156,"Low24hr":0.00000156},"BTC_ZIL":{"last":0.00000450,"lowestAsk":0.00000454,"highestBid":0.00000448,"percentChange":-1.96078431,"BaseVolume":49248.36509368,"QuoteVolume":0.22200201,"isFrozen":0,"High24hr":0.00000459,"Low24hr":0.00000438},"BTC_LTC":{"last":0.01181576,"lowestAsk":0.01186872,"highestBid":0.01178190,"percentChange":0.07792278,"BaseVolume":64.70260805,"QuoteVolume":0.76600235,"isFrozen":0,"High24hr":0.01197610,"Low24hr":0.01172037},"BTC_ZRX":{"last":0.00006388,"lowestAsk":0.00006402,"highestBid":0.00006310,"percentChange":3.53322528,"BaseVolume":13844.01150071,"QuoteVolume":0.86474510,"isFrozen":0,"High24hr":0.00006489,"Low24hr":0.00006106},"BTC_BAT":{"last":0.00004446,"lowestAsk":0.00004453,"highestBid":0.00004426,"percentChange":17.27776312,"BaseVolume":23457.67895933,"QuoteVolume":0.96946664,"isFrozen":0,"High24hr":0.00005059,"Low24hr":0.00003701},"BTC_ETH":{"last":0.03577055,"lowestAsk":0.03579586,"highestBid":0.03549651,"percentChange":-0.15508242,"BaseVolume":225.75041294,"QuoteVolume":8.11636293,"isFrozen":0,"High24hr":0.03619925,"Low24hr":0.03535384},"BTC_ZEC":{"last":0.01357416,"lowestAsk":0.01366362,"highestBid":0.01353397,"percentChange":0.49067655,"BaseVolume":36.84251811,"QuoteVolume":0.50040906,"isFrozen":0,"High24hr":0.01377298,"Low24hr":0.01347210},"FNX_ETH":{"last":17000.0,"lowestAsk":0.0,"highestBid":17000.00000000,"percentChange":0.0,"BaseVolume":0.0,"QuoteVolume":0.0,"isFrozen":0,"High24hr":17000.0,"Low24hr":17000.0},"FNX_BTC":{"last":400000.0,"lowestAsk":0.0,"highestBid":400000.00000000,"percentChange":0.0,"BaseVolume":0.0,"QuoteVolume":0.0,"isFrozen":0,"High24hr":400000.0,"Low24hr":400000.0},"IDR_FNX":{"last":62.0,"lowestAsk":75.00000000,"highestBid":50.00000000,"percentChange":6.89655172,"BaseVolume":1118738.0,"QuoteVolume":70226626.0,"isFrozen":0,"High24hr":74.0,"Low24hr":51.0},"IDR_ETH":{"last":1928078.0,"lowestAsk":1937471.00000000,"highestBid":1927584.00000000,"percentChange":-2.77116192,"BaseVolume":355.20062386,"QuoteVolume":697596359.35007700,"isFrozen":0,"High24hr":2001387.0,"Low24hr":1907542.0},"IDR_BTC":{"last":54099929.0,"lowestAsk":54206693.00000000,"highestBid":54049687.00000000,"percentChange":-1.64094035,"BaseVolume":40.57772438,"QuoteVolume":2217982768.85325000,"isFrozen":0,"High24hr":55197454.0,"Low24hr":53891700.0},"IDR_LTC":{"last":639067.0,"lowestAsk":642717.00000000,"highestBid":637092.00000000,"percentChange":-1.90204127,"BaseVolume":193.11352084,"QuoteVolume":125231679.0653,"isFrozen":0,"High24hr":659407.0,"Low24hr":635800.0},"IDR_SET":{"last":850.0,"lowestAsk":850.00000000,"highestBid":652.00000000,"percentChange":20.39660057,"BaseVolume":2097099.19056688,"QuoteVolume":1578473087.09204000,"isFrozen":0,"High24hr":949.0,"Low24hr":650.0},"IDR_ETC":{"last":60089.0,"lowestAsk":60703.00000000,"highestBid":60370.00000000,"percentChange":-1.23438527,"BaseVolume":170.99793151,"QuoteVolume":10434568.45996450,"isFrozen":0,"High24hr":62089.0,"Low24hr":59788.0},"USDC_BTC":{"last":3790.0639,"lowestAsk":3798.42654000,"highestBid":3789.76653000,"percentChange":-0.62586323,"BaseVolume":9.12216402,"QuoteVolume":34697.12009841,"isFrozen":0,"High24hr":3831.14541000,"Low24hr":3764.52418000},"USDC_ETH":{"last":135.10889000,"lowestAsk":135.76603000,"highestBid":135.32790000,"percentChange":-1.60613232,"BaseVolume":120.52909616,"QuoteVolume":16484.96171703,"isFrozen":0,"High24hr":137.97302000,"Low24hr":134.70615000},"USDC_LTC":{"last":44.73242000,"lowestAsk":45.01788000,"highestBid":44.79423000,"percentChange":-1.17346025,"BaseVolume":35.92113462,"QuoteVolume":1618.44454840,"isFrozen":0,"High24hr":45.75167000,"Low24hr":44.2631},"USDC_SET":{"last":0.02795841,"lowestAsk":0.0,"highestBid":0.0,"percentChange":0.0,"BaseVolume":0.0,"QuoteVolume":0.0,"isFrozen":0,"High24hr":0.02795841,"Low24hr":0.02795841},"USDC_ETC":{"last":4.22994000,"lowestAsk":4.25167000,"highestBid":4.23846000,"percentChange":0.07807620,"BaseVolume":194.36450126,"QuoteVolume":825.62275071,"isFrozen":0,"High24hr":4.3110,"Low24hr":4.1800},"VND_ZEC":{"last":1201200.0,"lowestAsk":1206283.00000000,"highestBid":1194640.00000000,"percentChange":-0.88863586,"BaseVolume":50.82527572,"QuoteVolume":61174737.86420950,"isFrozen":0,"High24hr":1223478.0,"Low24hr":1181500.0},"VND_SET":{"last":1075.0,"lowestAsk":2751.00000000,"highestBid":0.0,"percentChange":0.0,"BaseVolume":0.0,"QuoteVolume":0.0,"isFrozen":0,"High24hr":1075.0,"Low24hr":1075.0},"VND_ETC":{"last":98494.0,"lowestAsk":100000.00000000,"highestBid":97580.00000000,"percentChange":-0.33392698,"BaseVolume":168.36781480,"QuoteVolume":16692421.62337910,"isFrozen":0,"High24hr":101518.0,"Low24hr":96680.0},"VND_LTC":{"last":1043946.0,"lowestAsk":1051219.00000000,"highestBid":1041183.00000000,"percentChange":-0.48179218,"BaseVolume":310.38850032,"QuoteVolume":325550993.26677200,"isFrozen":0,"High24hr":1071888.0,"Low24hr":1032050.0},"VND_BTC":{"last":88313000.0,"lowestAsk":88525000.00000000,"highestBid":88185000.00000000,"percentChange":-1.08333091,"BaseVolume":70.94313974,"QuoteVolume":6289216364.07016000,"isFrozen":0,"High24hr":89544600.0,"Low24hr":87734480.0},"VND_ZIL":{"last":399.0,"lowestAsk":400.00000000,"highestBid":395.00000000,"percentChange":-0.49875312,"BaseVolume":117517.67815696,"QuoteVolume":47096251.79692330,"isFrozen":0,"High24hr":411.0,"Low24hr":393.0},"VND_BAT":{"last":3931.0,"lowestAsk":3947.00000000,"highestBid":3893.00000000,"percentChange":14.60641399,"BaseVolume":31688.50036025,"QuoteVolume":116692769.18744000,"isFrozen":0,"High24hr":4585.0,"Low24hr":3286.0},"VND_ETH":{"last":3163000.0,"lowestAsk":3166000.00000000,"highestBid":3146800.00000000,"percentChange":-1.87379785,"BaseVolume":621.77988240,"QuoteVolume":1981460950.58923000,"isFrozen":0,"High24hr":3225510.0,"Low24hr":3145809.0},"VND_FNX":{"last":102.0,"lowestAsk":106.00000000,"highestBid":100.00000000,"percentChange":-5.55555556,"BaseVolume":2530987.0,"QuoteVolume":262784535.0,"isFrozen":0,"High24hr":111.0,"Low24hr":100.0},"VND_USDC":{"last":22661.0,"lowestAsk":23895.00000000,"highestBid":22390.00000000,"percentChange":0.0,"BaseVolume":0.0,"QuoteVolume":0.0,"isFrozen":0,"High24hr":22661.0,"Low24hr":22661.0},"VND_ZRX":{"last":5636.0,"lowestAsk":5665.00000000,"highestBid":5636.00000000,"percentChange":1.13045039,"BaseVolume":14330.84547256,"QuoteVolume":79223374.38968500,"isFrozen":0,"High24hr":5779.0,"Low24hr":5367.0},"VND_OMG":{"last":30459.0,"lowestAsk":30411.00000000,"highestBid":30175.00000000,"percentChange":-1.26422250,"BaseVolume":1442.52727613,"QuoteVolume":43905598.20572420,"isFrozen":0,"High24hr":30973.0,"Low24hr":29697.0}}'
+    http_version: 
+  recorded_at: Tue, 26 Feb 2019 09:43:18 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/financex/integration/market_spec.rb
+++ b/spec/exchanges/financex/integration/market_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+RSpec.describe 'Financex integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:etc_btc_pair) { Cryptoexchange::Models::MarketPair.new(base: 'ETC', target: 'BTC', market: 'financex') }
+
+  it 'fetch pairs' do
+    pairs = client.pairs('financex')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.market).to eq 'financex'
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(etc_btc_pair)
+
+    expect(ticker.base).to eq 'ETC'
+    expect(ticker.target).to eq 'BTC'
+    expect(ticker.market).to eq 'financex'
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.ask).to be_a Numeric
+    expect(ticker.bid).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+    expect(ticker.high).to be_a Numeric
+    expect(ticker.low).to be_a Numeric
+    expect(ticker.timestamp).to be nil
+
+    expect(ticker.payload).to_not be nil
+  end
+end

--- a/spec/exchanges/financex/market_spec.rb
+++ b/spec/exchanges/financex/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Financex::Market do
+  it { expect(described_class::NAME).to eq 'financex' }
+  it { expect(described_class::API_URL).to eq 'https://market-watch.financex.io/api/v1/market-watch/ticker' }
+end


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [x] I have added Specs
- [x] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [x] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [x] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [x] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
