### PR TITLE
[#hotfix] Fix bitfinex orderbook using inst_id

### DIFF
--- a/lib/cryptoexchange/exchanges/bitfinex/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/bitfinex/services/order_book.rb
@@ -14,7 +14,7 @@ module Cryptoexchange::Exchanges
         end
 
         def order_book_url(market_pair)
-          "#{Cryptoexchange::Exchanges::Bitfinex::Market::API_URL}/book/t#{market_pair.base.upcase}#{market_pair.target.upcase}/P2?len=100"
+          "#{Cryptoexchange::Exchanges::Bitfinex::Market::API_URL}/book/#{market_pair.inst_id}/P2?len=100"
         end
 
         def adapt(output, market_pair)

--- a/lib/cryptoexchange/exchanges/bitfinex/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/bitfinex/services/pairs.rb
@@ -25,7 +25,8 @@ module Cryptoexchange::Exchanges
             Cryptoexchange::Models::MarketPair.new(
               base: base,
               target: target,
-              market: Bitfinex::Market::NAME
+              market: Bitfinex::Market::NAME,
+              inst_id: pair,
             )
           end.compact
         end

--- a/spec/exchanges/bitfinex/integration/market_spec.rb
+++ b/spec/exchanges/bitfinex/integration/market_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe 'Bitfinex integration specs' do
   client = Cryptoexchange::Client.new
-  let(:btc_usd_pair) { Cryptoexchange::Models::MarketPair.new(base: 'BTC', target: 'USD', market: 'bitfinex') }
+  let(:btc_usd_pair) { Cryptoexchange::Models::MarketPair.new(base: 'BTC', target: 'USD', market: 'bitfinex', inst_id: "tBTCUSD") }
 
   it 'fetch pairs' do
     pairs = client.pairs('bitfinex')


### PR DESCRIPTION
- What is the purpose of this Pull Request?
inst_id is needed to pass into orderbook API endpoint