### PR TITLE
add btse futures

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Or install it yourself as:
 | BTCTurk           | Y       | Y [x]      |         |         | Y           |          | btcturk           |       |
 | BTER              | Y       |            |         |         | Y           |          | bter              |       |
 | BTSE              | Y       | Y [x]      | Y       |         | Y           | Y        | btse              |       |
+| BTSE (Futures)    | Y       | Y [x]      | Y       |         | Y           | Y        | btse_futures      |       |
 | BTCNEXT           | Y       |            |         |         | Y           | N        | btcnext           |       |
 | Buyucoin          | Y       | N          | N       |         | Y           |          | buyucoin          |       |
 | BX Thailand       | Y       | Y [x]      |         |         | Y           |          | bx_thailand       |       |

--- a/lib/cryptoexchange/exchanges/btse_futures/market.rb
+++ b/lib/cryptoexchange/exchanges/btse_futures/market.rb
@@ -1,0 +1,12 @@
+module Cryptoexchange::Exchanges
+  module BtseFutures
+    class Market < Cryptoexchange::Models::Market
+      NAME = 'btse_futures'
+      API_URL = 'https://api.btse.com/futures/api/v1'
+
+      def self.trade_page_url(args={})
+        "https://www.btse.com/en/futures/#{args[:base]}PFC"
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/btse_futures/services/market.rb
+++ b/lib/cryptoexchange/exchanges/btse_futures/services/market.rb
@@ -1,0 +1,57 @@
+module Cryptoexchange::Exchanges
+  module BtseFutures
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            false
+          end
+        end
+
+        def fetch
+          output = super ticker_url
+          # need to add key for client match the correct ticker
+          output = output.each do |o|
+                     o.merge!(base: o["symbol"].chomp("PFC"), target: "USD", contract_interval: "Perpetual")
+                   end
+          adapt_all(output)
+        end
+
+        def ticker_url
+          "#{Cryptoexchange::Exchanges::BtseFutures::Market::API_URL}/market_summary"
+        end
+
+        def adapt_all(output)
+          output.map do |ticker|
+            market_pair = Cryptoexchange::Models::MarketPair.new({
+                            base: ticker[:base],
+                            target: ticker[:target],
+                            inst_id: ticker["symbol"],
+                            contract_interval: ticker[:contract_interval],
+                            market: BtseFutures::Market::NAME
+                          })
+            adapt(ticker, market_pair)
+          end
+        end
+
+        def adapt(output, market_pair)
+          ticker = Cryptoexchange::Models::Ticker.new
+          ticker.base = market_pair.base
+          ticker.target = market_pair.target
+          ticker.contract_interval = market_pair.contract_interval
+          ticker.market = BtseFutures::Market::NAME
+          ticker.last = NumericHelper.to_d(output['last'])
+          ticker.ask = NumericHelper.to_d(output['lowestAsk'])
+          ticker.bid = NumericHelper.to_d(output['highestBid'])          
+          ticker.high = NumericHelper.to_d(output['high24Hr'])
+          ticker.low = NumericHelper.to_d(output['low24Hr'])
+          ticker.volume = NumericHelper.to_d(output['volume'])
+          ticker.change = NumericHelper.to_d(output['percentageChange'])
+          ticker.timestamp = nil
+          ticker.payload = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/btse_futures/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/btse_futures/services/order_book.rb
@@ -1,0 +1,43 @@
+module Cryptoexchange::Exchanges
+  module BtseFutures
+    module Services
+      class OrderBook < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          "#{Cryptoexchange::Exchanges::BtseFutures::Market::API_URL}/orderbook/#{market_pair.inst_id}"
+        end
+
+        def adapt(output, market_pair)
+          order_book = Cryptoexchange::Models::OrderBook.new
+
+          order_book.base      = market_pair.base
+          order_book.target    = market_pair.target
+          order_book.market    = BtseFutures::Market::NAME
+          order_book.asks      = adapt_orders output['sellQuote']
+          order_book.bids      = adapt_orders output['buyQuote']
+          order_book.timestamp = output['timestamp'].to_i / 1000
+          order_book.payload   = output
+          order_book
+        end
+
+        def adapt_orders(orders)
+          orders.collect do |output|
+            Cryptoexchange::Models::Order.new(price: output["price"],
+                                              amount: output["size"],
+                                              timestamp: nil)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/btse_futures/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/btse_futures/services/pairs.rb
@@ -1,0 +1,31 @@
+module Cryptoexchange::Exchanges
+  module BtseFutures
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::BtseFutures::Market::API_URL}/market_summary"
+
+        def fetch
+          output = super
+          adapt(output)
+        end
+
+        def adapt(output)
+          output.map do |ticker|
+            base = ticker["symbol"].chomp("PFC") 
+            target = "USD"
+            inst_id = ticker["symbol"]
+            contract_interval = "Perpetual"
+
+            Cryptoexchange::Models::MarketPair.new({
+              base: base,
+              target: target,
+              inst_id: inst_id,
+              contract_interval: contract_interval,
+              market: BtseFutures::Market::NAME
+            })
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/btse_futures/services/trades.rb
+++ b/lib/cryptoexchange/exchanges/btse_futures/services/trades.rb
@@ -1,0 +1,32 @@
+module Cryptoexchange::Exchanges
+  module BtseFutures
+    module Services
+      class Trades < Cryptoexchange::Services::Market
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          "#{Cryptoexchange::Exchanges::BtseFutures::Market::API_URL}/trades/#{market_pair.inst_id}"
+        end
+
+        def adapt(output, market_pair)
+          output.map do |trade|
+            tr = Cryptoexchange::Models::Trade.new
+            tr.base      = market_pair.base
+            tr.target    = market_pair.target
+            tr.market    = BtseFutures::Market::NAME
+            tr.trade_id  = trade['tradeId']
+            tr.type      = trade['side']
+            tr.price     = trade['price']
+            tr.amount    = trade['size']
+            tr.timestamp = trade['timestamp'].to_i / 1000
+            tr.payload   = trade
+            tr
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/btse_futures/integration_specs_fetch_order_book.yml
+++ b/spec/cassettes/vcr_cassettes/btse_futures/integration_specs_fetch_order_book.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.btse.com/futures/api/v1/orderbook/BTCPFC
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.btse.com
+      User-Agent:
+      - http.rb/5.0.0.pre
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 05 Sep 2019 08:16:37 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '792'
+      Connection:
+      - close
+      Set-Cookie:
+      - incap_ses_1234_1816178=UMKIZiOkeWURLlrLxwwgEWTEcF0AAAAA871zBx0K1+wJIaSD8YYeJA==;
+        path=/; Domain=.btse.com
+      - nlbi_1816178=QcXZKsoUl20lA6/bCV6+vwAAAADfiv+xo/DlUQm4Gv2Rp115; path=/; Domain=.btse.com
+      - visid_incap_1816178=wxUQ0HoHRjiCgPFzNqb5WGTEcF0AAAAAQUIPAAAAAAAW/sTiRHlqfS0A6Iwwbn3Z;
+        expires=Fri, 04 Sep 2020 07:37:55 GMT; path=/; Domain=.btse.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Iinfo:
+      - 11-99809894-99809902 NNNN CT(51 51 0) RT(1567671396683 30) q(0 0 1 -1) r(1
+        1) U5
+      X-Cdn:
+      - Incapsula
+    body:
+      encoding: ASCII-8BIT
+      string: '{"buyQuote":[{"price":"10,556.0","size":"33"},{"price":"10,554.5","size":"1,801"},{"price":"10,554.0","size":"3,720"},{"price":"10,551.0","size":"1,512"},{"price":"10,550.5","size":"568"},{"price":"10,549.5","size":"4,274"},{"price":"10,548.5","size":"26,132"},{"price":"10,548.0","size":"13,775"},{"price":"10,547.5","size":"13,633"},{"price":"10,546.5","size":"15,959"}],"sellQuote":[{"price":"10,565.5","size":"20,630"},{"price":"10,565.0","size":"10,741"},{"price":"10,564.5","size":"34,895"},{"price":"10,564.0","size":"5,664"},{"price":"10,563.5","size":"10,836"},{"price":"10,563.0","size":"4,382"},{"price":"10,561.5","size":"1,446"},{"price":"10,559.0","size":"15"},{"price":"10,558.0","size":"3,739"},{"price":"10,557.5","size":"2,470"}],"timestamp":1567671397271,"symbol":"BTCPFC"}'
+    http_version: 
+  recorded_at: Thu, 05 Sep 2019 08:16:37 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/btse_futures/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/btse_futures/integration_specs_fetch_pairs.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.btse.com/futures/api/v1/market_summary
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.btse.com
+      User-Agent:
+      - http.rb/5.0.0.pre
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 05 Sep 2019 08:16:37 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '653'
+      Connection:
+      - close
+      Set-Cookie:
+      - incap_ses_1234_1816178=zntBUEeDqxzRLVrLxwwgEWTEcF0AAAAAd6WWQ+6pJcLE12HAZN1dZA==;
+        path=/; Domain=.btse.com
+      - nlbi_1816178=iVHMQ2KfDSAHnmgLCV6+vwAAAADQDdZiSnBnMEZGouetrC/O; path=/; Domain=.btse.com
+      - visid_incap_1816178=SaXF33BnQQOsIbN6ITAvGmTEcF0AAAAAQUIPAAAAAADAoguzxOh+JVZbimuzNxfJ;
+        expires=Fri, 04 Sep 2020 07:37:55 GMT; path=/; Domain=.btse.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Iinfo:
+      - 7-16453826-16453831 NNNN CT(51 52 0) RT(1567671396428 32) q(0 0 1 -1) r(2
+        2) U5
+      X-Cdn:
+      - Incapsula
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"volume":124871.0,"symbol":"ETHPFC","high24Hr":175.75,"last":174.8,"highestBid":175.75,"percentageChange":1.1095305832147873,"lowestAsk":173.8,"low24Hr":173.8},{"volume":421940.0,"symbol":"LTCPFC","high24Hr":67.6,"last":67.1,"highestBid":67.6,"percentageChange":1.7011834319526502,"lowestAsk":66.45,"low24Hr":66.45},{"volume":108161.0,"symbol":"USDTPFC","high24Hr":1.0019,"last":1.0011,"highestBid":1.0019,"percentageChange":0.12975346841002883,"lowestAsk":1.0006,"low24Hr":1.0006},{"volume":604929.0,"symbol":"BTCPFC","high24Hr":10656.5,"last":10559.5,"highestBid":10656.5,"percentageChange":1.4122835827898466,"lowestAsk":10506.0,"low24Hr":10506.0}]'
+    http_version: 
+  recorded_at: Thu, 05 Sep 2019 08:16:37 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/btse_futures/integration_specs_fetch_trade.yml
+++ b/spec/cassettes/vcr_cassettes/btse_futures/integration_specs_fetch_trade.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.btse.com/futures/api/v1/trades/BTCPFC
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.btse.com
+      User-Agent:
+      - http.rb/5.0.0.pre
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 05 Sep 2019 08:16:37 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '5407'
+      Connection:
+      - close
+      Vary:
+      - Accept-Encoding
+      Set-Cookie:
+      - incap_ses_1234_1816178=G2eHXBXswy5VLlrLxwwgEWXEcF0AAAAA5+bbALwcf4qanlrlffPOfg==;
+        path=/; Domain=.btse.com
+      - nlbi_1816178=4WyaBI5lEDtrY9nqCV6+vwAAAADKfg/tXAc89p7v2RL8LKYf; path=/; Domain=.btse.com
+      - visid_incap_1816178=xzJSyT+pQciYmwbpUSxpwmXEcF0AAAAAQUIPAAAAAAD3r4R2+CIvx2WRTYuAe924;
+        expires=Fri, 04 Sep 2020 07:37:55 GMT; path=/; Domain=.btse.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Iinfo:
+      - 11-99809940-99809946 NNNN CT(52 53 0) RT(1567671396908 31) q(0 0 1 -1) r(1
+        1) U5
+      X-Cdn:
+      - Incapsula
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"symbol":"BTCPFC-USD","side":"BUY","size":75.0,"price":10559.5,"tradeId":89399002,"timestamp":1567671392100},{"symbol":"BTCPFC-USD","side":"SELL","size":7.0,"price":10556.0,"tradeId":89398995,"timestamp":1567671383468},{"symbol":"BTCPFC-USD","side":"BUY","size":15.0,"price":10556.5,"tradeId":89398990,"timestamp":1567671380904},{"symbol":"BTCPFC-USD","side":"SELL","size":592.0,"price":10556.0,"tradeId":89398986,"timestamp":1567671380051},{"symbol":"BTCPFC-USD","side":"SELL","size":1255.0,"price":10555.0,"tradeId":89398981,"timestamp":1567671378254},{"symbol":"BTCPFC-USD","side":"BUY","size":1.0,"price":10555.0,"tradeId":89398978,"timestamp":1567671375492},{"symbol":"BTCPFC-USD","side":"SELL","size":20.0,"price":10555.0,"tradeId":89398976,"timestamp":1567671375018},{"symbol":"BTCPFC-USD","side":"BUY","size":21.0,"price":10555.5,"tradeId":89398974,"timestamp":1567671373829},{"symbol":"BTCPFC-USD","side":"SELL","size":97.0,"price":10555.0,"tradeId":89398972,"timestamp":1567671372907},{"symbol":"BTCPFC-USD","side":"SELL","size":5.0,"price":10549.0,"tradeId":89398968,"timestamp":1567671370976},{"symbol":"BTCPFC-USD","side":"BUY","size":4.0,"price":10550.0,"tradeId":89398964,"timestamp":1567671370069},{"symbol":"BTCPFC-USD","side":"BUY","size":155.0,"price":10551.0,"tradeId":89398960,"timestamp":1567671368758},{"symbol":"BTCPFC-USD","side":"BUY","size":5.0,"price":10551.0,"tradeId":89398956,"timestamp":1567671367739},{"symbol":"BTCPFC-USD","side":"SELL","size":22.0,"price":10550.5,"tradeId":89398954,"timestamp":1567671366365},{"symbol":"BTCPFC-USD","side":"SELL","size":1.0,"price":10550.5,"tradeId":89398950,"timestamp":1567671365878},{"symbol":"BTCPFC-USD","side":"SELL","size":2.0,"price":10550.5,"tradeId":89398948,"timestamp":1567671365379},{"symbol":"BTCPFC-USD","side":"SELL","size":11.0,"price":10550.5,"tradeId":89398946,"timestamp":1567671365009},{"symbol":"BTCPFC-USD","side":"BUY","size":3.0,"price":10551.5,"tradeId":89398944,"timestamp":1567671364223},{"symbol":"BTCPFC-USD","side":"BUY","size":1.0,"price":10550.0,"tradeId":89398940,"timestamp":1567671362312},{"symbol":"BTCPFC-USD","side":"BUY","size":19.0,"price":10550.0,"tradeId":89398938,"timestamp":1567671360622},{"symbol":"BTCPFC-USD","side":"SELL","size":101.0,"price":10549.0,"tradeId":89398936,"timestamp":1567671359722},{"symbol":"BTCPFC-USD","side":"SELL","size":3.0,"price":10549.0,"tradeId":89398934,"timestamp":1567671359622},{"symbol":"BTCPFC-USD","side":"SELL","size":15.0,"price":10545.5,"tradeId":89398932,"timestamp":1567671358327},{"symbol":"BTCPFC-USD","side":"SELL","size":15.0,"price":10545.5,"tradeId":89398930,"timestamp":1567671356346},{"symbol":"BTCPFC-USD","side":"BUY","size":5.0,"price":10546.0,"tradeId":89398928,"timestamp":1567671355447},{"symbol":"BTCPFC-USD","side":"BUY","size":12.0,"price":10545.5,"tradeId":89398926,"timestamp":1567671354641},{"symbol":"BTCPFC-USD","side":"BUY","size":12.0,"price":10545.5,"tradeId":89398922,"timestamp":1567671352743},{"symbol":"BTCPFC-USD","side":"SELL","size":5.0,"price":10544.5,"tradeId":89398920,"timestamp":1567671352011},{"symbol":"BTCPFC-USD","side":"BUY","size":10.0,"price":10545.5,"tradeId":89398918,"timestamp":1567671350676},{"symbol":"BTCPFC-USD","side":"BUY","size":21.0,"price":10545.5,"tradeId":89398916,"timestamp":1567671350090},{"symbol":"BTCPFC-USD","side":"SELL","size":21.0,"price":10544.5,"tradeId":89398912,"timestamp":1567671349565},{"symbol":"BTCPFC-USD","side":"BUY","size":9.0,"price":10545.5,"tradeId":89398910,"timestamp":1567671347832},{"symbol":"BTCPFC-USD","side":"BUY","size":1.0,"price":10545.5,"tradeId":89398906,"timestamp":1567671345883},{"symbol":"BTCPFC-USD","side":"SELL","size":1.0,"price":10540.0,"tradeId":89398894,"timestamp":1567671329435},{"symbol":"BTCPFC-USD","side":"SELL","size":14.0,"price":10540.0,"tradeId":89398892,"timestamp":1567671329044},{"symbol":"BTCPFC-USD","side":"SELL","size":98.0,"price":10539.0,"tradeId":89398889,"timestamp":1567671328045},{"symbol":"BTCPFC-USD","side":"BUY","size":20.0,"price":10541.0,"tradeId":89398888,"timestamp":1567671327599},{"symbol":"BTCPFC-USD","side":"SELL","size":2.0,"price":10539.0,"tradeId":89398886,"timestamp":1567671326001},{"symbol":"BTCPFC-USD","side":"BUY","size":8.0,"price":10540.5,"tradeId":89398884,"timestamp":1567671325579},{"symbol":"BTCPFC-USD","side":"BUY","size":5.0,"price":10539.5,"tradeId":89398882,"timestamp":1567671324378},{"symbol":"BTCPFC-USD","side":"SELL","size":101.0,"price":10537.5,"tradeId":89398876,"timestamp":1567671318151},{"symbol":"BTCPFC-USD","side":"SELL","size":512.0,"price":10532.0,"tradeId":89398872,"timestamp":1567671315730},{"symbol":"BTCPFC-USD","side":"BUY","size":10.0,"price":10530.0,"tradeId":89398870,"timestamp":1567671315276},{"symbol":"BTCPFC-USD","side":"SELL","size":35.0,"price":10531.5,"tradeId":89398860,"timestamp":1567671309847},{"symbol":"BTCPFC-USD","side":"SELL","size":242.0,"price":10530.5,"tradeId":89398862,"timestamp":1567671309847},{"symbol":"BTCPFC-USD","side":"SELL","size":5.0,"price":10529.5,"tradeId":89398858,"timestamp":1567671308251},{"symbol":"BTCPFC-USD","side":"SELL","size":67.0,"price":10529.5,"tradeId":89398856,"timestamp":1567671307543},{"symbol":"BTCPFC-USD","side":"BUY","size":20.0,"price":10530.5,"tradeId":89398854,"timestamp":1567671306533},{"symbol":"BTCPFC-USD","side":"SELL","size":20.0,"price":10529.5,"tradeId":89398850,"timestamp":1567671305550}]'
+    http_version: 
+  recorded_at: Thu, 05 Sep 2019 08:16:37 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/btse_futures/integration/market_spec.rb
+++ b/spec/exchanges/btse_futures/integration/market_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+RSpec.describe 'btse_futures integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:btc_usd_pair) { Cryptoexchange::Models::MarketPair.new(base: 'BTC', target: 'USD', market: 'btse_futures', contract_interval: "Perpetual", inst_id: "BTCPFC") }
+
+  it 'fetch pairs' do
+    pairs = client.pairs('btse_futures')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.contract_interval).to_not be nil
+    expect(pair.inst_id).to_not be nil
+    expect(pair.market).to eq 'btse_futures'
+  end
+
+  it 'give trade url' do
+    trade_page_url = client.trade_page_url 'btse_futures', base: btc_usd_pair.base
+    expect(trade_page_url).to eq "https://www.btse.com/en/futures/BTCPFC"
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(btc_usd_pair)
+
+    expect(ticker.base).to eq 'BTC'
+    expect(ticker.target).to eq 'USD'
+    expect(ticker.market).to eq 'btse_futures'
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.ask).to be_a Numeric
+    expect(ticker.bid).to be_a Numeric
+    expect(ticker.high).to be_a Numeric
+    expect(ticker.low).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+    expect(ticker.change).to be_a Numeric    
+    expect(ticker.timestamp).to be nil
+    
+    expect(ticker.payload).to_not be nil
+  end
+
+  it 'fetch order book' do
+    order_book = client.order_book(btc_usd_pair)
+
+    expect(order_book.base).to eq 'BTC'
+    expect(order_book.target).to eq 'USD'
+    expect(order_book.market).to eq 'btse_futures'
+    expect(order_book.asks).to_not be_empty
+    expect(order_book.bids).to_not be_empty
+    expect(order_book.asks.first.price).to_not be_nil
+    expect(order_book.bids.first.amount).to_not be_nil
+    expect(order_book.bids.first.timestamp).to be_nil
+    expect(order_book.asks.count).to be > 0
+    expect(order_book.bids.count).to be > 0
+    expect(order_book.timestamp).to be_a Numeric
+    expect(order_book.payload).to_not be nil
+  end
+
+  it 'fetch trade' do
+    trades = client.trades(btc_usd_pair)
+    trade = trades.sample
+
+    expect(trades).to_not be_empty
+    expect(trade.trade_id).to_not be_nil
+    expect(trade.base).to eq 'BTC'
+    expect(trade.target).to eq 'USD'
+    expect(['BUY', 'SELL']).to include trade.type
+    expect(trade.price).to_not be_nil
+    expect(trade.amount).to_not be_nil
+    expect(trade.timestamp).to be_a Numeric
+    expect(trade.payload).to_not be nil
+    expect(trade.market).to eq 'btse_futures'
+  end
+end

--- a/spec/exchanges/btse_futures/market_spec.rb
+++ b/spec/exchanges/btse_futures/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::BtseFutures::Market do
+  it { expect(described_class::NAME).to eq 'btse_futures' }
+  it { expect(described_class::API_URL).to eq 'https://api.btse.com/futures/api/v1' }
+end


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [x] I have added Specs
- [x] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [x] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [x] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [x] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
