### PR TITLE
update trade url bleutrade

### DIFF
--- a/lib/cryptoexchange/exchanges/bleutrade/market.rb
+++ b/lib/cryptoexchange/exchanges/bleutrade/market.rb
@@ -3,6 +3,10 @@ module Cryptoexchange::Exchanges
     class Market < Cryptoexchange::Models::Market
       NAME = 'bleutrade'
       API_URL = 'https://bleutrade.com/api/v2'
+
+      def self.trade_page_url(args={})
+        "https://bleutrade.com/en/trade/basic/#{args[:base].upcase}/#{args[:target].upcase}"
+      end
     end
   end
 end

--- a/spec/exchanges/bleutrade/integration/market_spec.rb
+++ b/spec/exchanges/bleutrade/integration/market_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe 'Bleutrade integration specs' do
     expect(pair.market).to eq 'bleutrade'
   end
 
+  it 'give trade url' do
+    trade_page_url = client.trade_page_url 'bleutrade', base: btc_adc_pair.base, target: btc_adc_pair.target
+    expect(trade_page_url).to eq "https://bleutrade.com/en/trade/basic/ADC/BTC"
+  end  
+
   it 'fetch pairs and assign the correct base/target' do
     pairs = client.pairs('bleutrade')
     expect(pairs).not_to be_empty


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [ ] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
