### PR TITLE
implement btc mex

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,7 @@ Or install it yourself as:
 | Bitforex Futures  | Y | Y  | Y    |  Y  |  Y      | Y   |  Y  |       |      |    |    | Y  | Y   | N   |  bitforex_futures  |
 | Bitmex            | Y | Y  | Y    |  Y  |  Y      | Y   |  Y  |   Y   |   Y  | Y  | Y  | Y  | Y   | Y   |  bitmex  |
 | Bitz Futures      | Y | Y  | Y    |  Y  |  Y      | Y   |  Y  |       |      | N  | N  | N  | N   | Y   |  bitz_futures  |
+| Btcmex            | Y | X  | Y    |  Y  |  Y      | Y   |  Y  |       |      | N  | N  | Y  | Y   | Y   |  btcmex |
 | Bybit             | Y | Y  | Y    |  Y  |  Y      | Y   |  Y  |       |      | N  | N  | Y  | Y   | Y   |  bybit |
 | CME Futures       | Y | N  | Y    |  Y  |  N      | Y   |  N  |       |      | N  | Y  | N  | N   | N   |  cme_futures |
 | Coinflex Futures  | N | N  | Y    |  Y  |  N      | Y*  |  N  |       |      | N  | N  |    |     |     |  coinflex_futures  |

