### PR TITLE
independent reserve volume divided by 3

### DIFF
--- a/lib/cryptoexchange/exchanges/independent_reserve/services/market.rb
+++ b/lib/cryptoexchange/exchanges/independent_reserve/services/market.rb
@@ -2,6 +2,9 @@ module Cryptoexchange::Exchanges
   module IndependentReserve
     module Services
       class Market < Cryptoexchange::Services::Market
+        # this exchange share the volume across 3 fiat, need divide the volume by 3
+        FIAT_SHARED_VOLUME = 3
+
         class << self
           def supports_individual_ticker_query?
             true
@@ -30,7 +33,7 @@ module Cryptoexchange::Exchanges
           ticker.last      = NumericHelper.to_d(output['LastPrice'])
           ticker.high      = NumericHelper.to_d(output['DayHighestPrice'])
           ticker.low       = NumericHelper.to_d(output['DayLowestPrice'])
-          ticker.volume    = NumericHelper.to_d(output["DayVolumeXbt"])
+          ticker.volume    = NumericHelper.to_d(output["DayVolumeXbt"]) / FIAT_SHARED_VOLUME
           ticker.timestamp = nil
           ticker.payload   = output
           ticker


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [ ] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
