### PR TITLE
fix basefex volume

### DIFF
--- a/lib/cryptoexchange/exchanges/basefex/services/market.rb
+++ b/lib/cryptoexchange/exchanges/basefex/services/market.rb
@@ -42,7 +42,11 @@ module Cryptoexchange::Exchanges
           ticker.last = NumericHelper.to_d(output['latestPrice'])
           ticker.high = NumericHelper.to_d(output['last24hMaxPrice'])
           ticker.low = NumericHelper.to_d(output['last24hMinPrice'])
-          ticker.volume = NumericHelper.to_d(output['turnover24h'])
+          if market_pair.base == "BTC"
+            ticker.volume = NumericHelper.to_d(output['turnover24h'])
+          else
+            ticker.volume = NumericHelper.to_d(output['turnover24h']) / ticker.last
+          end
           ticker.change = NumericHelper.to_d(output['last24hPriceChange'])
           ticker.timestamp = nil
           ticker.payload = output


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [ ] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
