### PR TITLE
Implement Bitsdaq trades, tickers, orderbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Or install it yourself as:
 | Bitrue            | Y       | Y [x]      |         |         | Y           | Y        | bitrue            |       |
 | Bits Blockchain   | Y       | Y          |         |         | Y           |          | bits_blockchain   |       |
 | Bitsane           | Y       | Y [x]      |         |         | Y           |          | bitsane           |       |
+| Bitsdaq           | Y       | Y [x]      | Y [limit: 50]|    | Y           | Y        | bisdaq            |       |
 | Bitshares Assets  | Y       |            |         |         | User-Defined|          | bitshares_assets  |       |
 | Bitso             | Y       | Y [x]      |         |         | Y           |          | bitso             |       |
 | Bitstamp          | Y       | Y [x]      | Y       |         | User-Defined|          | bitstamp          |       |

--- a/lib/cryptoexchange/exchanges/bitsdaq/market.rb
+++ b/lib/cryptoexchange/exchanges/bitsdaq/market.rb
@@ -1,0 +1,12 @@
+module Cryptoexchange::Exchanges
+  module Bitsdaq
+    class Market < Cryptoexchange::Models::Market
+      NAME = 'bitsdaq'
+      API_URL = 'https://bitsdaq.com/api'
+
+      def self.trade_page_url(args={})
+        "https://bitsdaq.com/exchange/#{args[:base].upcase}-#{args[:target].upcase}"
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/bitsdaq/services/market.rb
+++ b/lib/cryptoexchange/exchanges/bitsdaq/services/market.rb
@@ -1,0 +1,40 @@
+module Cryptoexchange::Exchanges
+  module Bitsdaq
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            false
+          end
+        end
+
+        def fetch
+          output = super(ticker_url)
+          adapt_all(output)
+        end
+
+        def ticker_url
+          "#{Cryptoexchange::Exchanges::Bitsdaq::Market::API_URL}/normal/dg/marketSummary24h/detail"
+        end
+
+        def adapt_all(output)
+          output.map do |data|
+            adapt(data)
+          end
+        end
+
+        def adapt(data)
+          ticker = Cryptoexchange::Models::Ticker.new
+          ticker.base      = data['symbol']
+          ticker.target    = data['anchor']
+          ticker.market    = Bitsdaq::Market::NAME
+          ticker.last      = NumericHelper.to_d(data['last_price'])
+          ticker.volume    = NumericHelper.to_d(data['volume_24h'])
+          ticker.timestamp = nil
+          ticker.payload   = data
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/bitsdaq/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/bitsdaq/services/order_book.rb
@@ -1,0 +1,48 @@
+require 'byebug'
+module Cryptoexchange::Exchanges
+  module Bitsdaq
+    module Services
+      class OrderBook < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          buy = super(order_book_buy_url(market_pair))
+          sell = super(order_book_sell_url(market_pair))
+          adapt(buy, sell, market_pair)
+        end
+
+        def order_book_buy_url(market_pair)
+          "#{Cryptoexchange::Exchanges::Bitsdaq::Market::API_URL}/order?orderType=BUY&marketSymbol=#{market_pair.base}-#{market_pair.target}&offset=0"
+        end
+
+        def order_book_sell_url(market_pair)
+          "#{Cryptoexchange::Exchanges::Bitsdaq::Market::API_URL}/order?orderType=SELL&marketSymbol=#{market_pair.base}-#{market_pair.target}&offset=0"
+        end
+
+        def adapt(buy, sell, market_pair)
+          order_book = Cryptoexchange::Models::OrderBook.new
+
+          order_book.base      = market_pair.base
+          order_book.target    = market_pair.target
+          order_book.market    = Bitsdaq::Market::NAME
+          order_book.asks      = adapt_orders(sell['result'])
+          order_book.bids      = adapt_orders(buy['result'])
+          order_book.payload   = buy['result'] + sell['result']
+          order_book
+        end
+
+        def adapt_orders(orders)
+          orders.collect do |order_entry|
+            Cryptoexchange::Models::Order.new(price: NumericHelper.to_d(order_entry["price"]),
+                                              amount: NumericHelper.to_d(order_entry["currentQuantity"]),
+                                              timestamp: nil)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/bitsdaq/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/bitsdaq/services/pairs.rb
@@ -1,0 +1,28 @@
+module Cryptoexchange::Exchanges
+  module Bitsdaq
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Bitsdaq::Market::API_URL}/normal/dg/marketSummary24h/detail"
+
+        def fetch
+          output = super
+          adapt(output)
+        end
+
+        def adapt(output)
+          pairs = output
+          market_pairs = []
+          pairs.each do |pair|
+            market_pairs << Cryptoexchange::Models::MarketPair.new(
+                              base: pair['symbol'],
+                              target: pair['anchor'],
+                              market: Bitsdaq::Market::NAME
+                            )
+          end
+
+          market_pairs
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/bitsdaq/services/trades.rb
+++ b/lib/cryptoexchange/exchanges/bitsdaq/services/trades.rb
@@ -1,0 +1,33 @@
+module Cryptoexchange::Exchanges
+  module Bitsdaq
+    module Services
+      class Trades < Cryptoexchange::Services::Market
+        def fetch(market_pair)
+          output = super(trades_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def trades_url(market_pair)
+          base = market_pair.base.upcase
+          target = market_pair.target.upcase
+          "#{Cryptoexchange::Exchanges::Bitsdaq::Market::API_URL}/order/matchedOrder?marketSymbol=#{base}-#{target}&size=50"
+        end
+
+        def adapt(output, market_pair)
+          output["result"].collect do |trade|
+            tr = Cryptoexchange::Models::Trade.new
+            tr.base      = market_pair.base
+            tr.target    = market_pair.target
+            tr.type      = trade["OrderType"] == "BUY" ? "buy" : "sell"
+            tr.price     = trade["price"].to_f
+            tr.amount    = trade["matchedQuantity"].to_f
+            tr.timestamp = trade["createdAt"].to_i / 1000
+            tr.payload   = trade
+            tr.market    = Bitsdaq::Market::NAME
+            tr
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/Bitsdaq/integration_specs_fetch_order_book.yml
+++ b/spec/cassettes/vcr_cassettes/Bitsdaq/integration_specs_fetch_order_book.yml
@@ -1,0 +1,147 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://bitsdaq.com/api/order?marketSymbol=ZEC-BTC&offset=0&orderType=BUY
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - bitsdaq.com
+      User-Agent:
+      - http.rb/5.0.0.pre
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 14 Jun 2019 07:56:51 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '3601'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d4238913a291dd91e52f1e6eace3192241560499010; expires=Sat, 13-Jun-20
+        07:56:50 GMT; path=/; domain=.bitsdaq.com; HttpOnly; Secure
+      - _csrf=3VXU9Gg4-TIg-1w4oT55QCRn; Path=/
+      - csrfToken=b7ma5Bzo-VGQBgMZQS9ibEYDql4nE-HgJnWo; Path=/; HttpOnly; SameSite=Strict
+      X-Dns-Prefetch-Control:
+      - 'off'
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      X-Download-Options:
+      - noopen
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - Origin, Authorization, X-Requested-With, Content-Type, Accept, X-Authorization,
+        X-Access-Token, x-cp-language, x-cp-timezone,x-cp-device,x-app-ko,x-app-token
+      Timestamp:
+      - '1560499010935'
+      Access-Control-Expose-Headers:
+      - timestamp, UserCountryCode
+      Etag:
+      - W/"e11-ncHTete5f3lPAKQV6eHonUNWOYM"
+      Usercountrycode:
+      - SG
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4e6abffdd810c359-SIN
+    body:
+      encoding: UTF-8
+      string: '{"result":[{"price":0.01082306,"currentQuantity":5.38316177,"amount":0.0582622828264162},{"price":0.01082305,"currentQuantity":49.407,"amount":0.53473443135},{"price":0.01082139,"currentQuantity":27.65691402,"amount":0.2992862528068878},{"price":0.01082138,"currentQuantity":22,"amount":0.23807036},{"price":0.01081395,"currentQuantity":45,"amount":0.48662775},{"price":0.01081233,"currentQuantity":0.12063965,"amount":0.0013043957068845},{"price":0.01081138,"currentQuantity":44,"amount":0.47570072},{"price":0.01080001,"currentQuantity":18.26,"amount":0.1972081826},{"price":0.01079501,"currentQuantity":59.99999986,"amount":0.6477005984886987},{"price":0.010795,"currentQuantity":36.2621,"amount":0.3914493695},{"price":0.01076819,"currentQuantity":23.05493576,"amount":0.2482599287014744},{"price":0.01076818,"currentQuantity":69.86,"amount":0.7522650548},{"price":0.01076809,"currentQuantity":4.61084471,"amount":0.0496499908133039},{"price":0.01075718,"currentQuantity":181.02,"amount":1.9472647236},{"price":0.01073196,"currentQuantity":54.22,"amount":0.5818868712},{"price":0.01073195,"currentQuantity":485.23588879,"amount":5.2075272966998405},{"price":0.01073161,"currentQuantity":10.77,"amount":0.1155794397},{"price":0.01071019,"currentQuantity":12.77,"amount":0.1367691263},{"price":0.0107,"currentQuantity":0.22882241,"amount":0.002448399787},{"price":0.01068882,"currentQuantity":45.33989353,"amount":0.4846299607613346},{"price":0.01068881,"currentQuantity":11.77,"amount":0.1258072937},{"price":0.01066748,"currentQuantity":11.77,"amount":0.1255562396},{"price":0.0106324,"currentQuantity":137.93,"amount":1.466526932},{"price":0.01063239,"currentQuantity":0.25877176,"amount":0.0027513622733064},{"price":0.01062527,"currentQuantity":0.09411525,"amount":0.0009999999423675},{"price":0.01062215,"currentQuantity":0.11297147,"amount":0.0011999999000605},{"price":0.01061221,"currentQuantity":5.57014427,"amount":0.0591115407235367},{"price":0.01060565,"currentQuantity":0.18857872,"amount":0.001999999901768},{"price":0.01060516,"currentQuantity":2.5,"amount":0.0265129},{"price":0.01060373,"currentQuantity":27.77,"amount":0.2944655821},{"price":0.0106007,"currentQuantity":0.51090364,"amount":0.005415936216548},{"price":0.0106,"currentQuantity":0.1,"amount":0.00106},{"price":0.01059781,"currentQuantity":0.0504,"amount":0.000534129624},{"price":0.01058748,"currentQuantity":17.77,"amount":0.1881395196},{"price":0.01058572,"currentQuantity":0.09456135,"amount":0.001000999973922},{"price":0.01058256,"currentQuantity":9.77,"amount":0.1033916112},{"price":0.01054388,"currentQuantity":0.12547563,"amount":0.0013229999856444},{"price":0.01054076,"currentQuantity":0.05137868,"amount":0.0005415703349968},{"price":0.01053,"currentQuantity":137.10298558,"amount":1.4436944381574},{"price":0.01051667,"currentQuantity":0.09508713,"amount":0.0009999999674571},{"price":0.01051043,"currentQuantity":17.73,"amount":0.1863499239},{"price":0.0105,"currentQuantity":2.186246,"amount":0.022955583},{"price":0.01048,"currentQuantity":5,"amount":0.0524},{"price":0.01047724,"currentQuantity":0.09544498,"amount":0.0009999999622552},{"price":0.01047584,"currentQuantity":3.67720532,"amount":0.0385218145794688},{"price":0.01046899,"currentQuantity":0.73160492,"amount":0.0076591645914308},{"price":0.01042517,"currentQuantity":0.21232555,"amount":0.0022135299540935},{"price":0.0104,"currentQuantity":44.66663717,"amount":0.464533026568},{"price":0.0103798,"currentQuantity":17.97,"amount":0.186525006},{"price":0.01037645,"currentQuantity":0.05,"amount":0.0005188225}],"status":200,"error":null}'
+    http_version: 
+  recorded_at: Fri, 14 Jun 2019 07:56:43 GMT
+- request:
+    method: get
+    uri: https://bitsdaq.com/api/order?marketSymbol=ZEC-BTC&offset=0&orderType=SELL
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - bitsdaq.com
+      User-Agent:
+      - http.rb/5.0.0.pre
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 14 Jun 2019 07:56:51 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '3690'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d1ccc4f22ffccd09b68784d90c598e5aa1560499011; expires=Sat, 13-Jun-20
+        07:56:51 GMT; path=/; domain=.bitsdaq.com; HttpOnly; Secure
+      - _csrf=y7q-3bUOySvHLQH0UPh1vCBn; Path=/
+      - csrfToken=zwuPIWA0-MAK0LIhX67wjkUe_15bqzDb9ClU; Path=/; HttpOnly; SameSite=Strict
+      X-Dns-Prefetch-Control:
+      - 'off'
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      X-Download-Options:
+      - noopen
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - Origin, Authorization, X-Requested-With, Content-Type, Accept, X-Authorization,
+        X-Access-Token, x-cp-language, x-cp-timezone,x-cp-device,x-app-ko,x-app-token
+      Timestamp:
+      - '1560499011323'
+      Access-Control-Expose-Headers:
+      - timestamp, UserCountryCode
+      Etag:
+      - W/"e6a-6P5EB9Fmg+kSwHqu+XgOINAGWqw"
+      Usercountrycode:
+      - SG
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4e6ac003d914c36d-SIN
+    body:
+      encoding: UTF-8
+      string: '{"result":[{"price":0.01086427,"currentQuantity":0.14709901,"amount":0.0015981233613727},{"price":0.01086428,"currentQuantity":18.21808127,"amount":0.1979263359800356},{"price":0.0108643,"currentQuantity":27.6564134,"amount":0.30046757210162},{"price":0.01086432,"currentQuantity":19.72800273,"amount":0.2143313346195936},{"price":0.01087071,"currentQuantity":8.5,"amount":0.092401035},{"price":0.01087351,"currentQuantity":14.61229391,"amount":0.1588869239533241},{"price":0.01087768,"currentQuantity":45,"amount":0.4894956},{"price":0.01091,"currentQuantity":46.6094,"amount":0.508508554},{"price":0.01091235,"currentQuantity":114.7,"amount":1.251646545},{"price":0.01091236,"currentQuantity":18.25,"amount":0.19915057},{"price":0.01091238,"currentQuantity":59.99999997,"amount":0.6547427996726286},{"price":0.01091239,"currentQuantity":0.11978956,"amount":0.0013071903966484},{"price":0.01092281,"currentQuantity":0.22039874,"amount":0.0024073735612594},{"price":0.01092896,"currentQuantity":181.01,"amount":1.9782510496},{"price":0.01093138,"currentQuantity":4.61084471,"amount":0.0504028956459998},{"price":0.0109355,"currentQuantity":0.21430827,"amount":0.002343568086585},{"price":0.01094222,"currentQuantity":4.73693636,"amount":0.0518325997771192},{"price":0.01094492,"currentQuantity":0.27158523,"amount":0.0029724786155316},{"price":0.01096489,"currentQuantity":8.69920962,"amount":0.0953858765702418},{"price":0.01096495,"currentQuantity":0.11933282,"amount":0.001308478404659},{"price":0.01096855,"currentQuantity":0.23252786,"amount":0.002550493458803},{"price":0.01097007,"currentQuantity":12.77,"amount":0.1400877939},{"price":0.01098059,"currentQuantity":54.21,"amount":0.5952577839},{"price":0.01098348,"currentQuantity":0.36531955,"amount":0.004012479971034},{"price":0.01099386,"currentQuantity":0.27584556,"amount":0.0030326074682616},{"price":0.01099697,"currentQuantity":0.05,"amount":0.0005498485},{"price":0.011,"currentQuantity":1.75988522,"amount":0.01935873742},{"price":0.01101399,"currentQuantity":9.77,"amount":0.1076066823},{"price":0.01102932,"currentQuantity":0.46016109,"amount":0.0050752639131588},{"price":0.01105499,"currentQuantity":216.24,"amount":2.3905310376},{"price":0.011055,"currentQuantity":0.70828999,"amount":0.00783014583945},{"price":0.01105846,"currentQuantity":16.73,"amount":0.1850080358},{"price":0.01106268,"currentQuantity":0.27481222,"amount":0.0030401596499496},{"price":0.01108021,"currentQuantity":8.77,"amount":0.0971734417},{"price":0.01108156,"currentQuantity":2.5,"amount":0.0277039},{"price":0.01110293,"currentQuantity":0.73662047,"amount":0.0081786455149771},{"price":0.01111239,"currentQuantity":0.11978956,"amount":0.0013311483086484},{"price":0.01112612,"currentQuantity":1.03958975,"amount":0.01156660030927},{"price":0.01113923,"currentQuantity":0.0506,"amount":0.000563645038},{"price":0.01114998,"currentQuantity":1.0487,"amount":0.011692984026},{"price":0.01115,"currentQuantity":166.34706859,"amount":1.8547698147785},{"price":0.0111723,"currentQuantity":0.09165468,"amount":0.001023993581364},{"price":0.01117233,"currentQuantity":0.14144401,"amount":0.0015802591562433},{"price":0.01117332,"currentQuantity":0.08474189,"amount":0.0009468482543748},{"price":0.0111834,"currentQuantity":0.69781139,"amount":0.007803903898926},{"price":0.01119297,"currentQuantity":0.54293839,"amount":0.0060770931111183},{"price":0.0112,"currentQuantity":0.2380409,"amount":0.00266605808},{"price":0.0112026,"currentQuantity":0.48956501,"amount":0.005484400981026},{"price":0.01121239,"currentQuantity":0.11978956,"amount":0.0013431272646484},{"price":0.0113,"currentQuantity":3.325,"amount":0.0375725}],"status":200,"error":null}'
+    http_version: 
+  recorded_at: Fri, 14 Jun 2019 07:56:43 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Bitsdaq/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/Bitsdaq/integration_specs_fetch_pairs.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://bitsdaq.com/api/normal/dg/marketSummary24h/detail
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - bitsdaq.com
+      User-Agent:
+      - http.rb/5.0.0.pre
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 14 Jun 2019 07:56:50 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '10612'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=df3c0f5e23720bb58ba40f08471df0ce01560499009; expires=Sat, 13-Jun-20
+        07:56:49 GMT; path=/; domain=.bitsdaq.com; HttpOnly; Secure
+      - _csrf=7bAQbzV90Fo8PuXvQ5gU_QSN; Path=/
+      - csrfToken=XPN37jL9-3KMRm-vhLjfptkvpDljPY-MF73k; Path=/; HttpOnly; SameSite=Strict
+      X-Dns-Prefetch-Control:
+      - 'off'
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      X-Download-Options:
+      - noopen
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - Origin, Authorization, X-Requested-With, Content-Type, Accept, X-Authorization,
+        X-Access-Token, x-cp-language, x-cp-timezone,x-cp-device,x-app-ko,x-app-token
+      Timestamp:
+      - '1560499009773'
+      Access-Control-Expose-Headers:
+      - timestamp, UserCountryCode
+      Etag:
+      - W/"2974-OgWQAegVZNtcMVEdiB5QnhuTgAA"
+      Usercountrycode:
+      - SG
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4e6abffa7e54d9d0-SIN
+    body:
+      encoding: UTF-8
+      string: '[{"last_price":0.00001022,"volume_24h":991761.86820911,"amount_24h":10.21649727,"price_updated_at":1560499005,"symbol":"LOOM","anchor":"BTC"},{"last_price":0.00011372,"volume_24h":2321.53417772,"amount_24h":0.26264577,"price_updated_at":1560499005,"symbol":"SRN","anchor":"ETH"},{"last_price":0.00035,"volume_24h":260707.03256464,"amount_24h":93.99112421,"price_updated_at":1560499005,"symbol":"CVC","anchor":"ETH"},{"last_price":0.00003971,"volume_24h":434469.23988681,"amount_24h":17.34584897,"price_updated_at":1560499005,"symbol":"BAT","anchor":"BTC"},{"last_price":0.00038729,"volume_24h":1122643.47522856,"amount_24h":458.17362048,"price_updated_at":1560499005,"symbol":"WAX","anchor":"ETH"},{"last_price":0.01067866,"volume_24h":1746.3759751,"amount_24h":19.04382227,"price_updated_at":1560499005,"symbol":"ZEC","anchor":"BTC"},{"last_price":0.01569121,"volume_24h":24658.18381713,"amount_24h":394.52993671,"price_updated_at":1560499005,"symbol":"LTC","anchor":"BTC"},{"last_price":0.00102363,"volume_24h":64273.78894258,"amount_24h":66.42790409,"price_updated_at":1560499005,"symbol":"PAY","anchor":"ETH"},{"last_price":0.31503373,"volume_24h":7172.54446727,"amount_24h":2354.91242929,"price_updated_at":1560499005,"symbol":"ZRX","anchor":"USDT"},{"last_price":3.1e-7,"volume_24h":12578684.25140741,"amount_24h":3.97767093,"price_updated_at":1560499005,"symbol":"OCN","anchor":"BTC"},{"last_price":0.00158432,"volume_24h":27819.03696657,"amount_24h":45.01107668,"price_updated_at":1560499005,"symbol":"NEO","anchor":"BTC"},{"last_price":0.00224376,"volume_24h":10755.11053033,"amount_24h":24.72560463,"price_updated_at":1560499005,"symbol":"REP","anchor":"BTC"},{"last_price":0.00000337,"volume_24h":936282.49288861,"amount_24h":3.23826866,"price_updated_at":1560499005,"symbol":"SRN","anchor":"BTC"},{"last_price":2.9e-7,"volume_24h":31871680.60869587,"amount_24h":9.2350205,"price_updated_at":1560499005,"symbol":"RFR","anchor":"BTC"},{"last_price":0.804,"volume_24h":146.8955474,"amount_24h":120.33280313,"price_updated_at":1560499005,"symbol":"BSV","anchor":"ETH"},{"last_price":1.60003067,"volume_24h":292.49978962,"amount_24h":467.75316448,"price_updated_at":1560499005,"symbol":"BCH","anchor":"ETH"},{"last_price":1.7e-7,"volume_24h":66924304.31469714,"amount_24h":11.47011865,"price_updated_at":1560499005,"symbol":"DTA","anchor":"BTC"},{"last_price":87.45974172,"volume_24h":254.00377412,"amount_24h":22643.68197507,"price_updated_at":1560499005,"symbol":"ZEC","anchor":"USDT"},{"last_price":0.00001506,"volume_24h":2794637.56989828,"amount_24h":42.5653233,"price_updated_at":1560499005,"symbol":"XLM","anchor":"BTC"},{"last_price":0.00067935,"volume_24h":11631.26287454,"amount_24h":7.72934613,"price_updated_at":1560499005,"symbol":"ADX","anchor":"ETH"},{"last_price":0.00039517,"volume_24h":231757.59387132,"amount_24h":92.05800323,"price_updated_at":1560499005,"symbol":"GNT","anchor":"ETH"},{"last_price":0.00156226,"volume_24h":439314.74999616,"amount_24h":679.34020913,"price_updated_at":1560499005,"symbol":"XRP","anchor":"ETH"},{"last_price":8196.90000004,"volume_24h":260.02367389,"amount_24h":2125016.40718636,"price_updated_at":1560499005,"symbol":"BTC","anchor":"USDT"},{"last_price":128.69710218,"volume_24h":3848.23508115,"amount_24h":506077.57779981,"price_updated_at":1560499005,"symbol":"LTC","anchor":"USDT"},{"last_price":0.05121299,"volume_24h":464.36703821,"amount_24h":23.90646258,"price_updated_at":1560499005,"symbol":"NEO","anchor":"ETH"},{"last_price":0.07280372,"volume_24h":1440.2687765,"amount_24h":106.35482664,"price_updated_at":1560499005,"symbol":"REP","anchor":"ETH"},{"last_price":0.00001006,"volume_24h":792996.85586461,"amount_24h":7.91347436,"price_updated_at":1560499005,"symbol":"OCN","anchor":"ETH"},{"last_price":254.045,"volume_24h":1460.9097846,"amount_24h":375137.05722182,"price_updated_at":1560499005,"symbol":"ETH","anchor":"USDT"},{"last_price":7e-8,"volume_24h":114603863.31187053,"amount_24h":7.62993636,"price_updated_at":1560499005,"symbol":"PMA","anchor":"BTC"},{"last_price":0.0012813,"volume_24h":59763.15530085,"amount_24h":75.91012099,"price_updated_at":1560499005,"symbol":"BAT","anchor":"ETH"},{"last_price":0.00012177,"volume_24h":128028.73354107,"amount_24h":15.59772359,"price_updated_at":1560499005,"symbol":"TUSD","anchor":"BTC"},{"last_price":0.000884,"volume_24h":6168.54634908,"amount_24h":5.32678981,"price_updated_at":1560499005,"symbol":"DMT","anchor":"ETH"},{"last_price":0.00852,"volume_24h":2448.45490032,"amount_24h":20.1933501,"price_updated_at":1560499005,"symbol":"OMG","anchor":"ETH"},{"last_price":0.00393,"volume_24h":11576.8129314,"amount_24h":45.06428317,"price_updated_at":1560499005,"symbol":"TUSD","anchor":"ETH"},{"last_price":0.00004676,"volume_24h":1052362.98923326,"amount_24h":49.13990197,"price_updated_at":1560499005,"symbol":"SOLVE","anchor":"BTC"},{"last_price":2.2e-7,"volume_24h":41001485.98520744,"amount_24h":8.62512897,"price_updated_at":1560499005,"symbol":"CMCT","anchor":"BTC"},{"last_price":0.04964771,"volume_24h":2248.60666503,"amount_24h":112.94600481,"price_updated_at":1560499005,"symbol":"BCH","anchor":"BTC"},{"last_price":2.16555263,"volume_24h":10987.68238698,"amount_24h":23037.49406633,"price_updated_at":1560499005,"symbol":"OMG","anchor":"USDT"},{"last_price":1.9e-7,"volume_24h":23484222.32087366,"amount_24h":4.3271593,"price_updated_at":1560499005,"symbol":"HYDRO","anchor":"BTC"},{"last_price":0.00001217,"volume_24h":1195967.8310608,"amount_24h":14.65952933,"price_updated_at":1560499005,"symbol":"POLY","anchor":"BTC"},{"last_price":0.00002713,"volume_24h":238567.88500855,"amount_24h":6.51900796,"price_updated_at":1560499005,"symbol":"DMT","anchor":"BTC"},{"last_price":0.00000205,"volume_24h":3089934.95356865,"amount_24h":6.44117257,"price_updated_at":1560499005,"symbol":"IHT","anchor":"BTC"},{"last_price":0.50889111,"volume_24h":925.83976849,"amount_24h":471.47180583,"price_updated_at":1560499005,"symbol":"LTC","anchor":"ETH"},{"last_price":0.0000147,"volume_24h":175505.28457418,"amount_24h":2.60167231,"price_updated_at":1560499005,"symbol":"POWR","anchor":"BTC"},{"last_price":0.00002097,"volume_24h":371597.48544116,"amount_24h":7.77387588,"price_updated_at":1560499005,"symbol":"ADX","anchor":"BTC"},{"last_price":0.00011345,"volume_24h":121935.03344295,"amount_24h":13.83613366,"price_updated_at":1560499005,"symbol":"SNT","anchor":"ETH"},{"last_price":0.00039451,"volume_24h":103133.49636036,"amount_24h":40.24954956,"price_updated_at":1560499005,"symbol":"POLY","anchor":"ETH"},{"last_price":0.00000484,"volume_24h":55785928.85401196,"amount_24h":274.50671607,"price_updated_at":1560499005,"symbol":"SPND","anchor":"BTC"},{"last_price":0.02481308,"volume_24h":8743.29892567,"amount_24h":224.60704303,"price_updated_at":1560499005,"symbol":"BSV","anchor":"BTC"},{"last_price":0.00000266,"volume_24h":1416884.53084131,"amount_24h":3.76895844,"price_updated_at":1560499005,"symbol":"EDR","anchor":"BTC"},{"last_price":0.00003144,"volume_24h":696063.02709239,"amount_24h":23.07735239,"price_updated_at":1560499005,"symbol":"PAY","anchor":"BTC"},{"last_price":0.00003975,"volume_24h":143128.68627476,"amount_24h":5.74143232,"price_updated_at":1560499005,"symbol":"ZRX","anchor":"BTC"},{"last_price":0.00022889,"volume_24h":143079.24282656,"amount_24h":32.47709954,"price_updated_at":1560499005,"symbol":"MANA","anchor":"ETH"},{"last_price":0.39560844,"volume_24h":541722.51674776,"amount_24h":216455.11495402,"price_updated_at":1560499005,"symbol":"XRP","anchor":"USDT"},{"last_price":0.00001212,"volume_24h":10441438.85478367,"amount_24h":133.70784532,"price_updated_at":1560499005,"symbol":"WAX","anchor":"BTC"},{"last_price":0.99604071,"volume_24h":2473.42603368,"amount_24h":2465.10351117,"price_updated_at":1560499005,"symbol":"TUSD","anchor":"USDT"},{"last_price":0.00001095,"volume_24h":2163115.69264389,"amount_24h":24.46106078,"price_updated_at":1560499005,"symbol":"CVC","anchor":"BTC"},{"last_price":0.00001222,"volume_24h":2007515.73420387,"amount_24h":24.98479996,"price_updated_at":1560499005,"symbol":"GNT","anchor":"BTC"},{"last_price":0.03094792,"volume_24h":7154.98871797,"amount_24h":224.69528048,"price_updated_at":1560499005,"symbol":"ETH","anchor":"BTC"},{"last_price":12.9729829,"volume_24h":32247.60786856,"amount_24h":426862.29147067,"price_updated_at":1560499005,"symbol":"NEO","anchor":"USDT"},{"last_price":0.00048784,"volume_24h":181649.56528775,"amount_24h":88.11654906,"price_updated_at":1560499005,"symbol":"XLM","anchor":"ETH"},{"last_price":0.000264,"volume_24h":64951.64035747,"amount_24h":16.6828245,"price_updated_at":1560499005,"symbol":"OMG","anchor":"BTC"},{"last_price":0.00126854,"volume_24h":24753.65420118,"amount_24h":31.66042994,"price_updated_at":1560499005,"symbol":"ZRX","anchor":"ETH"},{"last_price":0.00054125,"volume_24h":4539662.06767368,"amount_24h":2403.98963082,"price_updated_at":1560499005,"symbol":"PMA","anchor":"USDT"},{"last_price":0.00000709,"volume_24h":1049933.97824976,"amount_24h":7.39520967,"price_updated_at":1560499005,"symbol":"MANA","anchor":"BTC"},{"last_price":0.000217,"volume_24h":42276.91700492,"amount_24h":8.62979288,"price_updated_at":1560499005,"symbol":"VIB","anchor":"ETH"},{"last_price":0.00000666,"volume_24h":1729477.770985,"amount_24h":11.34573061,"price_updated_at":1560499005,"symbol":"VIB","anchor":"BTC"},{"last_price":4e-7,"volume_24h":21357964.19141903,"amount_24h":8.69013987,"price_updated_at":1560499005,"symbol":"MFT","anchor":"BTC"},{"last_price":203.954,"volume_24h":502.94098481,"amount_24h":104483.62622982,"price_updated_at":1560499005,"symbol":"BSV","anchor":"USDT"},{"last_price":0.34726435,"volume_24h":237.35239868,"amount_24h":81.94696048,"price_updated_at":1560499005,"symbol":"ZEC","anchor":"ETH"},{"last_price":0.000469,"volume_24h":9664.16838558,"amount_24h":4.57804433,"price_updated_at":1560499005,"symbol":"POWR","anchor":"ETH"},{"last_price":0.00000357,"volume_24h":798168.13720375,"amount_24h":2.84933699,"price_updated_at":1560499005,"symbol":"SNT","anchor":"BTC"},{"last_price":0.00004817,"volume_24h":3904974.40360687,"amount_24h":190.83721204,"price_updated_at":1560499005,"symbol":"XRP","anchor":"BTC"},{"last_price":0.32493235,"volume_24h":53450.02781369,"amount_24h":17499.30620595,"price_updated_at":1560499005,"symbol":"BAT","anchor":"USDT"},{"last_price":405.27788001,"volume_24h":436.91922557,"amount_24h":179014.0709604,"price_updated_at":1560499005,"symbol":"BCH","anchor":"USDT"},{"last_price":0.01068516,"volume_24h":155441346.7991657,"amount_24h":1741065.43761698,"price_updated_at":1560499010,"symbol":"BQQQ","anchor":"USDT"}]'
+    http_version: 
+  recorded_at: Fri, 14 Jun 2019 07:56:42 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/Bitsdaq/integration_specs_fetch_trades.yml
+++ b/spec/cassettes/vcr_cassettes/Bitsdaq/integration_specs_fetch_trades.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://bitsdaq.com/api/order/matchedOrder?marketSymbol=ZEC-BTC&size=50
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - bitsdaq.com
+      User-Agent:
+      - http.rb/5.0.0.pre
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 14 Jun 2019 07:56:51 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '4983'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d76510ed48e9297a4d59720eaccc429f41560499011; expires=Sat, 13-Jun-20
+        07:56:51 GMT; path=/; domain=.bitsdaq.com; HttpOnly; Secure
+      - _csrf=LHPR3cHq_LITLYkvURxL5B-8; Path=/
+      - csrfToken=0zF569WF-WaLKkz1sECr_GyQcG6-wVZjmqXg; Path=/; HttpOnly; SameSite=Strict
+      X-Dns-Prefetch-Control:
+      - 'off'
+      X-Frame-Options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      X-Download-Options:
+      - noopen
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST, PUT, DELETE, OPTIONS
+      Access-Control-Allow-Headers:
+      - Origin, Authorization, X-Requested-With, Content-Type, Accept, X-Authorization,
+        X-Access-Token, x-cp-language, x-cp-timezone,x-cp-device,x-app-ko,x-app-token
+      Timestamp:
+      - '1560499011647'
+      Access-Control-Expose-Headers:
+      - timestamp, UserCountryCode
+      Etag:
+      - W/"1377-2wZARDNXw42+iiCS+p6TtHh9Alg"
+      Usercountrycode:
+      - SG
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4e6ac0061b033208-SIN
+    body:
+      encoding: UTF-8
+      string: '{"result":[{"createdAt":1560498602740,"price":0.01083747,"matchedQuantity":0.07402121,"makerOrderType":"SELL"},{"createdAt":1560498144940,"price":0.01082138,"matchedQuantity":0.0730778,"makerOrderType":"SELL"},{"createdAt":1560497766210,"price":0.01086038,"matchedQuantity":0.09450077,"makerOrderType":"BUY"},{"createdAt":1560497482930,"price":0.01085029,"matchedQuantity":0.98773623,"makerOrderType":"BUY"},{"createdAt":1560497479950,"price":0.01085028,"matchedQuantity":3.82941842,"makerOrderType":"BUY"},{"createdAt":1560497424620,"price":0.01085569,"matchedQuantity":5.71843177,"makerOrderType":"BUY"},{"createdAt":1560497421590,"price":0.01085568,"matchedQuantity":0.11978956,"makerOrderType":"BUY"},{"createdAt":1560497418340,"price":0.01084963,"matchedQuantity":3.19780867,"makerOrderType":"BUY"},{"createdAt":1560497387430,"price":0.01081239,"matchedQuantity":0.11978956,"makerOrderType":"SELL"},{"createdAt":1560497231010,"price":0.01081368,"matchedQuantity":1.10780496,"makerOrderType":"BUY"},{"createdAt":1560497230080,"price":0.01081368,"matchedQuantity":0.92949499,"makerOrderType":"BUY"},{"createdAt":1560497229290,"price":0.01081368,"matchedQuantity":1.40352815,"makerOrderType":"BUY"},{"createdAt":1560497229210,"price":0.01081368,"matchedQuantity":0.92949499,"makerOrderType":"BUY"},{"createdAt":1560497228930,"price":0.01081368,"matchedQuantity":0.09254975,"makerOrderType":"BUY"},{"createdAt":1560497228520,"price":0.01081368,"matchedQuantity":0.09254975,"makerOrderType":"BUY"},{"createdAt":1560497228020,"price":0.01081368,"matchedQuantity":0.92949499,"makerOrderType":"BUY"},{"createdAt":1560497228010,"price":0.01081368,"matchedQuantity":1.40352815,"makerOrderType":"BUY"},{"createdAt":1560497227330,"price":0.01081368,"matchedQuantity":0.09254975,"makerOrderType":"BUY"},{"createdAt":1560497226930,"price":0.01081368,"matchedQuantity":0.09254975,"makerOrderType":"BUY"},{"createdAt":1560497226260,"price":0.01081368,"matchedQuantity":0.92949499,"makerOrderType":"BUY"},{"createdAt":1560497226180,"price":0.01081368,"matchedQuantity":1.40352815,"makerOrderType":"BUY"},{"createdAt":1560497211180,"price":0.01081368,"matchedQuantity":0.09254975,"makerOrderType":"BUY"},{"createdAt":1560497184220,"price":0.01081368,"matchedQuantity":0.1557,"makerOrderType":"BUY"},{"createdAt":1560497157400,"price":0.01081368,"matchedQuantity":0.46484094,"makerOrderType":"BUY"},{"createdAt":1560497155440,"price":0.01081368,"matchedQuantity":0.46484094,"makerOrderType":"BUY"},{"createdAt":1560496761330,"price":0.01081368,"matchedQuantity":0.07222497,"makerOrderType":"SELL"},{"createdAt":1560496751300,"price":0.0108137,"matchedQuantity":0.07222497,"makerOrderType":"SELL"},{"createdAt":1560496730310,"price":0.01085838,"matchedQuantity":0.04684617,"makerOrderType":"BUY"},{"createdAt":1560496205060,"price":0.010877,"matchedQuantity":2.40333213,"makerOrderType":"BUY"},{"createdAt":1560496203850,"price":0.01084003,"matchedQuantity":2.88797564,"makerOrderType":"SELL"},{"createdAt":1560496203850,"price":0.01084004,"matchedQuantity":2.44763583,"makerOrderType":"SELL"},{"createdAt":1560496203850,"price":0.01086601,"matchedQuantity":0.1241911,"makerOrderType":"SELL"},{"createdAt":1560496020340,"price":0.01086568,"matchedQuantity":0.10015068,"makerOrderType":"BUY"},{"createdAt":1560495772070,"price":0.01086568,"matchedQuantity":0.46016109,"makerOrderType":"BUY"},{"createdAt":1560494812590,"price":0.01083503,"matchedQuantity":1.95591982,"makerOrderType":"BUY"},{"createdAt":1560494516030,"price":0.01083503,"matchedQuantity":0.50542315,"makerOrderType":"BUY"},{"createdAt":1560494460770,"price":0.01078639,"matchedQuantity":12.2453742,"makerOrderType":"SELL"},{"createdAt":1560494460770,"price":0.0107916,"matchedQuantity":22,"makerOrderType":"SELL"},{"createdAt":1560494460770,"price":0.01079196,"matchedQuantity":9.0760541,"makerOrderType":"SELL"},{"createdAt":1560494460770,"price":0.01079847,"matchedQuantity":27.71199669,"makerOrderType":"SELL"},{"createdAt":1560494460770,"price":0.01079848,"matchedQuantity":18.26,"makerOrderType":"SELL"},{"createdAt":1560494460770,"price":0.01079951,"matchedQuantity":0.78939763,"makerOrderType":"SELL"},{"createdAt":1560494460770,"price":0.01079953,"matchedQuantity":3.24949292,"makerOrderType":"SELL"},{"createdAt":1560494460770,"price":0.01079954,"matchedQuantity":5.26768446,"makerOrderType":"SELL"},{"createdAt":1560494330390,"price":0.01083518,"matchedQuantity":1.44621087,"makerOrderType":"BUY"},{"createdAt":1560494326030,"price":0.01079589,"matchedQuantity":0.13603303,"makerOrderType":"SELL"},{"createdAt":1560493953900,"price":0.01084969,"matchedQuantity":0.10693131,"makerOrderType":"BUY"},{"createdAt":1560493898450,"price":0.01085323,"matchedQuantity":0.09280437,"makerOrderType":"BUY"},{"createdAt":1560493822450,"price":0.01082429,"matchedQuantity":0.08989994,"makerOrderType":"BUY"},{"createdAt":1560493811200,"price":0.01082429,"matchedQuantity":0.09215385,"makerOrderType":"SELL"}],"status":200,"error":null}'
+    http_version: 
+  recorded_at: Fri, 14 Jun 2019 07:56:44 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/bitsdaq/integration/market_spec.rb
+++ b/spec/exchanges/bitsdaq/integration/market_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+RSpec.describe 'Bitsdaq integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:market) { 'bitsdaq' }
+  let(:zec_btc_pair) { Cryptoexchange::Models::MarketPair.new(base: 'zec', target: 'btc', market: 'bitsdaq') }
+
+  it 'fetch pairs' do
+    pairs = client.pairs('bitsdaq')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.market).to eq 'bitsdaq'
+  end
+
+  it 'give trade url' do
+    trade_page_url = client.trade_page_url market, base: zec_btc_pair.base, target: zec_btc_pair.target
+    expect(trade_page_url).to eq "https://bitsdaq.com/exchange/ZEC-BTC"
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(zec_btc_pair)
+
+    expect(ticker.base).to eq 'ZEC'
+    expect(ticker.target).to eq 'BTC'
+    expect(ticker.market).to eq 'bitsdaq'
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+    expect(ticker.timestamp).to be nil
+    
+    expect(ticker.payload).to_not be nil
+  end
+
+  it 'fetch order book' do
+    order_book = client.order_book(zec_btc_pair)
+
+    expect(order_book.base).to eq 'ZEC'
+    expect(order_book.target).to eq 'BTC'
+    expect(order_book.market).to eq 'bitsdaq'
+
+    expect(order_book.asks).to_not be_empty
+    expect(order_book.bids).to_not be_empty
+    expect(order_book.asks.first.price).to_not be_nil
+    expect(order_book.bids.first.amount).to_not be_nil
+    expect(order_book.bids.first.timestamp).to be_nil
+    expect(order_book.asks.count).to be > 10
+    expect(order_book.bids.count).to be > 10
+    expect(order_book.timestamp).to be_nil
+    expect(order_book.payload).to_not be nil
+  end
+
+  it 'fetch trades' do
+    trades = client.trades(zec_btc_pair)
+    trade = trades.first
+
+    expect(trade.base).to eq 'ZEC'
+    expect(trade.target).to eq 'BTC'
+    expect(trade.market).to eq 'bitsdaq'
+
+    expect(trade.amount).to_not be_nil
+    expect(trade.price).to_not be_nil
+    expect(2000..Date.today.year).to include(Time.at(trade.timestamp).year)
+    expect(trade.type).to eq("buy").or eq("sell")
+  end
+end

--- a/spec/exchanges/bitsdaq/market_spec.rb
+++ b/spec/exchanges/bitsdaq/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Bitsdaq::Market do
+  it { expect(described_class::NAME).to eq 'bitsdaq' }
+  it { expect(described_class::API_URL).to eq 'https://bitsdaq.com/api' }
+end


### PR DESCRIPTION
- What is the purpose of this Pull Request?
Implement Bitsdaq

- [x] I have added Specs
- [x] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [x] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [x] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [x] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
