### PR TITLE
[#hotfix] Kraken Futures contract interval to not use duration anymore

### DIFF
--- a/lib/cryptoexchange/exchanges/kraken_future/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/kraken_future/services/pairs.rb
@@ -16,13 +16,18 @@ module Cryptoexchange::Exchanges
 
               next if target != "USD"
               # skipping non USD pair because volume reported is mixed (some in base, some in target)
+              contract_interval = if output["tag"] == "perpetual"
+                "perpetual"
+              else
+                "futures"
+              end
 
               Cryptoexchange::Models::MarketPair.new(
                 base: base,
                 target: target,
                 inst_id: output["symbol"],
                 market: KrakenFutures::Market::NAME,
-                contract_interval: output["tag"],
+                contract_interval: contract_interval,
               )
             end
           end.compact

--- a/spec/exchanges/kraken_futures/integration/market_spec.rb
+++ b/spec/exchanges/kraken_futures/integration/market_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'kraken_futures integration specs' do
   let(:client) { Cryptoexchange::Client.new }
   let(:market) { 'kraken_futures' }
   let(:eth_usd_pair) { Cryptoexchange::Models::MarketPair.new(base: 'ETH', target: 'USD', inst_id: "PI_ETHUSD", market: 'kraken_futures', contract_interval: "perpetual") }
-  let(:eth_usd_futures_pair) { Cryptoexchange::Models::MarketPair.new(base: 'ETH', target: 'USD', inst_id: "FI_ETHUSD_191129", market: 'kraken_futures', contract_interval: "month") }
+  let(:eth_usd_futures_pair) { Cryptoexchange::Models::MarketPair.new(base: 'ETH', target: 'USD', inst_id: "FI_ETHUSD_191129", market: 'kraken_futures', contract_interval: "futures") }
 
   it 'fetch pairs' do
     pairs = client.pairs('kraken_futures')
@@ -15,7 +15,7 @@ RSpec.describe 'kraken_futures integration specs' do
     expect(pair.target).to_not be nil
     expect(pair.inst_id).to eq 'fi_ltcusd_191129'
     expect(pair.market).to eq 'kraken_futures'
-    expect(pair.contract_interval).to eq "month"
+    expect(pair.contract_interval).to eq "futures"
   end
 
   it 'give trade url' do


### PR DESCRIPTION
- What is the purpose of this Pull Request?
Kraken futures contract duration can vary as time goes by