--- a/lib/cryptoexchange/exchanges/btcmex/market.rb
+++ b/lib/cryptoexchange/exchanges/btcmex/market.rb
@@ -1,0 +1,12 @@
+module Cryptoexchange::Exchanges
+  module Btcmex
+    class Market < Cryptoexchange::Models::Market
+      NAME = 'btcmex'
+      API_URL = 'https://www.btcmex.com/api/v1'
+
+      def self.trade_page_url(args={})
+        "https://www.btcmex.com/app/transaction/#{args[:base]}#{args[:target]}"
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/btcmex/services/contract_stat.rb
+++ b/lib/cryptoexchange/exchanges/btcmex/services/contract_stat.rb
@@ -1,0 +1,52 @@
+module Cryptoexchange::Exchanges
+  module Btcmex
+    module Services
+      class ContractStat < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            false
+          end
+        end
+
+        def fetch
+          contract_stat_data = super(ticker_url)
+          adapt_all(contract_stat_data)
+        end
+
+        def adapt_all(output)
+          output.map do |pair, ticker|
+            adapt(pair, ticker)
+          end
+        end
+
+        def ticker_url
+          "#{Cryptoexchange::Exchanges::Btcmex::Market::API_URL}/ticker"
+        end
+
+
+        def adapt(pair, ticker)
+          contract_stat = Cryptoexchange::Models::ContractStat.new
+          contract_stat.base      = pair.split("USD")[0]
+          contract_stat.target    = "USD"
+          contract_stat.market    = Btcmex::Market::NAME
+          contract_stat.index     = ticker["indexPrice"]
+          contract_stat.index_identifier = nil
+          contract_stat.index_name = nil
+
+          contract_stat.payload   = [pair, ticker]
+          contract_stat.expire_timestamp = nil
+
+          contract_stat.start_timestamp = nil
+          contract_stat.contract_type = "perpetual"
+
+          contract_stat.open_interest = ticker["openInterest"]
+          contract_stat.funding_rate_percentage = ticker["fundingRate"] * 100
+          contract_stat.next_funding_rate_timestamp = nil
+          contract_stat.funding_rate_percentage_predicted = nil
+
+          contract_stat
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/btcmex/services/market.rb
+++ b/lib/cryptoexchange/exchanges/btcmex/services/market.rb
@@ -1,0 +1,42 @@
+module Cryptoexchange::Exchanges
+  module Btcmex
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            false
+          end
+        end
+
+        def fetch
+          output = super(ticker_url)
+          adapt_all(output)
+        end
+
+        def ticker_url
+          "#{Cryptoexchange::Exchanges::Btcmex::Market::API_URL}/ticker"
+        end
+
+        def adapt_all(output)
+          output.map do |pair, ticker|
+            adapt(pair, ticker)
+          end
+        end
+
+        def adapt(pair, output)
+          base, target     = pair.split("USD")[0], "USD"
+          ticker           = Cryptoexchange::Models::Ticker.new
+          ticker.inst_id   = pair
+          ticker.contract_interval = "perpetual"
+          ticker.base      = base
+          ticker.target    = target
+          ticker.market    = Btcmex::Market::NAME
+          ticker.last      = NumericHelper.to_d(output['lastPrice'])
+          ticker.volume    = NumericHelper.to_d(output['baseVolume'])
+          ticker.payload   = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/btcmex/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/btcmex/services/pairs.rb
@@ -1,0 +1,24 @@
+module Cryptoexchange::Exchanges
+  module Btcmex
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Btcmex::Market::API_URL}/ticker"
+
+        def fetch
+          output = super
+          market_pairs = []
+          output.each do |pair, _ticker|
+            market_pairs << Cryptoexchange::Models::MarketPair.new(
+                              base: pair.split("USD")[0],
+                              target: "USD",
+                              inst_id: pair,
+                              contract_interval: "perpetual",
+                              market: Btcmex::Market::NAME
+                            )
+          end
+          market_pairs
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/Btcmex/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/Btcmex/integration_specs_fetch_pairs.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://www.btcmex.com/api/v1/ticker
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - www.btcmex.com
+      User-Agent:
+      - http.rb/5.0.0.pre
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 27 Mar 2020 08:44:06 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Server:
+      - nginx
+      Vary:
+      - Accept-Encoding
+      X-Xss-Protection:
+      - 1; mode=block
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - master-only
+      Referrer-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"XBTUSD":{"baseId":1,"quoteId":825,"lastPrice":6705.5,"quoteVolume":9729842,"baseVolume":1464.60410703,"isFrozen":0,"indexPrice":6711.12,"openInterest":2335983,"fundingRate":0.000100}}'
+    http_version: 
+  recorded_at: Fri, 27 Mar 2020 08:44:06 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/btcmex/integration/market_spec.rb
+++ b/spec/exchanges/btcmex/integration/market_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+RSpec.describe 'Btcmex integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:btc_usdt_pair) { Cryptoexchange::Models::MarketPair.new(base: 'XBT', target: 'USD', inst_id: 'XBTUSD', contract_interval: 'perpetual', market: 'btcmex') }
+
+  it 'fetch pairs' do
+    pairs = client.pairs('btcmex')
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.contract_interval).to eq 'perpetual'
+    expect(pair.inst_id).to eq 'XBTUSD'
+    expect(pair.market).to eq 'btcmex'
+  end
+
+  it 'give trade url' do
+    trade_page_url = client.trade_page_url 'btcmex', base: btc_usdt_pair.base, target: btc_usdt_pair.target, inst_id: btc_usdt_pair.inst_id
+    expect(trade_page_url).to eq "https://www.btcmex.com/app/transaction/XBTUSD"
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(btc_usdt_pair)
+
+    expect(ticker.base).to eq 'XBT'
+    expect(ticker.target).to eq 'USD'
+    expect(ticker.market).to eq 'btcmex'
+    expect(ticker.inst_id).to eq 'XBTUSD'
+    expect(ticker.contract_interval).to eq 'perpetual'
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+    expect(ticker.timestamp).to be nil
+
+    expect(ticker.payload).to_not be nil
+  end
+
+  context 'fetch contract stat' do
+    it 'fetch contract stat' do
+      contract_stat = client.contract_stat(btc_usdt_pair)
+
+      expect(contract_stat.base).to eq 'XBT'
+      expect(contract_stat.target).to eq 'USD'
+      expect(contract_stat.market).to eq 'btcmex'
+      expect(contract_stat.index).to be_a Numeric
+      expect(contract_stat.index_identifier).to be nil
+      expect(contract_stat.index_name).to be nil
+      expect(contract_stat.open_interest).to be_a Numeric
+      expect(contract_stat.timestamp).to be nil
+
+      expect(contract_stat.payload).to_not be nil
+    end
+
+    it 'fetch perpetual contract details' do
+      contract_stat = client.contract_stat(btc_usdt_pair)
+
+      expect(contract_stat.expire_timestamp).to be nil
+      expect(contract_stat.start_timestamp).to be nil
+      expect(contract_stat.contract_type).to eq 'perpetual'
+      expect(contract_stat.funding_rate_percentage).to be_a Numeric
+      expect(contract_stat.funding_rate_percentage_predicted).to be nil
+    end
+  end
+end

--- a/spec/exchanges/btcmex/market_spec.rb
+++ b/spec/exchanges/btcmex/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::Btcmex::Market do
+  it { expect(described_class::NAME).to eq 'btcmex' }
+  it { expect(described_class::API_URL).to eq 'https://www.btcmex.com/api/v1' }
+end


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [x] I have added Specs
- [x] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [x] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [x] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [x] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
