### PR TITLE
Add decentralized exchange NebliDex to CoinGecko index

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ Or install it yourself as:
 | Myspeedtrade      | Y       | Y          |         |         | Y           |          | myspeedtrade      |       |
 | Nanex             | Y       | N          | N       | N       | Y           |          | nanex             |       |
 | Nanu.Exchange     | Y       | Y          | Y       |         | Y           |          | nanu_exchange     |       |
+| NebliDex          | Y       | N          | N       | N       | Y           |          | neblide           |       |
 | Nebula            | Y       | N          | Y       |         | Y           |          | nebula            |       |
 | Negociecoins      | Y       | Y          | Y       |         | User-Defined|          | negociecoins      |       |
 | Neraex            | Y       | Y          | Y       |         | Y           | Y        | neraex            |       |

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Or install it yourself as:
 | Myspeedtrade      | Y       | Y          |         |         | Y           |          | myspeedtrade      |       |
 | Nanex             | Y       | N          | N       | N       | Y           |          | nanex             |       |
 | Nanu.Exchange     | Y       | Y          | Y       |         | Y           |          | nanu_exchange     |       |
-| NebliDex          | Y       | N          | N       | N       | Y           |          | neblide           |       |
+| NebliDex          | Y       | N          | N       | N       | Y           |          | neblidex           |       |
 | Nebula            | Y       | N          | Y       |         | Y           |          | nebula            |       |
 | Negociecoins      | Y       | Y          | Y       |         | User-Defined|          | negociecoins      |       |
 | Neraex            | Y       | Y          | Y       |         | Y           | Y        | neraex            |       |

--- a/lib/cryptoexchange/exchanges/neblidex/market.rb
+++ b/lib/cryptoexchange/exchanges/neblidex/market.rb
@@ -1,5 +1,5 @@
 module Cryptoexchange::Exchanges
-  module NebliDex
+  module Neblidex
     class Market
       NAME = 'neblidex'
       API_URL = 'https://www.neblidex.xyz/seed/?v=1&api=get_market_ticker'

--- a/lib/cryptoexchange/exchanges/neblidex/market.rb
+++ b/lib/cryptoexchange/exchanges/neblidex/market.rb
@@ -3,6 +3,10 @@ module Cryptoexchange::Exchanges
     class Market
       NAME = 'neblidex'
       API_URL = 'https://www.neblidex.xyz/seed/?v=1&api=get_market_ticker'
+      
+      def self.trade_page_url(args={})
+        "https://www.neblidex.xyz"
+      end
     end
   end
 end

--- a/lib/cryptoexchange/exchanges/neblidex/market.rb
+++ b/lib/cryptoexchange/exchanges/neblidex/market.rb
@@ -1,0 +1,8 @@
+module Cryptoexchange::Exchanges
+  module NebliDex
+    class Market
+      NAME = 'neblidex'
+      API_URL = 'https://www.neblidex.xyz/seed/?v=1&api=get_market_ticker'
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/neblidex/services/market.rb
+++ b/lib/cryptoexchange/exchanges/neblidex/services/market.rb
@@ -36,7 +36,7 @@ module Cryptoexchange::Exchanges
           ticker.target = market_pair.target
           ticker.market = NebliDex::Market::NAME
           ticker.last = NumericHelper.to_d(output['lastPrice'])
-          ticker.volume = NumericHelper.to_d(output['tradeVolume24Hour'])
+          ticker.volume = NumericHelper.to_d(output['baseVolume24Hour'])
           ticker.timestamp = Time.now.to_i
           ticker.payload = output
           ticker

--- a/lib/cryptoexchange/exchanges/neblidex/services/market.rb
+++ b/lib/cryptoexchange/exchanges/neblidex/services/market.rb
@@ -1,0 +1,49 @@
+module Cryptoexchange::Exchanges
+  module NebliDex
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            false
+          end
+        end
+
+        def fetch
+          output = super ticker_url
+          adapt_all(output)
+        end
+
+        def ticker_url
+          "#{Cryptoexchange::Exchanges::NebliDex::Market::API_URL}"
+        end
+
+        def adapt_all(output)
+          output.map do |pair|
+            base = pair['baseAsset']
+            target = pair['tradeAsset']
+            market_pair = Cryptoexchange::Models::MarketPair.new(
+                            base: base,
+                            target: target,
+                            market: NebliDex::Market::NAME
+            )
+            adapt(market_pair, pair)
+          end
+        end
+
+        def adapt(market_pair, output)
+          ticker = Cryptoexchange::Models::Ticker.new
+          ticker.base = market_pair.base
+          ticker.target = market_pair.target
+          ticker.market = NebliDex::Market::NAME
+
+          ticker.last = NumericHelper.to_d(output['lastPrice'])
+          ticker.volume = NumericHelper.to_d(output['tradeVolume24Hour'])
+
+          ticker.timestamp = Time.now.to_i
+          ticker.payload = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/neblidex/services/market.rb
+++ b/lib/cryptoexchange/exchanges/neblidex/services/market.rb
@@ -1,5 +1,5 @@
 module Cryptoexchange::Exchanges
