### PR TITLE
fix paribu order_book

### DIFF
--- a/lib/cryptoexchange/exchanges/paribu/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/paribu/services/order_book.rb
@@ -33,8 +33,8 @@ module Cryptoexchange::Exchanges
 
         def adapt_orders(orders)
           orders.collect do |order_entry|
-            Cryptoexchange::Models::Order.new(price: order_entry[0],
-                                              amount: order_entry[0][1])
+            Cryptoexchange::Models::Order.new(price: NumericHelper.to_d(order_entry[0]),
+                                              amount: NumericHelper.to_d(order_entry[0][1]))
           end
         end
       end

--- a/spec/exchanges/paribu/integration/market_spec.rb
+++ b/spec/exchanges/paribu/integration/market_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe 'Paribu integration specs' do
     expect(order_book.market).to eq 'paribu'
     expect(order_book.asks).to_not be_empty
     expect(order_book.bids).to_not be_empty
-    expect(order_book.asks.first.price).to_not be_nil
-    expect(order_book.bids.first.amount).to_not be_nil
+    expect(order_book.asks.first.price).to be_a Numeric
+    expect(order_book.bids.first.amount).to be_a Numeric
     expect(order_book.bids.first.timestamp).to be_nil
     expect(order_book.asks.count).to be > 10
     expect(order_book.bids.count).to be > 10


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [ ] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
