### PR TITLE
fix ethfinex market pairs bug

### DIFF
--- a/lib/cryptoexchange/exchanges/ethfinex/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/ethfinex/services/pairs.rb
@@ -10,15 +10,19 @@ module Cryptoexchange::Exchanges
         end
 
         def adapt(output)
-          market_pairs = []
-          output.each do |pair|
-            market_pairs << Cryptoexchange::Models::MarketPair.new(
-                              base: pair[0..2],
-                              target: pair[3..-1],
-                              market: Ethfinex::Market::NAME
-                            )
+          output.map do |pair|
+            if pair.include? ":"
+              base, target = pair.split(":")
+            else
+              base = pair[0..pair.length - 4]
+              target = pair[-3..-1]
+            end
+            Cryptoexchange::Models::MarketPair.new(
+              base: base,
+              target: target,
+              market: Ethfinex::Market::NAME
+            )
           end
-          market_pairs
         end
       end
     end


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [ ] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
