### PR TITLE
use inst id in kraken futures's ticker

### DIFF
--- a/lib/cryptoexchange/exchanges/kraken_future/market.rb
+++ b/lib/cryptoexchange/exchanges/kraken_future/market.rb
@@ -5,7 +5,7 @@ module Cryptoexchange::Exchanges
       API_URL = 'https://www.cryptofacilities.com/derivatives/api/v3'
 
       def self.trade_page_url(args={})
-        "https://futures.kraken.com/dashboard"
+        "https://futures.kraken.com/dashboard?symbol=#{args[:inst_id]}"
       end
     end
   end

--- a/lib/cryptoexchange/exchanges/kraken_future/services/market.rb
+++ b/lib/cryptoexchange/exchanges/kraken_future/services/market.rb
@@ -26,6 +26,7 @@ module Cryptoexchange::Exchanges
                 target: target,
                 market: KrakenFutures::Market::NAME,
                 contract_interval: output["tag"],
+                inst_id: output["symbol"],
               )
               adapt(market_pair, output)              
             end
@@ -37,6 +38,7 @@ module Cryptoexchange::Exchanges
           ticker.base      = market_pair.base
           ticker.target    = market_pair.target
           ticker.contract_interval = market_pair.contract_interval
+          ticker.inst_id   = market_pair.inst_id
           ticker.market    = KrakenFutures::Market::NAME
           ticker.last      = NumericHelper.to_d(output['last'])
           ticker.bid       = NumericHelper.to_d(output['bid'])

--- a/spec/exchanges/kraken_futures/integration/market_spec.rb
+++ b/spec/exchanges/kraken_futures/integration/market_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe 'kraken_futures integration specs' do
     expect(ticker.base).to eq 'ETH'
     expect(ticker.target).to eq 'USD'
     expect(ticker.market).to eq 'kraken_futures'
+    expect(ticker.inst_id).to eq 'pi_ethusd'
+    expect(ticker.contract_interval).to eq "perpetual"
     expect(ticker.last).to be_a Numeric
     expect(ticker.bid).to be_a Numeric
     expect(ticker.ask).to be_a Numeric

--- a/spec/exchanges/kraken_futures/integration/market_spec.rb
+++ b/spec/exchanges/kraken_futures/integration/market_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe 'kraken_futures integration specs' do
   end
 
   it 'give trade url' do
-    trade_page_url = client.trade_page_url market, base: eth_usd_pair.base, target: eth_usd_pair.target
-    expect(trade_page_url).to eq "https://futures.kraken.com/dashboard"
+    trade_page_url = client.trade_page_url market, inst_id: eth_usd_pair.inst_id
+    expect(trade_page_url).to eq "https://futures.kraken.com/dashboard?symbol=PI_ETHUSD"
   end
 
   it 'fetch ticker' do


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [ ] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
