### PR TITLE
add veridex markets and pairs

### DIFF
--- a/lib/cryptoexchange/exchanges/veridex/market.rb
+++ b/lib/cryptoexchange/exchanges/veridex/market.rb
@@ -1,0 +1,12 @@
+module Cryptoexchange::Exchanges
+  module Veridex
+    class Market < Cryptoexchange::Models::Market
+      NAME = 'veridex'
+      API_URL = 'https://veridex.herokuapp.com/v2'
+
+      def self.trade_page_url(args={})
+        "https://dex.verisafe.io/#/erc20/?base=#{args[:base]}&quote=#{args[:target]}"
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/veridex/services/market.rb
+++ b/lib/cryptoexchange/exchanges/veridex/services/market.rb
@@ -1,0 +1,56 @@
+module Cryptoexchange::Exchanges
+  module Veridex
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            false
+          end
+        end
+
+        def fetch
+          outputs = []
+          (1..25).each do |page_id|
+            ticker_output = super(ticker_url(page_id))
+            break if ticker_output.empty?
+            outputs = outputs + ticker_output
+          end
+          adapt_all(outputs)
+        end
+
+        def ticker_url(page_id)
+          "#{Cryptoexchange::Exchanges::Veridex::Market::API_URL}/markets?include=stats&page=#{page_id}&perPage=25"
+        end
+
+        def adapt_all(output)
+          output.map do |pair_ticker|
+            base, target = pair_ticker["id"].split("-")
+            market_pair = Cryptoexchange::Models::MarketPair.new(
+              base:   base,
+              target: target,
+              market: Veridex::Market::NAME
+            )
+            adapt(market_pair, pair_ticker["stats"])
+          end
+        end
+
+        def adapt(market_pair, stats_output)
+          ticker = Cryptoexchange::Models::Ticker.new
+
+          ticker.base      = market_pair.base
+          ticker.target    = market_pair.target
+          ticker.market    = Veridex::Market::NAME
+          ticker.bid       = NumericHelper.to_d(stats_output['price_max_24'])
+          ticker.ask       = NumericHelper.to_d(stats_output['price_min_24'])
+          ticker.last      = NumericHelper.to_d(stats_output['last_price'])
+          vol = NumericHelper.to_d(stats_output['volume_24'])
+          ticker.volume    = (vol.nil? || vol == "") ? 0 : NumericHelper.divide(vol, ticker.last)
+          ticker.change    = NumericHelper.to_d(stats_output['last_price_change'])
+          ticker.timestamp = nil
+          ticker.payload   = [stats_output]
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/veridex/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/veridex/services/pairs.rb
@@ -1,0 +1,32 @@
+module Cryptoexchange::Exchanges
+  module Veridex
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Veridex::Market::API_URL}/markets"
+
+        def fetch
+          outputs = []
+          (1..25).each do |page_id|
+            pair_url = PAIRS_URL + "?page=#{page_id}&perPage=25"
+            puts pair_url
+            output = fetch_via_api(pair_url)
+            break if output.empty?
+            outputs = outputs + output
+          end
+          adapt(outputs)
+        end
+
+        def adapt(output)
+          output.map do |ticker|
+            base, target = ticker['displayName'].split('-')
+            Cryptoexchange::Models::MarketPair.new({
+              base: base,
+              target: target,
+              market: Veridex::Market::NAME
+            })
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/exchanges/veridex/integration/market_spec.rb
+++ b/spec/exchanges/veridex/integration/market_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+RSpec.describe 'Veridex integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:vsf_weth_pair) { Cryptoexchange::Models::MarketPair.new(base: 'VSF', target: 'WETH', market: 'veridex') }
+
+  it 'fetch pairs' do
+    pairs = client.pairs('veridex')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.market).to eq 'veridex'
+  end
+
+  it 'give trade url' do
+    trade_page_url = client.trade_page_url 'veridex', base: vsf_weth_pair.base, target: vsf_weth_pair.target
+    expect(trade_page_url).to eq "https://dex.verisafe.io/#/erc20/?base=vsf&quote=weth"
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(vsf_weth_pair)
+
+    expect(ticker.base).to eq 'VSF'
+    expect(ticker.target).to eq 'WETH'
+    expect(ticker.market).to eq 'veridex'
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.last).to be < 100 # Test if number is reasonable
+    expect(ticker.bid).to be_a Numeric
+    expect(ticker.ask).to be_a Numeric
+    expect(ticker.change).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+    expect(ticker.timestamp).to be nil
+    expect(ticker.payload).to_not be nil
+  end
+end

--- a/spec/exchanges/veridex/market_spec.rb
+++ b/spec/exchanges/veridex/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Veridex::Market do
+  it { expect(described_class::NAME).to eq 'veridex' }
+  it { expect(described_class::API_URL).to eq 'https://veridex.herokuapp.com/v2' }
+end


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [x] I have added Specs
- [x] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [x] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [x] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [x] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
