### PR TITLE
fix fcoin trading link

### DIFF
--- a/lib/cryptoexchange/exchanges/fcoin/market.rb
+++ b/lib/cryptoexchange/exchanges/fcoin/market.rb
@@ -5,7 +5,7 @@ module Cryptoexchange::Exchanges
       API_URL = 'https://api.fcoin.com/v2'
 
       def self.trade_page_url(args={})
-        "https://exchange.fcoin.com/ex/main/#{args[:base]}-#{args[:target]}"
+        "https://exchange.fcoin.com/ex/spot/main/#{args[:base].downcase}/#{args[:target].downcase}"
       end
     end
   end

--- a/spec/exchanges/fcoin/integration/market_spec.rb
+++ b/spec/exchanges/fcoin/integration/market_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Fcoin integration specs' do
 
   it 'give trade url' do
     trade_page_url = client.trade_page_url 'fcoin', base: eth_usdt_pair.base, target: eth_usdt_pair.target
-    expect(trade_page_url).to eq "https://exchange.fcoin.com/ex/main/ETH-USDT"
+    expect(trade_page_url).to eq "https://exchange.fcoin.com/ex/spot/main/eth/usdt"
   end
 
   it 'fetch ticker' do


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- Closes: https://github.com/coingecko/cryptoexchange/issues/1487
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [ ] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
