### PR TITLE
add bitmax futures

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,7 @@ Or install it yourself as:
 | Bitflyer Futures  | Y | Y  | Y    |  Y  |  N      | Y   |  N  |       |      | N  | N  |    |     |     |  bitflyer_futures  |
 | Bitfinex Futures  | Y | Y  | Y    |     |  Y      | Y   |  Y  |       |      | N  | N  | Y  | Y   |     |  bitfinex_futures  |
 | Bitforex Futures  | Y | Y  | Y    |  Y  |  Y      | Y   |  Y  |       |      |    |    | Y  | Y   | N   |  bitforex_futures  |
+| Bitmax.IO Futures | Y | Y  | Y    |  Y  |  Y      | Y   |  Y  |       |      |    |    |    | Y   | N   |  bitmax_futures  |
 | Bitmex            | Y | Y  | Y    |  Y  |  Y      | Y   |  Y  |   Y   |   Y  | Y  | Y  | Y  | Y   | Y   |  bitmex  |
 | Bitz Futures      | Y | Y  | Y    |  Y  |  Y      | Y   |  Y  |       |      | N  | N  | N  | N   | Y   |  bitz_futures  |
 | Btcmex            | Y | X  | Y    |  Y  |  Y      | Y   |  Y  |       |      | N  | N  | Y  | Y   | Y   |  btcmex |

--- a/lib/cryptoexchange/exchanges/bitmax_futures/market.rb
+++ b/lib/cryptoexchange/exchanges/bitmax_futures/market.rb
@@ -1,0 +1,12 @@
+module Cryptoexchange::Exchanges
+  module BitmaxFutures
+    class Market < Cryptoexchange::Models::Market
+      NAME = 'bitmax_futures'
+      API_URL = 'https://bitmax.io/api/pro/v1'
+
+      def self.trade_page_url(args={})
+        "https://bitmax.io/#/futures/#{args[:inst_id].downcase}"
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/bitmax_futures/services/contract_stat.rb
+++ b/lib/cryptoexchange/exchanges/bitmax_futures/services/contract_stat.rb
@@ -1,0 +1,40 @@
+module Cryptoexchange::Exchanges
+  module BitmaxFutures
+    module Services
+      class ContractStat < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          "https://bitmax.io/api/pro/futures/market-data?symbol=#{market_pair.inst_id}"
+        end
+
+        def adapt(output, market_pair)
+          output = output["data"]
+          contract_stat = Cryptoexchange::Models::ContractStat.new
+
+          contract_stat.base          = market_pair.base
+          contract_stat.target        = market_pair.target
+          contract_stat.contract_type = "perpetual"
+          contract_stat.market        = BitmaxFutures::Market::NAME
+
+          contract_stat.open_interest = NumericHelper.to_d output["openInterest"]
+          contract_stat.index         = NumericHelper.to_d output["indexPrice"]
+          contract_stat.funding_rate_percentage = NumericHelper.to_d(output["fundingRate"]) * 100
+          contract_stat.next_funding_rate_timestamp = output["nextFundingPaymentTime"].to_i / 1000
+          contract_stat.payload       = output
+
+          contract_stat
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/bitmax_futures/services/market.rb
+++ b/lib/cryptoexchange/exchanges/bitmax_futures/services/market.rb
@@ -1,0 +1,41 @@
+module Cryptoexchange::Exchanges
+  module BitmaxFutures
+    module Services
+      class Market < Cryptoexchange::Services::Market
+        class << self
+          def supports_individual_ticker_query?
+            true
+          end
+        end
+
+        def fetch(market_pair)
+          output = super ticker_url(market_pair)
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          "#{Cryptoexchange::Exchanges::BitmaxFutures::Market::API_URL}/ticker?symbol=#{market_pair.inst_id}"
+        end
+
+        def adapt(output, market_pair)
+          ticker                   = Cryptoexchange::Models::Ticker.new
+          ticker.base              = market_pair.base
+          ticker.target            = market_pair.target
+          ticker.contract_interval = market_pair.contract_interval
+          ticker.inst_id           = market_pair.inst_id
+          ticker.market            = BitmaxFutures::Market::NAME
+
+          ticker.bid               = NumericHelper.to_d(output['data']['bid'][0])
+          ticker.ask               = NumericHelper.to_d(output['data']['ask'][0])
+          ticker.last              = NumericHelper.to_d(output['data']['close'])
+          ticker.volume            = NumericHelper.to_d(output['data']['volume'])
+          ticker.high              = NumericHelper.to_d(output['data']['high'])
+          ticker.low               = NumericHelper.to_d(output['data']['low'])
+          ticker.timestamp         = nil
+          ticker.payload           = output
+          ticker
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/bitmax_futures/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/bitmax_futures/services/pairs.rb
@@ -1,0 +1,27 @@
+module Cryptoexchange::Exchanges
+  module BitmaxFutures
+    module Services
+      class Pairs < Cryptoexchange::Services::Pairs
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::BitmaxFutures::Market::API_URL}/ticker?symbol=BTC-PERP"
+
+        def fetch
+          output = super
+          adapt(output)
+        end
+
+        def adapt(output)
+          market_pairs = []
+          base, target = output["data"]["symbol"].split('-')
+          market_pairs << Cryptoexchange::Models::MarketPair.new(
+            base: base,
+            target: "USDT",
+            contract_interval: "perpetual",
+            inst_id: output["data"]["symbol"],
+            market: BitmaxFutures::Market::NAME
+          )
+          market_pairs
+        end
+      end
+    end
+  end
+end

