### PR TITLE
add basefex

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,7 @@ Or install it yourself as:
 | OKEx Swaps        | Y | Y  | Y    |     |  Y      | Y   |  Y  |   Y   |   Y  | Y  | Y  | Y  | Y   | Y   |  okex_swaps  |
 | BTSE (Futures)    | Y | Y  | Y    |  Y  |  Y      | Y   |     |       |      | Y  | Y  |    |     |     |  btse_futures  |
 | Prime XBT         | Y | Y  | Y    |  Y  |  N      | Y   |  N  |       |      | N  | N  | N  | N   | N   |  prime_xbt  |
+| BaseFEX           | Y | Y  | Y    |  Y  |  Y      | Y   |  N  |       |      | N  | N  | Y  | Y   | Y   |  basefex  |
 
 *Legend*
 

--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ Or install it yourself as:
 | OKEx Swaps        | Y | Y  | Y    |     |  Y      | Y   |  Y  |   Y   |   Y  | Y  | Y  | Y  | Y   | Y   |  okex_swaps  |
 | BTSE (Futures)    | Y | Y  | Y    |  Y  |  Y      | Y   |     |       |      | Y  | Y  |    |     |     |  btse_futures  |
 | Prime XBT         | Y | Y  | Y    |  Y  |  N      | Y   |  N  |       |      | N  | N  | N  | N   | N   |  prime_xbt  |
-| BaseFEX           | Y | Y  | Y    |  Y  |  Y      | Y   |  N  |       |      | N  | N  | Y  | Y   | Y   |  basefex  |
+| BaseFEX           | Y | Y  | Y    |  Y  |  Y      | Y   |  Y  |       |      | N  | N  | Y  | Y   | Y   |  basefex  |
 
 *Legend*
 

--- a/lib/cryptoexchange/exchanges/basefex/market.rb
+++ b/lib/cryptoexchange/exchanges/basefex/market.rb
@@ -1,0 +1,21 @@
+module Cryptoexchange::Exchanges
+  module Basefex
+    class Market < Cryptoexchange::Models::Market
+      NAME = 'basefex'
+      API_URL = 'https://api.basefex.com'
+
+      def self.trade_page_url(args={})
+        "https://www.basefex.com/trade/#{args[:inst_id].upcase}"
+      end
+
+      def self.separate_symbol(pair)
+          separator = /(XBT|USDT|USD|BTC|ETH|XRP|BCH|LTC|BNB)\z/i =~ pair
+          base      = pair[0..separator - 1]
+          target    = pair[separator..-1]
+          [base, target]
+        rescue NoMethodError
+          nil
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/basefex/services/contract_stat.rb
+++ b/lib/cryptoexchange/exchanges/basefex/services/contract_stat.rb
@@ -38,10 +38,11 @@ module Cryptoexchange::Exchanges
           contract_stat.target = market_pair.target
           contract_stat.market = Basefex::Market::NAME
           contract_stat.contract_type = "perpetual"
-          contract_stat.open_interest = output['openValue']
-          contract_stat.funding_rate_percentage = output["fundingRate"]
+          contract_stat.open_interest = output['openInterest']
+          contract_stat.index = output['indexPrice']
+          contract_stat.funding_rate_percentage = output["fundingRate"] * 100
           contract_stat.next_funding_rate_timestamp = output["nextFundingTime"] / 1000
-          contract_stat.funding_rate_percentage_predicted = output["nextFundingRate"]
+          contract_stat.funding_rate_percentage_predicted = output["nextFundingRate"] * 100
           contract_stat.payload = output
           contract_stat
         end

