### PR TITLE
fix crytrex

### DIFF
--- a/lib/cryptoexchange/exchanges/crytrex/services/market.rb
+++ b/lib/cryptoexchange/exchanges/crytrex/services/market.rb
@@ -10,6 +10,10 @@ module Cryptoexchange::Exchanges
 
         def fetch(market_pair)
           output = super(ticker_url(market_pair))
+
+          return if output.length == 0
+          # return if empty hash
+
           adapt(output['stats'], market_pair)
         end
 


### PR DESCRIPTION
Fix CryTrex returning empty hash from `.ticker`