### PR TITLE
fix dex blue decimal

### DIFF
--- a/lib/cryptoexchange/exchanges/dex_blue/market.rb
+++ b/lib/cryptoexchange/exchanges/dex_blue/market.rb
@@ -7,6 +7,12 @@ module Cryptoexchange::Exchanges
       def self.trade_page_url(args={})
         "https://dex.blue/trading/##{args[:base]}/#{args[:target]}"
       end
+
+      def self.get_decimal(base)
+        output = JSON.parse(HTTP.get("https://api.dex.blue/rest/v1/listed"))
+        decimal = output["data"]["tokens"]["#{base}"]["decimals"].to_i
+        10 ** decimal
+      end 
     end
   end
 end

--- a/lib/cryptoexchange/exchanges/dex_blue/services/trades.rb
+++ b/lib/cryptoexchange/exchanges/dex_blue/services/trades.rb
@@ -13,6 +13,7 @@ module Cryptoexchange::Exchanges
 
         def adapt(output, market_pair)
           output['data']['trades'].collect do |trade|
+            decimal = Cryptoexchange::Exchanges::DexBlue::Market.get_decimal(market_pair.base)
             tr = Cryptoexchange::Models::Trade.new
             tr.trade_id  = trade['id']
             tr.base      = market_pair.base
@@ -20,7 +21,7 @@ module Cryptoexchange::Exchanges
             tr.market    = DexBlue::Market::NAME
             tr.type      = trade['direction'].downcase
             tr.price     = NumericHelper.to_d trade['rate']
-            tr.amount    = NumericHelper.to_d(trade['amount']) / 1000000000000000000
+            tr.amount    = NumericHelper.to_d(trade['amount']) / decimal
             tr.timestamp = trade['timestamp'].to_i / 1000
             tr.payload   = trade
             tr


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [ ] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
