### PR TITLE
fix nash repeating pairs

### DIFF
--- a/lib/cryptoexchange/exchanges/nash/services/market.rb
+++ b/lib/cryptoexchange/exchanges/nash/services/market.rb
@@ -22,15 +22,17 @@ module Cryptoexchange::Exchanges
 
         def adapt_all(output)
           output["data"]["listTickers"].map do |output|
-            base, target = output["market"]["name"].split('_')
-            market_pair = Cryptoexchange::Models::MarketPair.new(
-                            base: base.upcase,
-                            target: target.upcase,
-                            market: Nash::Market::NAME
-                          )
+            if output["market"]["primary"] == true
+              base, target = output["market"]["name"].split('_')
+              market_pair = Cryptoexchange::Models::MarketPair.new(
+                              base: base.upcase,
+                              target: target.upcase,
+                              market: Nash::Market::NAME
+                            )
 
-            adapt(market_pair, output)
-          end
+              adapt(market_pair, output)
+            end
+          end.compact
         end
 
         def adapt(market_pair, output)

--- a/lib/cryptoexchange/exchanges/nash/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/nash/services/pairs.rb
@@ -10,13 +10,15 @@ module Cryptoexchange::Exchanges
           output = JSON.parse(HTTP.post(PAIRS_URL, headers: headers, body: body))
           
           output["data"]["listTickers"].map do |output|
-            base, target = output["market"]["name"].split('_')
-            Cryptoexchange::Models::MarketPair.new(
-              base: base.upcase,
-              target: target.upcase,
-              market: Nash::Market::NAME
-            )
-          end
+            if output["market"]["primary"] == true
+              base, target = output["market"]["name"].split('_')
+              Cryptoexchange::Models::MarketPair.new(
+                base: base.upcase,
+                target: target.upcase,
+                market: Nash::Market::NAME
+              )
+            end
+          end.compact
         end
       end
     end


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [ ] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
