### PR TITLE
[#fix] Coinflex scale decimal and orderbook price scaling

### DIFF
--- a/lib/cryptoexchange/exchanges/coinflex/services/market.rb
+++ b/lib/cryptoexchange/exchanges/coinflex/services/market.rb
@@ -43,12 +43,12 @@ module Cryptoexchange::Exchanges
           ticker.base      = market_pair.base
           ticker.target    = market_pair.target
           ticker.market    = Coinflex::Market::NAME
-          ticker.bid       = output['bid'].to_f / 10000
-          ticker.ask       = output['ask'].to_f / 10000
-          ticker.last      = output['last'].to_f / 10000
-          ticker.high      = output['high'].to_f / 10000
-          ticker.low       = output['low'].to_f / 10000
-          ticker.volume    = output['volume'].to_f / 10000
+          ticker.bid       = output['bid'].to_f / 10000.0
+          ticker.ask       = output['ask'].to_f / 10000.0
+          ticker.last      = output['last'].to_f / 10000.0
+          ticker.high      = output['high'].to_f / 10000.0
+          ticker.low       = output['low'].to_f / 10000.0
+          ticker.volume    = output['volume'].to_f / 10000.0
           ticker.timestamp = nil
           ticker.payload   = output
           ticker

--- a/lib/cryptoexchange/exchanges/coinflex/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/coinflex/services/order_book.rb
@@ -31,8 +31,8 @@ module Cryptoexchange::Exchanges
 
         def adapt_orders(orders)
           orders.collect do |order_entry|
-            Cryptoexchange::Models::Order.new(price:  order_entry[0] / 10000,
-                                              amount: order_entry[1])
+            Cryptoexchange::Models::Order.new(price:  order_entry[0] / 10000.0,
+                                              amount: order_entry[1] / 10000.0)
           end
         end
       end

--- a/lib/cryptoexchange/exchanges/coinflex_futures/services/market.rb
+++ b/lib/cryptoexchange/exchanges/coinflex_futures/services/market.rb
@@ -24,12 +24,12 @@ module Cryptoexchange::Exchanges
           ticker.target    = market_pair.target
           ticker.contract_interval = market_pair.contract_interval
           ticker.market    = CoinflexFutures::Market::NAME
-          ticker.bid       = output['bid'].to_f / 10000
-          ticker.ask       = output['ask'].to_f / 10000
-          ticker.last      = output['last'].to_f / 10000
-          ticker.high      = output['high'].to_f / 10000
-          ticker.low       = output['low'].to_f / 10000
-          ticker.volume    = output['volume'].to_f / 10000
+          ticker.bid       = output['bid'].to_f / 10000.0
+          ticker.ask       = output['ask'].to_f / 10000.0
+          ticker.last      = output['last'].to_f / 10000.0
+          ticker.high      = output['high'].to_f / 10000.0
+          ticker.low       = output['low'].to_f / 10000.0
+          ticker.volume    = output['volume'].to_f / 10000.0
           ticker.timestamp = nil
           ticker.payload   = output
           ticker

--- a/lib/cryptoexchange/exchanges/coinflex_futures/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/coinflex_futures/services/order_book.rb
@@ -31,8 +31,8 @@ module Cryptoexchange::Exchanges
 
         def adapt_orders(orders)
           orders.collect do |order_entry|
-            Cryptoexchange::Models::Order.new(price:  order_entry[0] / 10000,
-                                              amount: order_entry[1])
+            Cryptoexchange::Models::Order.new(price:  order_entry[0] / 10000.0,
+                                              amount: order_entry[1] / 10000.0)
           end
         end
       end


### PR DESCRIPTION
- What is the purpose of this Pull Request?
Coinflex price in orderbook not scaled correctly
Scaling needs to be decimal