### PR TITLE
fix vitex trade link

### DIFF
--- a/lib/cryptoexchange/exchanges/vitex/services/market.rb
+++ b/lib/cryptoexchange/exchanges/vitex/services/market.rb
@@ -35,6 +35,7 @@ module Cryptoexchange::Exchanges
           ticker.base      = market_pair.base
           ticker.target    = market_pair.target
           ticker.market    = Vitex::Market::NAME
+          ticker.inst_id   = market_pair.inst_id
           ticker.last      = NumericHelper.to_d(output['closePrice'])
           ticker.volume    = NumericHelper.to_d(output['quantity'])
           ticker.change    = NumericHelper.to_d(output['priceChange'])


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [ ] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
