### PR TITLE
Updated# api url and name cezex to lucent

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,6 @@ Or install it yourself as:
 | CCex              | Y       |            |         |         | Y           |          | ccex              |       |
 | Ccx               | Y       |            |         |         | Y           | Y        | ccx               |       |
 | Cex               | Y       | Y [x]      | Y       |         | Y           |          | cex               |       |
-| Cezex             | Y       | N          | N       |         | Y           | Y        | cezex             |       |
 | Cfinex            | Y       | Y          | Y       |         | Y           | Y        | cfinex            |       |
 | Chaince           | Y       |            |         |         | Y           | Y        | chaince           |       |
 | Chainrift         | Y       | Y [x]      | Y       |         | Y           |          | chainrift         |       |
@@ -341,6 +340,7 @@ Or install it yourself as:
 | Livecoin          | Y       | Y [x]      |         |         | Y           |          | livecoin          |       |
 | LocalBitcoins     | Y       | N          | Y [limit: 500]|   | Y           |          | localbitcoins     |  P2P  |
 | LocalTrade        | Y       |            |         |         | Y           | Y        | localtrade        |       |
+| Lucent            | Y       | N          | N       |         | Y           | Y        | lucent             |       |
 | Lukki             | Y       | Y [x]      |         |         | Y           | Y        | lukki             |       |
 | Luno              | Y       |            |         |         | Y           | Y        | luno              |       |
 | Lykke             | Y       | Y          | N       |         | Y           |          | lykke             |       |

--- a/lib/cryptoexchange/exchanges/lucent/market.rb
+++ b/lib/cryptoexchange/exchanges/lucent/market.rb
@@ -1,8 +1,8 @@
 module Cryptoexchange::Exchanges
-  module Cezex
+  module Lucent
     class Market < Cryptoexchange::Models::Market
-      NAME = 'cezex'
-      API_URL = 'https://beta.cezex.io/api/v2'
+      NAME = 'lucent'
+      API_URL = 'https://lucent.exchange/api/v2'
     end
   end
 end

--- a/lib/cryptoexchange/exchanges/lucent/services/market.rb
+++ b/lib/cryptoexchange/exchanges/lucent/services/market.rb
@@ -1,5 +1,5 @@
 module Cryptoexchange::Exchanges
-  module Cezex
+  module Lucent
     module Services
       class Market < Cryptoexchange::Services::Market
         class << self
@@ -15,7 +15,7 @@ module Cryptoexchange::Exchanges
 
         def ticker_url(market_pair)
           market = "#{market_pair.base}#{market_pair.target}".downcase
-          "#{Cryptoexchange::Exchanges::Cezex::Market::API_URL}/tickers/#{market}.json"
+          "#{Cryptoexchange::Exchanges::Lucent::Market::API_URL}/tickers/#{market}.json"
         end
 
         def adapt(output, market_pair)
@@ -23,7 +23,7 @@ module Cryptoexchange::Exchanges
           ticker_json      = output['ticker']
           ticker.base      = market_pair.base
           ticker.target    = market_pair.target
-          ticker.market    = Cezex::Market::NAME
+          ticker.market    = Lucent::Market::NAME
           ticker.bid       = NumericHelper.to_d(ticker_json['buy'])
           ticker.ask       = NumericHelper.to_d(ticker_json['sell'])
           ticker.low       = NumericHelper.to_d(ticker_json['low'])

--- a/lib/cryptoexchange/exchanges/lucent/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/lucent/services/pairs.rb
@@ -1,8 +1,8 @@
 module Cryptoexchange::Exchanges
-  module Cezex
+  module Lucent
     module Services
       class Pairs < Cryptoexchange::Services::Pairs
-        PAIRS_URL = "#{Cryptoexchange::Exchanges::Cezex::Market::API_URL}/markets"
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Lucent::Market::API_URL}/markets"
 
         def fetch
           output = super
@@ -14,7 +14,7 @@ module Cryptoexchange::Exchanges
             Cryptoexchange::Models::MarketPair.new({
               base: market['name'].split("/")[0],
               target: market['name'].split("/")[1],
-              market: Cezex::Market::NAME
+              market: Lucent::Market::NAME
             })
           end
         end

--- a/spec/cassettes/vcr_cassettes/Lucent/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/Lucent/integration_specs_fetch_pairs.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://beta.cezex.io/api/v2/markets
+    uri: https://lucent.exchange/api/v2/markets
     body:
       encoding: UTF-8
       string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Connection:
       - close
       Host:
-      - beta.cezex.io
+      - lucent.exchange
       User-Agent:
       - http.rb/3.0.0
   response:

--- a/spec/cassettes/vcr_cassettes/Lucent/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/Lucent/integration_specs_fetch_ticker.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://beta.cezex.io/api/v2/tickers/giobtc.json
+    uri: https://lucent.exchange/api/v2/tickers/giobtc.json
     body:
       encoding: UTF-8
       string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Connection:
       - close
       Host:
-      - beta.cezex.io
+      -lucent.exchange
       User-Agent:
       - http.rb/3.0.0
   response:

--- a/spec/exchanges/cezex/market_spec.rb
+++ b/spec/exchanges/cezex/market_spec.rb
@@ -1,7 +1,0 @@
-require 'spec_helper'
-
-RSpec.describe Cryptoexchange::Exchanges::Cezex::Market do
-  it { expect(described_class::NAME).to eq 'cezex' }
-  it { expect(described_class::API_URL).to eq 'https://beta.cezex.io/api/v2' }
-end
-

--- a/spec/exchanges/lucent/integration/market_spec.rb
+++ b/spec/exchanges/lucent/integration/market_spec.rb
@@ -1,17 +1,17 @@
 require 'spec_helper'
 
-RSpec.describe 'Cezex integration specs' do
+RSpec.describe 'Lucent integration specs' do
   let(:client) { Cryptoexchange::Client.new }
-  let(:gio_btc_pair) { Cryptoexchange::Models::MarketPair.new(base: 'GIO', target: 'BTC', market: 'cezex') }
+  let(:gio_btc_pair) { Cryptoexchange::Models::MarketPair.new(base: 'GIO', target: 'BTC', market: 'lucent') }
 
   it 'fetch pairs' do
-    pairs = client.pairs('cezex')
+    pairs = client.pairs('lucent')
     expect(pairs).not_to be_empty
 
     pair = pairs.first
     expect(pair.base).not_to be_nil
     expect(pair.target).not_to be_nil
-    expect(pair.market).to eq 'cezex'
+    expect(pair.market).to eq 'lucent'
   end
 
   it 'fetch ticker' do
@@ -19,7 +19,7 @@ RSpec.describe 'Cezex integration specs' do
 
     expect(ticker.base).to eq 'GIO'
     expect(ticker.target).to eq 'BTC'
-    expect(ticker.market).to eq 'cezex'
+    expect(ticker.market).to eq 'lucent'
     expect(ticker.last).to be_a Numeric
     expect(ticker.bid).to be_a Numeric
     expect(ticker.ask).to be_a Numeric

--- a/spec/exchanges/lucent/market_spec.rb
+++ b/spec/exchanges/lucent/market_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Lucent::Market do
+  it { expect(described_class::NAME).to eq 'lucent' }
+  it { expect(described_class::API_URL).to eq 'https://lucent.exchange/api/v2' }
+end
+


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [ ] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
