### PR TITLE
edit financex pairs link

### DIFF
--- a/lib/cryptoexchange/exchanges/financex/market.rb
+++ b/lib/cryptoexchange/exchanges/financex/market.rb
@@ -5,7 +5,7 @@ module Cryptoexchange::Exchanges
       API_URL = 'https://market-watch.financex.io/api/v1/market-watch/ticker'
 
       def self.trade_page_url(args={})
-        "https://financex.io/en/buy-sell-bitcoin-cash-abc/#{args[:base]}_#{args[:target]}"
+        "https://financex.io/en/#{args[:base]}_#{args[:target]}"
       end
     end
   end

--- a/spec/exchanges/financex/integration/market_spec.rb
+++ b/spec/exchanges/financex/integration/market_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Financex integration specs' do
 
   it 'give trade url' do
     trade_page_url = client.trade_page_url 'financex', base: etc_btc_pair.base, target: etc_btc_pair.target
-    expect(trade_page_url).to eq "https://financex.io/en/buy-sell-bitcoin-cash-abc/ETC_BTC"
+    expect(trade_page_url).to eq "https://financex.io/en/ETC_BTC"
   end
 
   it 'fetch ticker' do


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [ ] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
