### PR TITLE
ignore non USD pairs in kraken_futures

### DIFF
--- a/lib/cryptoexchange/exchanges/kraken_future/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/kraken_future/services/pairs.rb
@@ -13,12 +13,16 @@ module Cryptoexchange::Exchanges
           output['tickers'].map do |output|
             if output.key?("pair")
               base, target = output["pair"].split(":")
+
+              next if target != "USD"
+              # skipping non USD pair because volume reported is mixed (some in base, some in target)
+
               Cryptoexchange::Models::MarketPair.new(
                 base: base,
                 target: target,
                 market: KrakenFutures::Market::NAME,
                 contract_interval: output["tag"],
-              )              
+              )
             end
           end.compact
         end


### PR DESCRIPTION
^ because /tickers endpoint is returning mixed volume representation (some in base and some in target)
