### PR TITLE
fix abcc link

### DIFF
--- a/lib/cryptoexchange/exchanges/abcc/market.rb
+++ b/lib/cryptoexchange/exchanges/abcc/market.rb
@@ -5,7 +5,7 @@ module Cryptoexchange::Exchanges
       API_URL = 'https://api.abcc.com/api/v2'
       class << self
         def trade_page_url(args = {})
-          "https://abcc.com/markets/#{args[:base]}#{args[:target]}"
+          "https://abcc.com/markets/#{args[:base].downcase}#{args[:target].downcase}"
         end
 
         def separate_symbol(pair)

--- a/spec/exchanges/abcc/integration/market_spec.rb
+++ b/spec/exchanges/abcc/integration/market_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Abcc integration specs' do
 
   it 'give trade url' do
     trade_page_url = client.trade_page_url 'abcc', base: ltc_btc_pair.base, target: ltc_btc_pair.target
-    expect(trade_page_url).to eq "https://abcc.com/markets/LTCBTC"
+    expect(trade_page_url).to eq "https://abcc.com/markets/ltcbtc"
   end
 
   it 'fetch ticker' do


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [ ] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
