### PR TITLE
Fix NCOV trade page URL

### DIFF
--- a/lib/cryptoexchange/exchanges/saturn_network/market.rb
+++ b/lib/cryptoexchange/exchanges/saturn_network/market.rb
@@ -5,7 +5,7 @@ module Cryptoexchange::Exchanges
       API_URL = 'https://ticker.saturn.network'
 
       def self.trade_page_url(args={})
-        "https://www.saturn.network/exchange/#{args[:target]}/order-book/#{args[:base]}"
+        "https://www.saturn.network/exchange/#{args[:target]}/order-book/#{args[:base].split('-').last}"
       end
     end
   end


### PR DESCRIPTION
- What is the purpose of this Pull Request?
Fixup issue with [coronacoin's token page](https://www.coingecko.com/en/coins/coronacoin) leading to broken URL
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
Fixes https://github.com/coingecko/cryptoexchange/pull/2004
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [x] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
