### PR TITLE
implement shortex exchange, update readme to include Bitasset

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Or install it yourself as:
 | Bit2C             | Y       | Y [x]      | Y       |         | User-Defined| Y        | bit2c             |       |
 | Bit-Z             | Y       |            |         |         | Y           |          | bit_z             |       |
 | Bitalong          | Y       | Y [x]      | Y       |         | Y           | Y        | bitalong          |       |
+| Bitasset          | Y       | Y [x]      | Y       |         | Y           | Y        | bitasset          |       |
 | Bitbank           | Y       | Y [x]      | Y       |         | User-Defined| Y        | bitbank           |       |
 | Bitbay            | Y       |            |         |         | User-Defined|          | bitbay            |       |
 | Bitbegin          | Y       | N          | N       |         | Y           | Y        | bitbegin          |       |
@@ -339,13 +340,14 @@ Or install it yourself as:
 | Qtrade            | Y       | Y [x]      |         |         | Y           |          | qtrade            |       |
 | QuadrigaCX        | Y       |            |         |         | User-Defined|          | quadrigacx        |       |
 | Liquid (Quoine)   | Y       | Y [x]      |         |         | Y           | Y        | quoine            |       |
-| RadarRelay        | Y       | Y [x]      |[No Price]|         | Y           | Y        | radar_relay       |       |
+| RadarRelay        | Y       | Y [x]      |[No Price]|         | Y           | Y        | radar_relay      |       |
 | Raisex            | Y       |            |         |         | Y           |          | raisex            |       |
 | Rfinex            | Y       | Y          | Y       |         | Y           |          | rfinex            |       |
 | RightBTC          | Y       | Y [x]      | Y       |         | Y           |          | rightbtc          |       |
 | SafeTrade         | Y       | N          | N       |         | Y           |          | safe_trade        |       |
 | SaturnNetwork     | Y       |            |         |         | Y           | Y        | saturn_network    |       |
 | Secondbtc         | Y       | N          | N       |         | Y           | Y        | secondbtc         |       |
+| Shortex           | Y       | Y [x]      | N       |         | Y           | Y        | shortex           |       |
 | Sigen             | Y       |            |         |         | Y           | Y        | sigen             |       |
 | Simex             | Y       | N          | N       |         | Y           | Y        | simex             |       |
 | Singularx         | Y       | N          | N       |         | Y           |          | singularx         |       |

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ Or install it yourself as:
 | SafeTrade         | Y       | N          | N       |         | Y           |          | safe_trade        |       |
 | SaturnNetwork     | Y       |            |         |         | Y           | Y        | saturn_network    |       |
 | Secondbtc         | Y       | N          | N       |         | Y           | Y        | secondbtc         |       |
-| Shortex           | Y       | Y [x]      | N       |         | Y           | Y        | shortex           |       |
+| Shortex           | Y       | Y [x]      |         |         | Y           | Y        | shortex           |       |
 | Sigen             | Y       |            |         |         | Y           | Y        | sigen             |       |
 | Simex             | Y       | N          | N       |         | Y           | Y        | simex             |       |
 | Singularx         | Y       | N          | N       |         | Y           |          | singularx         |       |

