### PR TITLE
Wj use inst id in gate futures

### DIFF
--- a/lib/cryptoexchange/exchanges/cme_futures/services/market.rb
+++ b/lib/cryptoexchange/exchanges/cme_futures/services/market.rb
@@ -22,6 +22,7 @@ module Cryptoexchange::Exchanges
             pair = Cryptoexchange::Models::MarketPair.new(
                       base: ticker["productCode"],
                       target: "USD",
+                      inst_id: ticker["quoteCode"],
                       market: CmeFutures::Market::NAME,
                       contract_interval: ticker["expirationMonth"]
                     )
@@ -34,6 +35,7 @@ module Cryptoexchange::Exchanges
           ticker.base = market_pair.base
           ticker.target = market_pair.target
           ticker.market = CmeFutures::Market::NAME
+          ticker.inst_id = market_pair.inst_id
           ticker.last = NumericHelper.to_d(output["last"])
           ticker.volume = NumericHelper.to_d(output["volume"]) * 5.0
           ticker.contract_interval = market_pair.contract_interval

--- a/lib/cryptoexchange/exchanges/cme_futures/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/cme_futures/services/pairs.rb
@@ -15,6 +15,7 @@ module Cryptoexchange::Exchanges
             market_pairs << Cryptoexchange::Models::MarketPair.new(
                               base: pair["productCode"],
                               target: "USD",
+                              inst_id: pair["quoteCode"],
                               market: CmeFutures::Market::NAME,
                               contract_interval: pair["expirationMonth"]
                             )

--- a/spec/exchanges/cme_futures/integration/market_spec.rb
+++ b/spec/exchanges/cme_futures/integration/market_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe 'CME Futures integration specs' do
   let(:client) { Cryptoexchange::Client.new }
-  let(:btc_usd_pair) { Cryptoexchange::Models::MarketPair.new(base: 'BTC', target: 'USD', market: 'cme_futures', contract_interval: "SEP 2019") }
+  let(:btc_usd_pair) { Cryptoexchange::Models::MarketPair.new(base: 'BTC', target: 'USD', market: 'cme_futures', contract_interval: "AUG 2019", inst_id: "BTCQ9") }
 
   it 'fetch pairs' do
     pairs = client.pairs('cme_futures')
@@ -11,6 +11,7 @@ RSpec.describe 'CME Futures integration specs' do
     pair = pairs.first
     expect(pair.base).to_not be nil
     expect(pair.target).to_not be nil
+    expect(pair.inst_id).to_not be nil
     expect(pair.market).to eq 'cme_futures'
     expect(pair.contract_interval).to eq "AUG 2019"
   end
@@ -21,12 +22,13 @@ RSpec.describe 'CME Futures integration specs' do
     expect(ticker.base).to eq 'BTC'
     expect(ticker.target).to eq 'USD'
     expect(ticker.market).to eq 'cme_futures'
+    expect(ticker.inst_id).to eq 'BTCQ9'
     expect(ticker.last).to be_a Numeric
     expect(ticker.ask).to be nil
     expect(ticker.bid).to be nil
     expect(ticker.volume).to be_a Numeric
     expect(ticker.timestamp).to be nil
     expect(ticker.payload).to_not be nil
-    expect(ticker.contract_interval).to eq "SEP 2019"
+    expect(ticker.contract_interval).to eq "AUG 2019"
   end
 end


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [ ] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
