### PR TITLE
skip perpetual pair

### DIFF
--- a/lib/cryptoexchange/exchanges/bibox/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/bibox/services/pairs.rb
@@ -11,12 +11,14 @@ module Cryptoexchange::Exchanges
 
         def adapt(output)
           output['result'].map do |pair|
+            next if pair["pair_type"] == 4
+
             Cryptoexchange::Models::MarketPair.new(
               base: pair['coin_symbol'],
               target: pair['currency_symbol'],
               market: Bibox::Market::NAME
             )
-          end
+          end.compact
         end
       end
     end


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [ ] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