--- a/lib/cryptoexchange/exchanges/bitmax_futures/services/trades.rb
+++ b/lib/cryptoexchange/exchanges/bitmax_futures/services/trades.rb
@@ -1,0 +1,32 @@
+module Cryptoexchange::Exchanges
+  module BitmaxFutures
+    module Services
+      class Trades < Cryptoexchange::Services::Market
+        def fetch(market_pair)
+          output = super(ticker_url(market_pair))
+          adapt(output, market_pair)
+        end
+
+        def ticker_url(market_pair)
+          "#{Cryptoexchange::Exchanges::BitmaxFutures::Market::API_URL}/trades?symbol=#{market_pair.inst_id}"
+        end
+
+        def adapt(output, market_pair)
+          output['data']['data'].collect do |trade|
+            tr = Cryptoexchange::Models::Trade.new
+            tr.trade_id  = trade['seqnum']
+            tr.base      = market_pair.base
+            tr.target    = market_pair.target
+            tr.market    = BitmaxFutures::Market::NAME
+            tr.type      = trade['bm'] == true ? 'sell' : 'buy'
+            tr.price     = trade['p']
+            tr.amount    = trade['q']
+            tr.timestamp = trade['ts'].to_i / 1000
+            tr.payload   = trade
+            tr
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/vcr_cassettes/BitmaxFutures/integration_specs_fetch_contract_stat_fetch_contract_stat.yml
+++ b/spec/cassettes/vcr_cassettes/BitmaxFutures/integration_specs_fetch_contract_stat_fetch_contract_stat.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://bitmax.io/api/pro/futures/market-data?symbol=BTC-PERP
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - bitmax.io
+      User-Agent:
+      - http.rb/5.0.0.pre
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 31 Mar 2020 06:58:52 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '237'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=db0832530e342e959cd4e168425c746eb1585637932; expires=Thu, 30-Apr-20
+        06:58:52 GMT; path=/; domain=.bitmax.io; HttpOnly; SameSite=Lax; Secure
+      Instance:
+      - 0-_-5
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 57c82f37bdecdcc2-SIN
+    body:
+      encoding: ASCII-8BIT
+      string: '{"code":0,"data":{"symbol":"BTC-PERP","openInterest":"75.4992","sourceTime":1585637886156,"fundingRate":"0.000167436","fundingPaymentFlag":false,"nextFundingPaymentTime":1585612800000,"indexPrice":"6461.53","markPrice":"6462.611897076"}}'
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 06:58:53 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/BitmaxFutures/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/BitmaxFutures/integration_specs_fetch_pairs.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://bitmax.io/api/pro/v1/ticker?symbol=BTC-PERP
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - bitmax.io
+      User-Agent:
+      - http.rb/5.0.0.pre
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 31 Mar 2020 06:58:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '181'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d5030f08c078affdf134edc84ba51f65e1585637930; expires=Thu, 30-Apr-20
+        06:58:50 GMT; path=/; domain=.bitmax.io; HttpOnly; SameSite=Lax; Secure
+      Instance:
+      - 0-_-4
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 57c82f2acec4d9d0-SIN
+    body:
+      encoding: ASCII-8BIT
+      string: '{"code":0,"data":{"symbol":"BTC-PERP","open":"6194.75","close":"6452.75","high":"6596.75","low":"6208.25","volume":"326.1955","ask":["6459.25","0.2585"],"bid":["6457.25","1.2528"]}}'
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 06:58:50 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/BitmaxFutures/integration_specs_fetch_trade.yml
+++ b/spec/cassettes/vcr_cassettes/BitmaxFutures/integration_specs_fetch_trade.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://bitmax.io/api/pro/v1/trades?symbol=BTC-PERP
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - bitmax.io
+      User-Agent:
+      - http.rb/5.0.0.pre
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 31 Mar 2020 06:58:51 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '911'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=d3150b866c73e9021e3f6723c9c1e3dfb1585637931; expires=Thu, 30-Apr-20
+        06:58:51 GMT; path=/; domain=.bitmax.io; HttpOnly; SameSite=Lax; Secure
+      Instance:
+      - 7-_-5
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 57c82f31084bddab-SIN
+    body:
+      encoding: ASCII-8BIT
+      string: '{"code":0,"data":{"m":"trades","symbol":"BTC-PERP","data":[{"p":"6448","q":"0.7346","ts":1585637665279,"bm":false,"seqnum":180143985142055710},{"p":"6450.75","q":"0.0050","ts":1585637715101,"bm":false,"seqnum":180143985142056490},{"p":"6450","q":"0.3454","ts":1585637717099,"bm":false,"seqnum":180143985142056524},{"p":"6450","q":"0.0050","ts":1585637718797,"bm":false,"seqnum":180143985142056551},{"p":"6449.75","q":"0.0030","ts":1585637728946,"bm":false,"seqnum":180143985142056684},{"p":"6450","q":"0.0020","ts":1585637739346,"bm":false,"seqnum":180143985142056847},{"p":"6449","q":"0.3454","ts":1585637745860,"bm":false,"seqnum":180143985142056988},{"p":"6449","q":"0.0010","ts":1585637746786,"bm":false,"seqnum":180143985142057003},{"p":"6449","q":"0.1138","ts":1585637757520,"bm":false,"seqnum":180143985142057136},{"p":"6452.75","q":"0.34490","ts":1585637787383,"bm":false,"seqnum":180143985142057600}]}}'
+    http_version: 
+  recorded_at: Tue, 31 Mar 2020 06:58:51 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/bitmax_futures/integration/market_spec.rb
+++ b/spec/exchanges/bitmax_futures/integration/market_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+RSpec.describe 'BitmaxFutures integration specs' do
+  let(:client) { Cryptoexchange::Client.new }
+  let(:market) { 'bitmax_futures' }
+  let(:btc_usdt_pair) { Cryptoexchange::Models::MarketPair.new(base: 'BTC', target: 'USDT', market: market, inst_id: "BTC-PERP", contract_interval: "perpetual") }
+
+  it 'fetch pairs' do
+    pairs = client.pairs(market)
+    expect(pairs).not_to be_empty
+
+    pair = pairs.first
+    expect(pair.base).to_not be nil
+    expect(pair.target).to_not be nil
+    expect(pair.market).to eq market
+  end
+
+  it 'give trade url' do
+    trade_page_url = client.trade_page_url market, inst_id: btc_usdt_pair.inst_id
+    expect(trade_page_url).to eq "https://bitmax.io/#/futures/btc-perp"
+  end
+
+  it 'fetch ticker' do
+    ticker = client.ticker(btc_usdt_pair)
+
+    expect(ticker.base).to eq 'BTC'
+    expect(ticker.target).to eq 'USDT'
+    expect(ticker.market).to eq market
+    expect(ticker.last).to be_a Numeric
+    expect(ticker.ask).to be_a Numeric
+    expect(ticker.bid).to be_a Numeric
+    expect(ticker.low).to be_a Numeric
+    expect(ticker.high).to be_a Numeric
+    expect(ticker.volume).to be_a Numeric
+    expect(ticker.timestamp).to be nil
+    
+    expect(ticker.payload).to_not be nil
+  end
+
+  it 'fetch trade' do
+    trades = client.trades(btc_usdt_pair)
+    trade = trades.sample
+
+    expect(trades).to_not be_empty
+    expect(trade.base).to eq 'BTC'
+    expect(trade.target).to eq 'USDT'
+    expect(trade.market).to eq market
+    expect(trade.trade_id).to_not be_nil
+    expect(['buy', 'sell']).to include trade.type
+    expect(trade.price).to_not be_nil
+    expect(trade.amount).to_not be_nil
+    expect(trade.timestamp).to be_a Numeric
+    expect(trade.payload).to_not be nil
+  end
+
+
+  context 'fetch contract stat' do
+    it 'fetch contract stat' do
+      contract_stat = client.contract_stat(btc_usdt_pair)
+
+      expect(contract_stat.base).to eq 'BTC'
+      expect(contract_stat.target).to eq 'USDT'
+      expect(contract_stat.market).to eq market
+      expect(contract_stat.index).to be_a Numeric
+      expect(contract_stat.index_identifier).to be nil
+      expect(contract_stat.index_name).to be nil
+      expect(contract_stat.open_interest).to be_a Numeric
+      expect(contract_stat.timestamp).to be nil
+
+      expect(contract_stat.payload).to_not be nil
+    end
+
+    it 'fetch perpetual contract details' do
+      contract_stat = client.contract_stat(btc_usdt_pair)
+
+      expect(contract_stat.expire_timestamp).to be nil
+      expect(contract_stat.start_timestamp).to be nil
+      expect(contract_stat.contract_type).to eq 'perpetual'
+      expect(contract_stat.funding_rate_percentage).to be_a Numeric
+      expect(2018..Date.today.year).to include(Time.at(contract_stat.next_funding_rate_timestamp).year)
+      expect(contract_stat.funding_rate_percentage_predicted).to be nil
+    end
+  end
+end

--- a/spec/exchanges/bitmax_futures/market_spec.rb
+++ b/spec/exchanges/bitmax_futures/market_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+RSpec.describe Cryptoexchange::Exchanges::BitmaxFutures::Market do
+  it { expect(described_class::NAME).to eq 'bitmax_futures' }
+  it { expect(described_class::API_URL).to eq 'https://bitmax.io/api/pro/v1' }
+end


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [ ] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
