### PR TITLE
add method to check url

### DIFF
--- a/lib/cryptoexchange/client.rb
+++ b/lib/cryptoexchange/client.rb
@@ -136,6 +136,44 @@ module Cryptoexchange
       )
     end
 
+    def pair_url(market_pair)
+      exchange = market_pair.market
+      pairs_classname = "Cryptoexchange::Exchanges::#{StringHelper.camelize(exchange)}::Services::Pairs"
+      pairs_class = Object.const_get(pairs_classname)
+      pair_url = pairs_class::PAIRS_URL
+    end
+
+    def market_url(market_pair)
+      exchange = market_pair.market
+      market_classname = "Cryptoexchange::Exchanges::#{StringHelper.camelize(exchange)}::Services::Market"
+      market_class = Object.const_get(market_classname)
+
+      if market_class.supports_individual_ticker_query?
+        market_url = market_class.new.ticker_url(market_pair)
+      else
+        market_url = market_class.new.ticker_url
+      end
+    end 
+
+    def order_book_url(market_pair)
+      exchange = market_pair.market
+      order_book_classname = "Cryptoexchange::Exchanges::#{StringHelper.camelize(exchange)}::Services::OrderBook"
+      order_book_class = Object.const_get(order_book_classname)
+
+      if order_book_class.supports_individual_ticker_query?
+        order_book_url = order_book_class.new.ticker_url(market_pair)
+      else
+        order_book_url = order_book_class.new.ticker_url
+      end
+    end 
+
+    def trades_url(market_pair)
+      exchange = market_pair.market
+      trades_classname = "Cryptoexchange::Exchanges::#{StringHelper.camelize(exchange)}::Services::Trades"
+      trades_class = Object.const_get(trades_classname)
+      trades_url = trades_class.new.ticker_url(market_pair)
+    end            
+
     private
 
     # NOTE: # https://ruby-doc.org/core-2.5.0/Thread.html#method-c-abort_on_exception


### PR DESCRIPTION


- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [ ] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
