### PR TITLE
add citex trade url

### DIFF
--- a/lib/cryptoexchange/exchanges/citex/market.rb
+++ b/lib/cryptoexchange/exchanges/citex/market.rb
@@ -3,6 +3,10 @@ module Cryptoexchange::Exchanges
     class Market < Cryptoexchange::Models::Market
       NAME='citex'
       API_URL = 'https://open.citex.co.kr/api/v1/common'
+
+      def self.trade_page_url(args={})
+        "https://trade.citex.co.kr/trade/#{args[:base].upcase}_#{args[:target].upcase}"
+      end
     end
   end
 end

--- a/spec/exchanges/citex/integration/market_spec.rb
+++ b/spec/exchanges/citex/integration/market_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe 'Citex integration specs' do
     expect(pair.market).to eq 'citex'
   end
 
+  it 'give trade url' do
+    trade_page_url = client.trade_page_url 'citex', base: veil_btc_pair.base, target: veil_btc_pair.target
+    expect(trade_page_url).to eq "https://trade.citex.co.kr/trade/VEIL_BTC"
+  end  
+
   it 'fetch ticker' do
     pending "Skip this test due to restriction"
 


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [ ] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
