### PR TITLE
add contract_interval in future

### DIFF
--- a/lib/cryptoexchange/exchanges/coinflex_futures/services/market.rb
+++ b/lib/cryptoexchange/exchanges/coinflex_futures/services/market.rb
@@ -22,6 +22,7 @@ module Cryptoexchange::Exchanges
           ticker           = Cryptoexchange::Models::Ticker.new
           ticker.base      = market_pair.base
           ticker.target    = market_pair.target
+          ticker.contract_interval = market_pair.contract_interval
           ticker.market    = CoinflexFutures::Market::NAME
           ticker.bid       = output['bid'].to_f / 10000
           ticker.ask       = output['ask'].to_f / 10000

--- a/spec/exchanges/coinflex_futures/integration/market_spec.rb
+++ b/spec/exchanges/coinflex_futures/integration/market_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe 'Coinflex Futures integration specs' do
     expect(ticker.base).to eq xbt_usdt_pair.base
     expect(ticker.target).to eq xbt_usdt_pair.target
     expect(ticker.market).to eq xbt_usdt_pair.market
+    expect(ticker.contract_interval).to_not be nil
     expect(ticker.ask).to be_a Numeric
     expect(ticker.bid).to be_a Numeric
     expect(ticker.last).to be_a Numeric


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [ ] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
