### PR TITLE
fix okex_swap spec

### DIFF
--- a/lib/cryptoexchange/exchanges/okex_swap/services/contract_stat.rb
+++ b/lib/cryptoexchange/exchanges/okex_swap/services/contract_stat.rb
@@ -37,7 +37,7 @@ module Cryptoexchange::Exchanges
         def get_underlying_index(market_pair)
           instrument_info = if market_pair.contract_interval == "perpetual"
                           HTTP.get(SWAP_URL).parse(:json)
-                        elsif market_pair.contract_interval == "futures"
+                        elsif "futures"
                           HTTP.get(FUTURES_URL).parse(:json)
                         end
           instrument_info = instrument_info.find { |i| i["instrument_id"] == market_pair.inst_id }


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [ ] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
