### PR TITLE
fix vitex trade url

### DIFF
--- a/lib/cryptoexchange/exchanges/vitex/market.rb
+++ b/lib/cryptoexchange/exchanges/vitex/market.rb
@@ -5,7 +5,7 @@ module Cryptoexchange::Exchanges
       API_URL = 'https://vitex.vite.net/api/v1'
 
       def self.trade_page_url(args={})
-        "https://x.vite.net/trade"
+        "https://x.vite.net/trade?symbol=#{args[:inst_id]}"
       end
     end
   end

--- a/spec/exchanges/vitex/integration/market_spec.rb
+++ b/spec/exchanges/vitex/integration/market_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe 'Vitex integration specs' do
   end
 
   it 'give trade url' do
-    trade_page_url = client.trade_page_url 'vitex', base: "BTC", target: "USDT"
-    expect(trade_page_url).to eq "https://x.vite.net/trade"
+    trade_page_url = client.trade_page_url 'vitex', base: "BTC", target: "USDT", inst_id: "BTC-000_USDT-000"
+    expect(trade_page_url).to eq "https://x.vite.net/trade?symbol=BTC-000_USDT-000"
   end
 
   it 'fetch ticker' do


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [ ] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
