### PR TITLE
Update saturn trade url

### DIFF
--- a/lib/cryptoexchange/exchanges/saturn_network/market.rb
+++ b/lib/cryptoexchange/exchanges/saturn_network/market.rb
@@ -5,7 +5,7 @@ module Cryptoexchange::Exchanges
       API_URL = 'https://ticker.saturn.network'
 
       def self.trade_page_url(args={})
-        "https://www.saturn.network/exchange/#{args[:target]}/order-book/#{args[:base].split('-').last}"
+        "https://www.saturn.network/exchange/#{args[:target]}/order-book/#{args[:base].split('-').first}"
       end
     end
   end


### PR DESCRIPTION
Yesterday's fix did not work due to weird renaming. Visually it looked like token's address was appended after a `-` symbol, but it sounds like you've appended `OX` instead of `0x`?

Going through token's ticker instead is a more robust approach. Confirmed it works for [NCOV](https://www.saturn.network/exchange/ETH/order-book/NCOV)


- What is the purpose of this Pull Request?
Fix NCOV trade url
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
https://github.com/coingecko/cryptoexchange/pull/2006
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [x] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
