### PR TITLE
Fix ruby syntax warning - string literal in condition

### DIFF
--- a/lib/cryptoexchange/exchanges/okex_swap/services/contract_stat.rb
+++ b/lib/cryptoexchange/exchanges/okex_swap/services/contract_stat.rb
@@ -24,11 +24,12 @@ module Cryptoexchange::Exchanges
         end
 
         def get_contract_info(market_pair)
-          contract_info = if market_pair.contract_interval == "perpetual"
-                          HTTP.get("#{SWAP_URL}/#{market_pair.inst_id}/funding_time").parse(:json)
-                        elsif "futures"
-                          HTTP.get(FUTURES_URL).parse(:json)
-                        end
+          contract_info = \
+            if market_pair.contract_interval == "perpetual"
+              HTTP.get("#{SWAP_URL}/#{market_pair.inst_id}/funding_time").parse(:json)
+            else
+              HTTP.get(FUTURES_URL).parse(:json)
+            end
           process_contract_info(contract_info, market_pair)
         end
 


### PR DESCRIPTION
This PR removes the unusual appearance of "string literal" in `elsif` condition.

It causes an Ruby syntax warning:

```
cryptoexchange/exchanges/okex_swap/services/contract_stat.rb:31: warning: string literal in condition
```