### PR TITLE
edit bitforex trade link

### DIFF
--- a/lib/cryptoexchange/exchanges/bitforex/market.rb
+++ b/lib/cryptoexchange/exchanges/bitforex/market.rb
@@ -5,7 +5,7 @@ module Cryptoexchange::Exchanges
       API_URL = 'https://www.bitforex.com/server'
 
       def self.trade_page_url(args={})
-        "https://www.bitforex.com/trade/spotTrading?commodityCode=#{args[:base].upcase}&currencyCode=#{args[:target].upcase}"
+        "https://www.bitforex.com/en/trade/spotTrading?commodityCode=#{args[:base].upcase}&currencyCode=#{args[:target].upcase}"
       end
     end
   end

--- a/spec/exchanges/bitforex/integration/market_spec.rb
+++ b/spec/exchanges/bitforex/integration/market_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Bitforex integration specs' do
 
   it 'give trade url' do
     trade_page_url = client.trade_page_url market, base: btc_usdt_pair.base, target: btc_usdt_pair.target
-    expect(trade_page_url).to eq 'https://www.bitforex.com/trade/spotTrading?commodityCode=BTC&currencyCode=USDT'
+    expect(trade_page_url).to eq 'https://www.bitforex.com/en/trade/spotTrading?commodityCode=BTC&currencyCode=USDT'
   end
 
   it 'fetch ticker' do


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [ ] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
