### PR TITLE
Fix Trade Page Url for BitHash

### DIFF
--- a/lib/cryptoexchange/exchanges/bithash/market.rb
+++ b/lib/cryptoexchange/exchanges/bithash/market.rb
@@ -5,7 +5,7 @@ module Cryptoexchange::Exchanges
       API_URL = 'https://www.bithash.net/api'
 
       def self.trade_page_url(args={})
-        "https://www.bithash.net/en/trade/#{args[:base]}/#{args[:target]}"
+        "https://www.bithash.net/en/exchange/#{args[:base].downcase}/#{args[:target].downcase}"
       end
     end
   end


### PR DESCRIPTION
https://www.bithash.net/en/exchange/btc/usd - for desktop devices
https://www.bithash.net/en/trade/btc/usd - for mobile devices

- What is the purpose of this Pull Request?

Url should be lowsercase, _exchange_ used by default instead of _trade_

- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?

https://github.com/coingecko/cryptoexchange/issues/1129