### PR TITLE
wip fix contract_interval problem in ticker

### DIFF
--- a/lib/cryptoexchange/client.rb
+++ b/lib/cryptoexchange/client.rb
@@ -35,7 +35,8 @@ module Cryptoexchange
         tickers = market.fetch
         tickers.find do |t|
           t.base.casecmp(market_pair.base) == 0 &&
-            t.target.casecmp(market_pair.target) == 0
+          t.target.casecmp(market_pair.target) == 0 &&
+          t.contract_interval.casecmp(market_pair.contract_interval) == 0
         end
       end
     end


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [ ] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