--- a/lib/cryptoexchange/exchanges/shortex/market.rb
+++ b/lib/cryptoexchange/exchanges/shortex/market.rb
@@ -1,0 +1,12 @@
+module Cryptoexchange::Exchanges
+  module Shortex
+    class Market < Cryptoexchange::Models::Market
+      NAME = 'shortex'
+      API_URL = 'https://api.shortex.net/api/v2'
+
+      def self.trade_page_url(args={})
+        "https://api.shortex.net/trading/#{args[:base].downcase}#{args[:target].downcase}"
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/shortex/services/market.rb
+++ b/lib/cryptoexchange/exchanges/shortex/services/market.rb
@@ -1,0 +1,40 @@
+module Cryptoexchange::Exchanges
+  module Shortex
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(market_pair, output)
+        end
+
+        def ticker_url(market_pair)
+          "#{Cryptoexchange::Exchanges::Shortex::Market::API_URL}/tickers/#{market_pair.base.downcase}#{market_pair.target.downcase}"
+        end
+
+        def adapt(market_pair, output)
+          output = output["ticker"]
+          ticker = Cryptoexchange::Models::Ticker.new
+
+          ticker.base      = market_pair.base
+          ticker.target    = market_pair.target
+          ticker.market    = Shortex::Market::NAME
+          ticker.ask       = NumericHelper.to_d(output['sell'])
+          ticker.bid       = NumericHelper.to_d(output['buy'])
+          ticker.last      = NumericHelper.to_d(output['last'])
+          ticker.high      = NumericHelper.to_d(output['high'])
+          ticker.low       = NumericHelper.to_d(output['low'])
+          ticker.volume    = NumericHelper.to_d(output['volume'])
+          ticker.timestamp = nil
+          ticker.payload   = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/shortex/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/shortex/services/order_book.rb
@@ -1,0 +1,44 @@
+module Cryptoexchange::Exchanges
+  module Shortex
+    module Services
+      class OrderBook < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          "#{Cryptoexchange::Exchanges::Shortex::Market::API_URL}/order_book?market=#{market_pair.base.downcase}#{market_pair.target.downcase}&asks_limit=100&bids_limit=100"
+        end
+
+        def adapt(output, market_pair)
+          order_book = Cryptoexchange::Models::OrderBook.new
+
+          order_book.base      = market_pair.base
+          order_book.target    = market_pair.target
+          order_book.market    = Shortex::Market::NAME
+          order_book.asks      = adapt_orders(output['asks'])
+          order_book.bids      = adapt_orders(output['bids'])
+          order_book.timestamp = nil
+          order_book.payload   = output
+          order_book
+        end
+
+        def adapt_orders(orders)
+          orders.collect do |order_entry|
+            Cryptoexchange::Models::Order.new(
+              price: NumericHelper.to_d(order_entry["price"]),
+              amount: NumericHelper.to_d(order_entry["volume"])
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/shortex/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/shortex/services/pairs.rb
@@ -1,0 +1,25 @@
+module Cryptoexchange::Exchanges
+  module Shortex
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Shortex::Market::API_URL}/markets"
+
+        def fetch
+          output = super
+          adapt(output)
+        end
+
+        def adapt(output)
+          output.map do |pair|
+            base, target = pair["name"].split("/")
+            Cryptoexchange::Models::MarketPair.new(
+              base:   base,
+              target: target,
+              market: Shortex::Market::NAME,
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/Shortex/integration_specs_fetch_order_book.yml
+++ b/spec/cassettes/vcr_cassettes/Shortex/integration_specs_fetch_order_book.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.shortex.net/api/v2/order_book?asks_limit=100&bids_limit=100&market=ethbtc
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.shortex.net
+      User-Agent:
+      - http.rb/5.0.0.pre
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Encoding:
+      - gzip
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept, Authorization
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '9548'
+      Content-Type:
+      - application/json
+      Etag:
+      - W/"f1def1fa1f8f2bcd2c6f7db9c3e1b857"
+      Host:
+      - api.shortex.net
+      User-Agent:
+      - http.rb/5.0.0.pre
+      Version:
+      - HTTP/1.1
+      X-Forwarded-For:
+      - 1.32.17.220
+      X-Forwarded-Host:
+      - api.shortex.net
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Forwarded-Server:
+      - 4e04ae4ad714
+      X-Real-Ip:
+      - 1.32.17.220
+      X-Request-Id:
+      - 95528595-490c-44ca-a32d-ac08c393fe8d
+      X-Runtime:
+      - '0.132248'
+      Date:
+      - Wed, 22 May 2019 16:16:52 GMT
+      Connection:
+      - close
+    body:
+      encoding: ASCII-8BIT
+      string: '{"asks":[{"id":135793051,"side":"sell","ord_type":"limit","price":"0.03311","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:14:42+02:00","volume":"0.37598048","remaining_volume":"0.37598048","executed_volume":"0.0","trades_count":0},{"id":135793052,"side":"sell","ord_type":"limit","price":"0.03314308","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:14:42+02:00","volume":"0.54308292","remaining_volume":"0.54308292","executed_volume":"0.0","trades_count":0},{"id":135793053,"side":"sell","ord_type":"limit","price":"0.03317615","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:14:42+02:00","volume":"0.71018536","remaining_volume":"0.71018536","executed_volume":"0.0","trades_count":0},{"id":135776232,"side":"sell","ord_type":"limit","price":"0.03319789","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:03:37+02:00","volume":"0.19717685","remaining_volume":"0.19717685","executed_volume":"0.0","trades_count":0},{"id":135776314,"side":"sell","ord_type":"limit","price":"0.03319908","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:03:41+02:00","volume":"0.23101813","remaining_volume":"0.23101813","executed_volume":"0.0","trades_count":0},{"id":135776895,"side":"sell","ord_type":"limit","price":"0.0331996","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:04:03+02:00","volume":"0.23663002","remaining_volume":"0.23663002","executed_volume":"0.0","trades_count":0},{"id":135775958,"side":"sell","ord_type":"limit","price":"0.03320023","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:03:26+02:00","volume":"0.20951307","remaining_volume":"0.20951307","executed_volume":"0.0","trades_count":0},{"id":135774838,"side":"sell","ord_type":"limit","price":"0.0332009","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:02:39+02:00","volume":"0.20897711","remaining_volume":"0.20897711","executed_volume":"0.0","trades_count":0},{"id":135776640,"side":"sell","ord_type":"limit","price":"0.03320137","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:03:53+02:00","volume":"0.2221223","remaining_volume":"0.2221223","executed_volume":"0.0","trades_count":0},{"id":135775806,"side":"sell","ord_type":"limit","price":"0.03320168","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:03:22+02:00","volume":"0.20340245","remaining_volume":"0.20340245","executed_volume":"0.0","trades_count":0},{"id":135776945,"side":"sell","ord_type":"limit","price":"0.03320206","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:04:07+02:00","volume":"0.20393983","remaining_volume":"0.20393983","executed_volume":"0.0","trades_count":0},{"id":135776032,"side":"sell","ord_type":"limit","price":"0.03320512","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:03:30+02:00","volume":"0.20442709","remaining_volume":"0.20442709","executed_volume":"0.0","trades_count":0},{"id":135775693,"side":"sell","ord_type":"limit","price":"0.03320558","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:03:15+02:00","volume":"0.22044954","remaining_volume":"0.22044954","executed_volume":"0.0","trades_count":0},{"id":135776799,"side":"sell","ord_type":"limit","price":"0.03320651","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:03:59+02:00","volume":"0.20850995","remaining_volume":"0.20850995","executed_volume":"0.0","trades_count":0},{"id":135777062,"side":"sell","ord_type":"limit","price":"0.0332089","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:04:10+02:00","volume":"0.21945789","remaining_volume":"0.21945789","executed_volume":"0.0","trades_count":0},{"id":135793054,"side":"sell","ord_type":"limit","price":"0.03320923","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:14:42+02:00","volume":"0.8772878","remaining_volume":"0.8772878","executed_volume":"0.0","trades_count":0},{"id":135776511,"side":"sell","ord_type":"limit","price":"0.03321128","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:03:48+02:00","volume":"0.23636989","remaining_volume":"0.23636989","executed_volume":"0.0","trades_count":0},{"id":135793056,"side":"sell","ord_type":"limit","price":"0.03324231","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:14:42+02:00","volume":"1.04439024","remaining_volume":"1.04439024","executed_volume":"0.0","trades_count":0},{"id":135793058,"side":"sell","ord_type":"limit","price":"0.03327538","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:14:42+02:00","volume":"1.21149268","remaining_volume":"1.21149268","executed_volume":"0.0","trades_count":0},{"id":135793059,"side":"sell","ord_type":"limit","price":"0.03330846","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:14:42+02:00","volume":"1.37859512","remaining_volume":"1.37859512","executed_volume":"0.0","trades_count":0},{"id":135793060,"side":"sell","ord_type":"limit","price":"0.03334154","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:14:42+02:00","volume":"1.54569756","remaining_volume":"1.54569756","executed_volume":"0.0","trades_count":0},{"id":135793061,"side":"sell","ord_type":"limit","price":"0.03337461","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:14:42+02:00","volume":"1.7128","remaining_volume":"1.7128","executed_volume":"0.0","trades_count":0},{"id":135793062,"side":"sell","ord_type":"limit","price":"0.03340769","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:14:42+02:00","volume":"1.87990244","remaining_volume":"1.87990244","executed_volume":"0.0","trades_count":0},{"id":135793064,"side":"sell","ord_type":"limit","price":"0.03344077","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:14:42+02:00","volume":"2.04700488","remaining_volume":"2.04700488","executed_volume":"0.0","trades_count":0},{"id":135793065,"side":"sell","ord_type":"limit","price":"0.03347384","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:14:42+02:00","volume":"2.21410732","remaining_volume":"2.21410732","executed_volume":"0.0","trades_count":0},{"id":135793066,"side":"sell","ord_type":"limit","price":"0.03350692","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:14:42+02:00","volume":"2.38120976","remaining_volume":"2.38120976","executed_volume":"0.0","trades_count":0}],"bids":[{"id":135793649,"side":"buy","ord_type":"limit","price":"0.03305466","avg_price":"0.03305466","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:15:07+02:00","volume":"0.23205006","remaining_volume":"0.08240838","executed_volume":"0.14964168","trades_count":1},{"id":135794432,"side":"buy","ord_type":"limit","price":"0.03305068","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:15:41+02:00","volume":"0.23600646","remaining_volume":"0.23600646","executed_volume":"0.0","trades_count":0},{"id":135794639,"side":"buy","ord_type":"limit","price":"0.03304992","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:15:48+02:00","volume":"0.23295688","remaining_volume":"0.23295688","executed_volume":"0.0","trades_count":0},{"id":135796242,"side":"buy","ord_type":"limit","price":"0.03304717","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:16:49+02:00","volume":"0.21047447","remaining_volume":"0.21047447","executed_volume":"0.0","trades_count":0},{"id":135793067,"side":"buy","ord_type":"limit","price":"0.03304384","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:14:43+02:00","volume":"0.37598048","remaining_volume":"0.37598048","executed_volume":"0.0","trades_count":0},{"id":135793068,"side":"buy","ord_type":"limit","price":"0.03301077","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:14:43+02:00","volume":"0.54308292","remaining_volume":"0.54308292","executed_volume":"0.0","trades_count":0},{"id":135793069,"side":"buy","ord_type":"limit","price":"0.03297769","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:14:43+02:00","volume":"0.71018536","remaining_volume":"0.71018536","executed_volume":"0.0","trades_count":0},{"id":135793070,"side":"buy","ord_type":"limit","price":"0.03294461","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:14:43+02:00","volume":"0.8772878","remaining_volume":"0.8772878","executed_volume":"0.0","trades_count":0},{"id":135793071,"side":"buy","ord_type":"limit","price":"0.03291154","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:14:43+02:00","volume":"1.04439024","remaining_volume":"1.04439024","executed_volume":"0.0","trades_count":0},{"id":135793072,"side":"buy","ord_type":"limit","price":"0.03287846","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:14:43+02:00","volume":"1.21149268","remaining_volume":"1.21149268","executed_volume":"0.0","trades_count":0},{"id":135793073,"side":"buy","ord_type":"limit","price":"0.03284538","avg_price":"0.0","state":"wait","market":"ethbtc","created_at":"2019-05-22T18:14:43+02:00","volume":"1.37859512","remaining_volume":"1.37859512","executed_volume":"0.0","trades_count":0}]}'
+    http_version: 
+  recorded_at: Wed, 22 May 2019 16:16:53 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Shortex/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/Shortex/integration_specs_fetch_pairs.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.shortex.net/api/v2/markets
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.shortex.net
+      User-Agent:
+      - http.rb/5.0.0.pre
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Encoding:
+      - gzip
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept, Authorization
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '648'
+      Content-Type:
+      - application/json
+      Etag:
+      - W/"d1e08777e4b9126d99aaa7ea386efefa"
+      Host:
+      - api.shortex.net
+      User-Agent:
+      - http.rb/5.0.0.pre
+      Version:
+      - HTTP/1.1
+      X-Forwarded-For:
+      - 1.32.17.220
+      X-Forwarded-Host:
+      - api.shortex.net
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Forwarded-Server:
+      - 4e04ae4ad714
+      X-Real-Ip:
+      - 1.32.17.220
+      X-Request-Id:
+      - 1a6a6016-f51a-4017-a320-6d0131f112d9
+      X-Runtime:
+      - '0.013940'
+      Date:
+      - Wed, 22 May 2019 16:16:49 GMT
+      Connection:
+      - close
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"id":"ethbtc","name":"ETH/BTC"},{"id":"ethusdc","name":"ETH/USDC"},{"id":"btcusdc","name":"BTC/USDC"},{"id":"egteth","name":"EGT/ETH"},{"id":"youeth","name":"YOU/ETH"},{"id":"trueeth","name":"TRUE/ETH"},{"id":"swftceth","name":"SWFTC/ETH"},{"id":"omgeth","name":"OMG/ETH"},{"id":"mkreth","name":"MKR/ETH"},{"id":"linkusdc","name":"LINK/USDC"},{"id":"linketh","name":"LINK/ETH"},{"id":"gtoeth","name":"GTO/ETH"},{"id":"mkrbtc","name":"MKR/BTC"},{"id":"omgbtc","name":"OMG/BTC"},{"id":"linkbtc","name":"LINK/BTC"},{"id":"truebtc","name":"TRUE/BTC"},{"id":"youbtc","name":"YOU/BTC"},{"id":"gtobtc","name":"GTO/BTC"},{"id":"vraeth","name":"VRA/ETH"}]'
+    http_version: 
+  recorded_at: Wed, 22 May 2019 16:16:49 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Shortex/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/Shortex/integration_specs_fetch_ticker.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.shortex.net/api/v2/tickers/ethbtc
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.shortex.net
+      User-Agent:
+      - http.rb/5.0.0.pre
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Encoding:
+      - gzip
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept, Authorization
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, PATCH, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Length:
+      - '256'
+      Content-Type:
+      - application/json
+      Etag:
+      - W/"75fca6b1c353f901db2ca752d951b51b"
+      Host:
+      - api.shortex.net
+      User-Agent:
+      - http.rb/5.0.0.pre
+      Version:
+      - HTTP/1.1
+      X-Forwarded-For:
+      - 1.32.17.220
+      X-Forwarded-Host:
+      - api.shortex.net
+      X-Forwarded-Port:
+      - '443'
+      X-Forwarded-Proto:
+      - https
+      X-Forwarded-Server:
+      - 4e04ae4ad714
+      X-Real-Ip:
+      - 1.32.17.220
+      X-Request-Id:
+      - 5d675cd0-5937-4133-9480-bbc6f22af630
+      X-Runtime:
+      - '0.191406'
+      Date:
+      - Wed, 22 May 2019 16:16:51 GMT
+      Connection:
+      - close
+    body:
+      encoding: ASCII-8BIT
+      string: '{"at":1558541811,"ticker":{"buy":"0.03305466","sell":"0.03311","low":"0.03264523","high":"0.0336044","open":0.03274077,"last":"0.03305466","volume":"4254.45047372","avg_price":"0.03322147514810861298","price_change_percent":"+0.96%","vol":"4254.45047372"}}'
+    http_version: 
+  recorded_at: Wed, 22 May 2019 16:16:51 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/shortex/integration/market_spec.rb
+++ b/spec/exchanges/shortex/integration/market_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+RSpec.describe 'Shortex integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:eth_btc_pair) { Cryptoexchange::Models::MarketPair.new(base: 'ETH', target: 'BTC', market: 'shortex') }
+
+  it 'fetch pairs' do
+    pairs = client.pairs('shortex')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.market).to eq 'shortex'
+  end
+
+  it 'give trade url' do
+    trade_page_url = client.trade_page_url 'shortex', base: eth_btc_pair.base, target: eth_btc_pair.target
+    expect(trade_page_url).to eq "https://api.shortex.net/trading/ethbtc"
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(eth_btc_pair)
+
+    expect(ticker.base).to eq 'ETH'
+    expect(ticker.target).to eq 'BTC'
+    expect(ticker.market).to eq 'shortex'
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.last).to be_a Numeric # Test if number is reasonable
+    expect(ticker.bid).to be_a Numeric
+    expect(ticker.ask).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+    expect(ticker.timestamp).to be nil
+    expect(ticker.payload).to_not be nil
+  end
+
+  it 'fetch order book' do
+    order_book = client.order_book(eth_btc_pair)
+
+    expect(order_book.base).to eq 'ETH'
+    expect(order_book.target).to eq 'BTC'
+    expect(order_book.market).to eq 'shortex'
+
+    expect(order_book.asks).to_not be_empty
+    expect(order_book.bids).to_not be_empty
+    expect(order_book.asks.first.price).to_not be_nil
+    expect(order_book.bids.first.amount).to_not be_nil
+    expect(order_book.bids.first.timestamp).to be_nil
+    expect(order_book.asks.count).to be > 2
+    expect(order_book.bids.count).to be > 2
+    expect(order_book.timestamp).to be_nil
+    expect(order_book.payload).to_not be nil
+  end
+end

--- a/spec/exchanges/shortex/market_spec.rb
+++ b/spec/exchanges/shortex/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Shortex::Market do
+  it { expect(described_class::NAME).to eq 'shortex' }
+  it { expect(described_class::API_URL).to eq 'https://api.shortex.net/api/v2' }
+end


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [x] I have added Specs
- [x] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [x] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [x] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [x] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