--- a/lib/cryptoexchange/exchanges/basefex/services/contract_stat.rb
+++ b/lib/cryptoexchange/exchanges/basefex/services/contract_stat.rb
@@ -1,0 +1,51 @@
+module Cryptoexchange::Exchanges
+  module Basefex
+    module Services
+      class ContractStat < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            false
+          end
+        end
+
+        def fetch
+          output = super ticker_url
+          adapt_all(output)
+        end
+
+        def ticker_url
+          "#{Cryptoexchange::Exchanges::Basefex::Market::API_URL}/instruments"
+        end
+
+        def adapt_all(output)
+          output.map do |pair|
+            base, target = Basefex::Market.separate_symbol(pair["symbol"])
+            market_pair = Cryptoexchange::Models::MarketPair.new(
+                            base: base,
+                            target: target,
+                            inst_id: pair["symbol"],
+                            contract_interval: "perpetual",
+                            market: Basefex::Market::NAME
+                          )
+
+            adapt(pair, market_pair)
+          end
+        end
+
+        def adapt(output, market_pair)
+          contract_stat = Cryptoexchange::Models::ContractStat.new
+          contract_stat.base = market_pair.base
+          contract_stat.target = market_pair.target
+          contract_stat.market = Basefex::Market::NAME
+          contract_stat.contract_type = "perpetual"
+          contract_stat.open_interest = output['openValue']
+          contract_stat.funding_rate_percentage = output["fundingRate"]
+          contract_stat.next_funding_rate_timestamp = output["nextFundingTime"] / 1000
+          contract_stat.funding_rate_percentage_predicted = output["nextFundingRate"]
+          contract_stat.payload = output
+          contract_stat
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/basefex/services/market.rb
+++ b/lib/cryptoexchange/exchanges/basefex/services/market.rb
@@ -1,0 +1,54 @@
+module Cryptoexchange::Exchanges
+  module Basefex
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            false
+          end
+        end
+
+        def fetch
+          output = super ticker_url
+          adapt_all(output)
+        end
+
+        def ticker_url
+          "#{Cryptoexchange::Exchanges::Basefex::Market::API_URL}/instruments"
+        end
+
+        def adapt_all(output)
+          output.map do |pair|
+            base, target = Basefex::Market.separate_symbol(pair["symbol"])
+            market_pair = Cryptoexchange::Models::MarketPair.new(
+                            base: base,
+                            target: target,
+                            inst_id: pair["symbol"],
+                            contract_interval: "perpetual",
+                            market: Basefex::Market::NAME
+                          )
+
+            adapt(pair, market_pair)
+          end
+        end
+
+        def adapt(output, market_pair)
+          ticker = Cryptoexchange::Models::Ticker.new
+          ticker.base = market_pair.base
+          ticker.target = market_pair.target
+          ticker.contract_interval = market_pair.contract_interval
+          ticker.inst_id = market_pair.inst_id
+          ticker.market = Basefex::Market::NAME
+          ticker.last = NumericHelper.to_d(output['latestPrice'])
+          ticker.high = NumericHelper.to_d(output['last24hMaxPrice'])
+          ticker.low = NumericHelper.to_d(output['last24hMinPrice'])
+          ticker.volume = NumericHelper.to_d(output['turnover24h'])
+          ticker.change = NumericHelper.to_d(output['last24hPriceChange'])
+          ticker.timestamp = nil
+          ticker.payload = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/basefex/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/basefex/services/order_book.rb
@@ -1,0 +1,43 @@
+module Cryptoexchange::Exchanges
+  module Basefex
+    module Services
+      class OrderBook < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          "#{Cryptoexchange::Exchanges::Basefex::Market::API_URL}/depth@#{market_pair.inst_id.upcase}/snapshot"
+        end
+
+        def adapt(output, market_pair)
+          order_book = Cryptoexchange::Models::OrderBook.new
+
+          order_book.base      = market_pair.base
+          order_book.target    = market_pair.target
+          order_book.market    = Basefex::Market::NAME
+          order_book.asks      = adapt_orders output['asks']
+          order_book.bids      = adapt_orders output['bids']
+          order_book.timestamp = nil
+          order_book.payload   = output
+          order_book
+        end
+
+        def adapt_orders(orders)
+          orders.collect do |output|
+            Cryptoexchange::Models::Order.new(price: output[0],
+                                              amount: output[0][1],
+                                              timestamp: nil)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/basefex/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/basefex/services/pairs.rb
@@ -1,0 +1,27 @@
+module Cryptoexchange::Exchanges
+  module Basefex
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Basefex::Market::API_URL}/instruments"
+
+        def fetch
+          output = super
+          adapt(output)
+        end
+
+        def adapt(output)
+          output.map do |pair|
+            base, target = Basefex::Market.separate_symbol(pair["symbol"])
+            Cryptoexchange::Models::MarketPair.new(
+              base: base,
+              target: target,
+              inst_id: pair["symbol"],
+              contract_interval: "perpetual",
+              market: Basefex::Market::NAME
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/basefex/integration_specs_fetch_order_book.yml
+++ b/spec/cassettes/vcr_cassettes/basefex/integration_specs_fetch_order_book.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.basefex.com/depth@BTCUSD/snapshot
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.basefex.com
+      User-Agent:
+      - http.rb/5.0.0.pre
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 13 Nov 2019 04:44:40 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d6173cc3a913ae0f2a46d7d50e07cd2611573620280; expires=Thu, 12-Nov-20
+        04:44:40 GMT; path=/; domain=.basefex.com; HttpOnly
+      X-Ratelimit-Limit:
+      - '180'
+      X-Ratelimit-Remaining:
+      - '180'
+      X-Ratelimit-Reset:
+      - '1573620280'
+      Access-Control-Allow-Headers:
+      - DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,x-device-platform,X-TOKEN
+      Access-Control-Allow-Methods:
+      - GET,POST,OPTIONS,PUT,DELETE,PATCH
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 534e177e0942dd52-KUL
+    body:
+      encoding: UTF-8
+      string: '{"to":156528817,"bestPrices":{"ask":8698.5,"bid":8698},"lastPrice":8702.5,"bids":{"8689.5":9880,"4444":100,"8696":2957,"8685.5":9126,"8696.5":9708,"6000":1000000,"8695.5":10029,"8690.5":9117,"8669.5":5,"8688":1000,"8684":9882,"8688.5":4,"8694":7765,"8693.5":6099,"8687.5":9882,"8100":40000,"8500":20000,"8698":2957,"8695":7530,"8692.5":15233,"5555":100,"8400":20000,"8689":9119,"8000":50000,"7000":100000,"8691.5":15657,"7500":100000,"8672.5":125,"8686.5":9882},"asks":{"8704.5":4489,"8724":125,"16000":500000,"8726.5":397,"8830":60,"8724.5":19106,"8710":10878,"8705":4105,"8703":8625,"8716.5":12648,"16666":150,"8722.5":16272,"8698.5":4142,"8720.5":15013,"8701.5":9857,"8713.5":12778,"14545":100,"12000":100000,"8709":4452,"8717.5":15008,"8711.5":7767,"8707.5":317,"11000":100000,"8699":4489,"8707":11169,"13000":500000,"8730":1000,"8701":5715},"from":0}'
+    http_version: 
+  recorded_at: Wed, 13 Nov 2019 04:44:40 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/basefex/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/basefex/integration_specs_fetch_pairs.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.basefex.com/instruments
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.basefex.com
+      User-Agent:
+      - http.rb/5.0.0.pre
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 13 Nov 2019 04:44:39 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=deead88fc930fad1609100227a1b3fa211573620279; expires=Thu, 12-Nov-20
+        04:44:39 GMT; path=/; domain=.basefex.com; HttpOnly
+      Access-Control-Allow-Headers:
+      - DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization,x-device-platform,X-TOKEN
+      Access-Control-Allow-Methods:
+      - GET,POST,OPTIONS,PUT,DELETE,PATCH
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 534e177baed9dd66-KUL
+    body:
+      encoding: UTF-8
+      string: '[{"nextFundingRate":-0.00104261,"usdtPrice":0.9982,"turnover24h":992.6570807092766,"openInterest":1689831,"nextFundingTime":1573639200000,"volume24hInUsd":8625369,"fundingRate":-0.00122087,"volume24h":8625369,"last24hMaxPrice":8849,"btcPrice":8717.96,"latestPrice":8702.5,"symbol":"BTCUSD","last24hPriceChange":-0.0023501089074859567,"openValue":193.74524851825456,"last24hMinPrice":8556.5,"openTime":0,"markPrice":8710.96592941,"indexPrice":8717.96},{"nextFundingRate":0.0001,"usdtPrice":0.9982,"turnover24h":206.46252,"openInterest":949,"nextFundingTime":1573639200000,"volume24hInUsd":1799931.9908592,"fundingRate":0.0001,"volume24h":9724,"last24hMaxPrice":0.02142,"btcPrice":8717.96,"latestPrice":0.02125,"symbol":"ETHXBT","last24hPriceChange":0.00047080979284383533,"openValue":20.1903185879296,"last24hMinPrice":0.02113,"openTime":0,"markPrice":0.02125483,"indexPrice":0.02125343},{"nextFundingRate":0.0001,"usdtPrice":0.9982,"turnover24h":43.5161601,"openInterest":147322,"nextFundingTime":1573639200000,"volume24hInUsd":379067.094823095,"fundingRate":0.0001,"volume24h":1399354,"last24hMaxPrice":0.00003129,"btcPrice":8710.95,"latestPrice":0.00003111,"symbol":"XRPXBT","last24hPriceChange":-0.004161331626120373,"openValue":4.584418560646006,"last24hMinPrice":0.00003085,"openTime":0,"markPrice":0.0000311,"indexPrice":0.0000311},{"nextFundingRate":0.00245637,"usdtPrice":0.9982,"turnover24h":451.75146,"openInterest":1390,"nextFundingTime":1573639200000,"volume24hInUsd":3938509.2712326,"fundingRate":0.00080698,"volume24h":13731,"last24hMaxPrice":0.03329,"btcPrice":8718.31,"latestPrice":0.03275,"symbol":"BCHXBT","last24hPriceChange":0.0018354236769655705,"openValue":45.56827765229249,"last24hMinPrice":0.03262,"openTime":0,"markPrice":0.03276476,"indexPrice":0.03274739},{"nextFundingRate":0.0001,"usdtPrice":0.9982,"turnover24h":710.22399,"openInterest":9688,"nextFundingTime":1573639200000,"volume24hInUsd":6186796.688089499,"fundingRate":0.0001,"volume24h":101399,"last24hMaxPrice":0.0071,"btcPrice":8711.05,"latestPrice":0.007,"symbol":"LTCXBT","last24hPriceChange":-0.014084507042253558,"openValue":67.64173704016498,"last24hMinPrice":0.00694,"openTime":0,"markPrice":0.00698196,"indexPrice":0.0069815},{"nextFundingRate":0.0001,"usdtPrice":0.9982,"turnover24h":3517.839395,"openInterest":143976,"nextFundingTime":1573639200000,"volume24hInUsd":30668383.132034197,"fundingRate":0.0001,"volume24h":1496132,"last24hMaxPrice":0.002382,"btcPrice":8717.96,"latestPrice":0.002382,"symbol":"BNBXBT","last24hPriceChange":0.026724137931034477,"openValue":343.0998840348022,"last24hMinPrice":0.002309,"openTime":0,"markPrice":0.00238315,"indexPrice":0.00238299},{"nextFundingRate":0,"usdtPrice":0.9982,"turnover24h":62114187.64,"openInterest":68512,"nextFundingTime":1573639200000,"volume24hInUsd":62049063.58210385,"fundingRate":0,"volume24h":709944,"last24hMaxPrice":8869,"btcPrice":8717.96,"latestPrice":8727.5,"symbol":"BTCUSDT","last24hPriceChange":-0.0014302059496567505,"openValue":5979213.859333769,"last24hMinPrice":8587,"openTime":0,"markPrice":8727.11,"indexPrice":8727.11},{"nextFundingRate":0.0001,"usdtPrice":0.9982,"turnover24h":31388073.138,"openInterest":168115,"nextFundingTime":1573639200000,"volume24hInUsd":31355164.091452774,"fundingRate":0.0001,"volume24h":1689758,"last24hMaxPrice":187.41,"btcPrice":8717.96,"latestPrice":185.48,"symbol":"ETHUSDT","last24hPriceChange":-0.0017760077498520667,"openValue":3118576.7485913727,"last24hMinPrice":182.82,"openTime":0,"markPrice":185.49218789,"indexPrice":185.48}]'
+    http_version: 
+  recorded_at: Wed, 13 Nov 2019 04:44:39 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/basefex/integration/market_spec.rb
+++ b/spec/exchanges/basefex/integration/market_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+RSpec.describe 'basefex integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:btc_usd_pair) { Cryptoexchange::Models::MarketPair.new(base: 'BTC', target: 'USD', market: 'basefex', contract_interval: "perpetual", inst_id: "BTCUSD") }
+
+  it 'fetch pairs' do
+    pairs = client.pairs('basefex')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.contract_interval).to_not be nil
+    expect(pair.inst_id).to_not be nil
+    expect(pair.market).to eq 'basefex'
+  end
+
+  it 'give trade url' do
+    trade_page_url = client.trade_page_url 'basefex', inst_id: btc_usd_pair.inst_id
+    expect(trade_page_url).to eq "https://www.basefex.com/trade/BTCUSD"
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(btc_usd_pair)
+
+    expect(ticker.base).to eq 'BTC'
+    expect(ticker.target).to eq 'USD'
+    expect(ticker.inst_id).to eq 'BTCUSD'
+    expect(ticker.market).to eq 'basefex'
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.high).to be_a Numeric
+    expect(ticker.low).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+    expect(ticker.change).to be_a Numeric
+    expect(ticker.timestamp).to be nil
+
+    expect(ticker.payload).to_not be nil
+  end
+
+  it 'fetch order book' do
+    order_book = client.order_book(btc_usd_pair)
+
+    expect(order_book.base).to eq 'BTC'
+    expect(order_book.target).to eq 'USD'
+    expect(order_book.market).to eq 'basefex'
+    expect(order_book.asks).to_not be_empty
+    expect(order_book.bids).to_not be_empty
+    expect(order_book.asks.first.price).to_not be_nil
+    expect(order_book.bids.first.amount).to_not be_nil
+    expect(order_book.bids.first.timestamp).to be_nil
+    expect(order_book.asks.count).to be > 0
+    expect(order_book.bids.count).to be > 0
+    expect(order_book.timestamp).to be_nil
+    expect(order_book.payload).to_not be nil
+  end
+
+  it 'fetch contract stat' do
+    contract_stat = client.contract_stat(btc_usd_pair)
+    expect(contract_stat.base).to eq 'BTC'
+    expect(contract_stat.target).to eq 'USD'
+    expect(contract_stat.market).to eq 'basefex'
+    expect(contract_stat.open_interest).to be_a Numeric
+    expect(contract_stat.funding_rate_percentage).to be_a Numeric
+    expect(contract_stat.next_funding_rate_timestamp).to_not be_nil
+    expect(contract_stat.funding_rate_percentage_predicted).to be_a Numeric
+    expect(contract_stat.contract_type).to eq 'perpetual'
+    expect(contract_stat.payload).to_not be nil
+  end
+end

--- a/spec/exchanges/basefex/integration/market_spec.rb
+++ b/spec/exchanges/basefex/integration/market_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe 'basefex integration specs' do
     expect(contract_stat.target).to eq 'USD'
     expect(contract_stat.market).to eq 'basefex'
     expect(contract_stat.open_interest).to be_a Numeric
+    expect(contract_stat.index).to be_a Numeric
     expect(contract_stat.funding_rate_percentage).to be_a Numeric
     expect(contract_stat.next_funding_rate_timestamp).to_not be_nil
     expect(contract_stat.funding_rate_percentage_predicted).to be_a Numeric

--- a/spec/exchanges/basefex/market_spec.rb
+++ b/spec/exchanges/basefex/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Basefex::Market do
+  it { expect(described_class::NAME).to eq 'basefex' }
+  it { expect(described_class::API_URL).to eq 'https://api.basefex.com' }
+end


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [x] I have added Specs
- [x] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [x] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [x] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [x] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
