### PR TITLE
use inst_id in jex_futures

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,7 @@ Or install it yourself as:
 | Huobi DM          | Y       |            | Y             |               | Y     | Y          | Y           |                |huobi_dm|
 | Kraken Futures    |         |            |               |               |       |            |             |                |       |
 | OKEx Swaps        | Y       |            | Y             |               | Y     | Y          | Y           |                |okex_swap |
+| JexFutures        | Y       | N          | N             | N       | N     | Y          | Y           |                |jex_futures|
 
 
 ** Mapping and data may be incorrect (Cannot determine correctness)

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Or install it yourself as:
 | Ironex            | Y       |            |         |         | Y           |          | ironex            |       |
 | Itbit             | Y       | Y [x]      | Y       |         | User-Defined|          | itbit             |       |
 | Jex               | Y       | Y [x]      | N       |         | Y           | Y        | jex               |       |
-| JexFutures        | Y       | Y [x]      | N       |         | Y           | Y        | jex_future        |       |
+| JexFutures        | Y       | Y [x]      | N       |         | Y           | Y        | jex_future        | futures |
 | Joyso             | Y       | Y [x]      |         |         | Y           |          | joyso             |       |
 | Jubi              | Y       |            |         |         | Y           |          | jubi              |       |
 | Kairex            | Y       | Y [x]      |         |         | Y           |          | kairex            |       |

--- a/lib/cryptoexchange/exchanges/jex_futures/services/market.rb
+++ b/lib/cryptoexchange/exchanges/jex_futures/services/market.rb
@@ -25,9 +25,11 @@ module Cryptoexchange::Exchanges
             # we don't want pair i.e., BINANACEETH, HUOBIETH etc
             next if ticker["symbol"].include? "ETF"
             pair = pairs.find { |i| "#{i.base}#{i.target}" == ticker["symbol"] }
+            inst_id = ticker["symbol"]
             market_pair  = Cryptoexchange::Models::MarketPair.new(
               base:   pair.base,
               target: pair.target,
+              inst_id: inst_id,
               market: JexFutures::Market::NAME
             )
             adapt(market_pair, ticker)
@@ -39,6 +41,7 @@ module Cryptoexchange::Exchanges
           ticker.base       = market_pair.base
           ticker.target     = market_pair.target
           ticker.market     = JexFutures::Market::NAME
+          ticker.inst_id    = market_pair.inst_id
           ticker.last       = NumericHelper.to_d(output['lastPrice'])
           ticker.bid        = NumericHelper.to_d(output['bidPrice'])
           ticker.ask        = NumericHelper.to_d(output['askPrice'])

--- a/lib/cryptoexchange/exchanges/jex_futures/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/jex_futures/services/order_book.rb
@@ -14,7 +14,7 @@ module Cryptoexchange::Exchanges
         end
 
         def ticker_url(market_pair)
-          "#{Cryptoexchange::Exchanges::JexFutures::Market::API_URL}/contract/depth?symbol=#{market_pair.base}#{market_pair.target}"
+          "#{Cryptoexchange::Exchanges::JexFutures::Market::API_URL}/contract/depth?symbol=#{market_pair.inst_id}"
         end
 
         def adapt(output, market_pair)

--- a/lib/cryptoexchange/exchanges/jex_futures/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/jex_futures/services/pairs.rb
@@ -14,9 +14,11 @@ module Cryptoexchange::Exchanges
           output = output['contractSymbols']
           output.map do |pair|
             base, target = pair['baseAsset'], pair['quoteAsset']
+            inst_id = pair['symbol']
             market_pairs << Cryptoexchange::Models::MarketPair.new(
               base: base.upcase,
               target: target.upcase,
+              inst_id: inst_id,
               market: JexFutures::Market::NAME
             )
           end

--- a/lib/cryptoexchange/exchanges/jex_futures/services/trades.rb
+++ b/lib/cryptoexchange/exchanges/jex_futures/services/trades.rb
@@ -8,7 +8,7 @@ module Cryptoexchange::Exchanges
         end
 
         def ticker_url(market_pair)
-          "#{Cryptoexchange::Exchanges::JexFutures::Market::API_URL}/contract/trades?symbol=#{market_pair.base}#{market_pair.target}"
+          "#{Cryptoexchange::Exchanges::JexFutures::Market::API_URL}/contract/trades?symbol=#{market_pair.inst_id}"
         end
 
 

--- a/spec/exchanges/jex_futures/integration/market_spec.rb
+++ b/spec/exchanges/jex_futures/integration/market_spec.rb
@@ -2,16 +2,17 @@ require 'spec_helper'
 
 RSpec.describe 'JexFutures integration specs' do
   let(:client) { Cryptoexchange::Client.new }
-  let(:btc_usdt_pair) { Cryptoexchange::Models::MarketPair.new(base: 'BTC', target: 'USDT', market: 'jex_futures') }
+  let(:btc_usdt_pair) { Cryptoexchange::Models::MarketPair.new(base: 'BTC', target: 'USDT', market: 'jex_futures', inst_id: "BTCUSDT") }
 
   it 'fetch pairs' do
-    pairs = client.pairs('jex')
+    pairs = client.pairs('jex_futures')
     expect(pairs).not_to be_empty
 
     pair = pairs.first
     expect(pair.base).to_not be nil
     expect(pair.target).to_not be nil
-    expect(pair.market).to eq 'jex'
+    expect(pair.inst_id).to_not be nil
+    expect(pair.market).to eq 'jex_futures'
   end
 
   it 'fetch ticker' do
@@ -19,6 +20,7 @@ RSpec.describe 'JexFutures integration specs' do
 
     expect(ticker.base).to eq 'BTC'
     expect(ticker.target).to eq 'USDT'
+    expect(ticker.inst_id).to eq 'BTCUSDT'
     expect(ticker.market).to eq 'jex_futures'
     expect(ticker.last).to be_a Numeric
     expect(ticker.bid).to be_a Numeric


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [ ] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
