### PR TITLE
Removed depriciated BigDecimal.new

### DIFF
--- a/lib/cryptoexchange/helpers/numeric_helper.rb
+++ b/lib/cryptoexchange/helpers/numeric_helper.rb
@@ -3,7 +3,7 @@ class NumericHelper
     def to_d(number)
       if !number.nil? || number != ""
         num = number.to_s
-        num.empty? ? nil : BigDecimal.new(num)
+        num.empty? ? nil : BigDecimal(num)
       else
         nil
       end


### PR DESCRIPTION
Updated code
BigDecimal.new is deprecated; use BigDecimal() method 



