### PR TITLE
Change Catex trading page link

### DIFF
--- a/lib/cryptoexchange/exchanges/catex/market.rb
+++ b/lib/cryptoexchange/exchanges/catex/market.rb
@@ -5,7 +5,7 @@ module Cryptoexchange::Exchanges
       API_URL = 'https://www.catex.io/api'
 
       def self.trade_page_url(args={})
-        "https://www.catex.io/trading/#{args[:target]}/#{args[:base]}"
+        "https://www.catex.io/trading/#{args[:base]}/#{args[:target]}"
       end
     end
   end


### PR DESCRIPTION
This link https://www.catex.io/trading/BTC/CPU doesn't work

https://www.catex.io/trading/CPU/BTC should be normal