### PR TITLE
add drab finance trade url

### DIFF
--- a/lib/cryptoexchange/exchanges/darb_finance/market.rb
+++ b/lib/cryptoexchange/exchanges/darb_finance/market.rb
@@ -3,6 +3,10 @@ module Cryptoexchange::Exchanges
     class Market < Cryptoexchange::Models::Market
       NAME = 'darb_finance'
       API_URL = 'https://api.darbfinance.com/api/v1'
+
+      def self.trade_page_url(args={})
+        "https://base.darbfinance.com/trade/#{args[:base].upcase}-#{args[:target].upcase}"
+      end      
     end
   end
 end

--- a/spec/exchanges/darb_finance/integration/market_spec.rb
+++ b/spec/exchanges/darb_finance/integration/market_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe 'DarbFinance integration specs' do
     expect(pair.market).to eq 'darb_finance'
   end
 
+  it 'give trade url' do
+    trade_page_url = client.trade_page_url "darb_finance", base: btc_usd_pair.base, target: btc_usd_pair.target
+    expect(trade_page_url).to eq "https://base.darbfinance.com/trade/BTC-USD"
+  end  
+
   it 'fetch ticker' do
     ticker = client.ticker(btc_usd_pair)
 


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [ ] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
