### PR TITLE
[#ErrorHandling] Unmatched and unparsable response - raise ResultPars…

### DIFF
--- a/lib/cryptoexchange/client.rb
+++ b/lib/cryptoexchange/client.rb
@@ -33,12 +33,17 @@ module Cryptoexchange
         market.fetch(market_pair)
       else
         tickers = market.fetch
-        tickers.find do |t|
+        ticker = tickers.find do |t|
           if t.inst_id.nil? || t.inst_id == ""
             (t.base.casecmp(market_pair.base) == 0 && t.target.casecmp(market_pair.target) == 0)
           else
             (t.inst_id.casecmp(market_pair.inst_id) == 0 )
           end
+        end
+        if ticker.nil?
+          raise Cryptoexchange::ResultParseError, { response: nil }
+        else
+          ticker
         end
       end
     end

--- a/lib/cryptoexchange/exchanges/huobi/services/market.rb
+++ b/lib/cryptoexchange/exchanges/huobi/services/market.rb
@@ -23,6 +23,7 @@ module Cryptoexchange::Exchanges
         end
 
         def adapt(output, market_pair)
+          handle_invalid(output)
           market = output['tick']
 
           ticker           = Cryptoexchange::Models::Ticker.new
@@ -38,6 +39,12 @@ module Cryptoexchange::Exchanges
           ticker.timestamp = nil
           ticker.payload   = market
           ticker
+        end
+
+        def handle_invalid(output)
+          if output['status'] == "error"
+            raise Cryptoexchange::ResultParseError, { response: output }
+          end
         end
       end
     end


### PR DESCRIPTION
- Universal handling for exchange with supports_individual_ticker_query? == false
- Added Huobi parse handling for supports_individual_ticker_query?


**- What is the purpose of this Pull Request?**
When there is unmatched unparasable response for supports_individual_ticker_query == false exchange, it will raise ResultParseError exception