-  module NebliDex
+  module Neblidex
     module Services
       class Market < Cryptoexchange::Services::Market
         class << self
@@ -14,7 +14,7 @@ module Cryptoexchange::Exchanges
         end
 
         def ticker_url
-          "#{Cryptoexchange::Exchanges::NebliDex::Market::API_URL}"
+          "#{Cryptoexchange::Exchanges::Neblidex::Market::API_URL}"
         end
 
         def adapt_all(output)
@@ -24,7 +24,7 @@ module Cryptoexchange::Exchanges
             market_pair = Cryptoexchange::Models::MarketPair.new(
                             base: base,
                             target: target,
-                            market: NebliDex::Market::NAME
+                            market: Neblidex::Market::NAME
             )
             adapt(market_pair, pair)
           end
@@ -34,7 +34,7 @@ module Cryptoexchange::Exchanges
           ticker = Cryptoexchange::Models::Ticker.new
           ticker.base = market_pair.base
           ticker.target = market_pair.target
-          ticker.market = NebliDex::Market::NAME
+          ticker.market = Neblidex::Market::NAME
           ticker.last = NumericHelper.to_d(output['lastPrice'])
           ticker.volume = NumericHelper.to_d(output['baseVolume24Hour'])
           ticker.timestamp = Time.now.to_i

--- a/lib/cryptoexchange/exchanges/neblidex/services/market.rb
+++ b/lib/cryptoexchange/exchanges/neblidex/services/market.rb
@@ -35,10 +35,8 @@ module Cryptoexchange::Exchanges
           ticker.base = market_pair.base
           ticker.target = market_pair.target
           ticker.market = NebliDex::Market::NAME
-
           ticker.last = NumericHelper.to_d(output['lastPrice'])
           ticker.volume = NumericHelper.to_d(output['tradeVolume24Hour'])
-
           ticker.timestamp = Time.now.to_i
           ticker.payload = output
           ticker

--- a/lib/cryptoexchange/exchanges/neblidex/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/neblidex/services/pairs.rb
@@ -1,0 +1,26 @@
+module Cryptoexchange::Exchanges
+  module NebliDex
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::NebliDex::Market::API_URL}"
+
+        def fetch
+          output = super
+          adapt(output)
+        end
+
+        def adapt(output)
+          output.map do |pair|
+            base = pair['baseAsset']
+            target = pair['tradeAsset']
+            Cryptoexchange::Models::MarketPair.new({
+              base: base,
+              target: target,
+              market: NebliDex::Market::NAME
+            })
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/neblidex/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/neblidex/services/pairs.rb
@@ -1,8 +1,8 @@
 module Cryptoexchange::Exchanges
-  module NebliDex
+  module Neblidex
     module Services
       class Pairs < Cryptoexchange::Services::Pairs
-        PAIRS_URL = "#{Cryptoexchange::Exchanges::NebliDex::Market::API_URL}"
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Neblidex::Market::API_URL}"
 
         def fetch
           output = super
@@ -16,7 +16,7 @@ module Cryptoexchange::Exchanges
             Cryptoexchange::Models::MarketPair.new({
               base: base,
               target: target,
-              market: NebliDex::Market::NAME
+              market: Neblidex::Market::NAME
             })
           end
         end

--- a/spec/exchanges/neblidex/integration/market_spec.rb
+++ b/spec/exchanges/neblidex/integration/market_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+RSpec.describe 'NebliDex integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:btc_nebl_pair) { Cryptoexchange::Models::MarketPair.new(base: 'BTC', target: 'NEBL', market: 'neblidex') }
+
+  it 'fetch pairs' do
+    pairs = client.pairs('neblidex')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).not_to be_nil
+    expect(pair.target).not_to be_nil
+    expect(pair.market).to eq 'neblidex'
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(btc_nebl_pair)
+
+    expect(ticker.base).to eq 'BTC'
+    expect(ticker.target).to eq 'NEBL'
+    expect(ticker.market).to eq 'neblidex'
+
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+
+    expect(ticker.timestamp).to be_a Numeric
+    expect(2000..Date.today.year).to include(Time.at(ticker.timestamp).year)
+    expect(ticker.payload).to_not be nil
+  end
+end

--- a/spec/exchanges/neblidex/market_spec.rb
+++ b/spec/exchanges/neblidex/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::NebliDex::Market do
+  it { expect(described_class::NAME).to eq 'neblidex' }
+  it { expect(described_class::API_URL).to eq 'https://www.neblidex.xyz/seed/?v=1&api=get_market_ticker' }
+end

--- a/spec/exchanges/neblidex/market_spec.rb
+++ b/spec/exchanges/neblidex/market_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Cryptoexchange::Exchanges::NebliDex::Market do
+RSpec.describe Cryptoexchange::Exchanges::Neblidex::Market do
   it { expect(described_class::NAME).to eq 'neblidex' }
   it { expect(described_class::API_URL).to eq 'https://www.neblidex.xyz/seed/?v=1&api=get_market_ticker' }
 end


### PR DESCRIPTION
- What is the purpose of this Pull Request? To add NebliDex ticker information
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
Fixes #1192
- [X] I have added Specs
- [X] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [X] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [X] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [X] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'neblidex'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
