### PR TITLE
[#hotfix] Workaround for Hoo, when 200 response getting cached

### DIFF
--- a/lib/cryptoexchange/cache.rb
+++ b/lib/cryptoexchange/cache.rb
@@ -31,5 +31,17 @@ module Cryptoexchange
         end
       end
     end
+
+    def delete(cache_key)
+      if @cache_instance.class.ancestors.to_s.include? "ActiveSupport::Cache::Store"
+        @cache_instance.send(:delete, cache_key, { expires_in: Cryptoexchange.configuration.ticker_ttl }) do
+          block.call
+        end
+      else
+        @cache_instance.send(:delete, cache_key) do
+          block.call
+        end
+      end
+    end
   end
 end

--- a/lib/cryptoexchange/exchanges/hoo/services/market.rb
+++ b/lib/cryptoexchange/exchanges/hoo/services/market.rb
@@ -10,6 +10,13 @@ module Cryptoexchange::Exchanges
 
         def fetch
           output = super ticker_url
+          # Workaround for Hoo
+          # Handling error response 200 getting cached
+          # if error, clear the cache and bail out
+          if output['code'] == 1
+            Cryptoexchange::Cache.ticker_cache.delete(ticker_url)
+            raise Cryptoexchange::ResultParseError, { response: output }
+          end
           adapt_all(output)
         end
 


### PR DESCRIPTION
- What is the purpose of this Pull Request?
Hoo response an error with a 200 when it hits rate limit
which makes it a valid response to be cached
causing other reference to get stuck due to reading an invalid cache response

this is a workaround until an elegant solution is found