### PR TITLE
add missing paramters for dydx perpetual market pairs.

### DIFF
--- a/lib/cryptoexchange/exchanges/dydx_perpetual/market.rb
+++ b/lib/cryptoexchange/exchanges/dydx_perpetual/market.rb
@@ -5,13 +5,7 @@ module Cryptoexchange::Exchanges
       API_URL = 'https://api.dydx.exchange/v1'
 
       def self.trade_page_url(args={})
-        base = if args[:base] == "PBTC"
-          "BTC"
-        else
-          args[:base]
-        end
-
-        "https://trade.dydx.exchange/perpetual/#{base}-#{args[:target]}"
+        "https://trade.dydx.exchange/perpetual/#{args[:inst_id]}"
       end
     end
   end

--- a/lib/cryptoexchange/exchanges/dydx_perpetual/services/contract_stat.rb
+++ b/lib/cryptoexchange/exchanges/dydx_perpetual/services/contract_stat.rb
@@ -14,7 +14,7 @@ module Cryptoexchange::Exchanges
         end
 
         def contract_info_url(market_pair)
-          "#{Cryptoexchange::Exchanges::DydxPerpetual::Market::API_URL}/perpetual-markets/#{market_pair.base}-#{market_pair.target}"
+          "#{Cryptoexchange::Exchanges::DydxPerpetual::Market::API_URL}/perpetual-markets/#{market_pair.inst_id}"
         end
 
         def adapt(market_pair, contract_info)

--- a/lib/cryptoexchange/exchanges/dydx_perpetual/services/market.rb
+++ b/lib/cryptoexchange/exchanges/dydx_perpetual/services/market.rb
@@ -17,14 +17,26 @@ module Cryptoexchange::Exchanges
           "#{Cryptoexchange::Exchanges::DydxPerpetual::Market::API_URL}/stats/markets"
         end
 
+        def get_base(base)
+          if base == "PBTC"
+            return "BTC"
+          end
+
+          base
+        end
+
         def adapt_all(output)
           output["markets"].map do |ticker, value|
             next if value["type"] != "PERPETUAL"
 
             base, target = ticker.split('-')
+            converted_base = get_base(base)
+
             market_pair = Cryptoexchange::Models::MarketPair.new(
-              base: base,
+              base: converted_base,
               target: target,
+              contract_interval: "perpetual",
+              inst_id: value["symbol"],
               market: DydxPerpetual::Market::NAME
             )
             adapt(value, market_pair)

--- a/lib/cryptoexchange/exchanges/dydx_perpetual/services/order_book.rb
+++ b/lib/cryptoexchange/exchanges/dydx_perpetual/services/order_book.rb
@@ -14,7 +14,7 @@ module Cryptoexchange::Exchanges
         end
 
         def ticker_url(market_pair)
-          "#{Cryptoexchange::Exchanges::Dydx::Market::API_URL}/orderbook/#{market_pair.base}-#{market_pair.target}"
+          "#{Cryptoexchange::Exchanges::Dydx::Market::API_URL}/orderbook/#{market_pair.inst_id}"
         end
 
         def adapt(output, market_pair)

--- a/lib/cryptoexchange/exchanges/dydx_perpetual/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/dydx_perpetual/services/pairs.rb
@@ -17,6 +17,8 @@ module Cryptoexchange::Exchanges
             Cryptoexchange::Models::MarketPair.new(
               base:   base,
               target: target,
+              inst_id: value["symbol"],
+              contract_interval: "perpetual",
               market: DydxPerpetual::Market::NAME
             )
           end.compact

--- a/lib/cryptoexchange/exchanges/dydx_perpetual/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/dydx_perpetual/services/pairs.rb
@@ -9,13 +9,22 @@ module Cryptoexchange::Exchanges
           adapt(output)
         end
 
+        def get_base(base)
+          if base == "PBTC"
+            return "BTC"
+          end
+
+          base
+        end
+
         def adapt(output)
           output['markets'].map do |pair, value|
             next if value["type"] != "PERPETUAL"
 
             base, target = pair.split("-")
+            converted_base = get_base(base)
             Cryptoexchange::Models::MarketPair.new(
-              base:   base,
+              base:   converted_base,
               target: target,
               inst_id: value["symbol"],
               contract_interval: "perpetual",

--- a/spec/cassettes/vcr_cassettes/DydxPerpetual/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/DydxPerpetual/integration_specs_fetch_pairs.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.dydx.exchange/v1/stats/markets
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - api.dydx.exchange
+      User-Agent:
+      - http.rb/5.0.0.pre
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Jun 2020 06:19:39 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '859'
+      Connection:
+      - close
+      Set-Cookie:
+      - __cfduid=db006d90dfebd73b32371478bb157c1bb1591251579; expires=Sat, 04-Jul-20
+        06:19:39 GMT; path=/; domain=.dydx.exchange; HttpOnly; SameSite=Lax; Secure
+      X-Powered-By:
+      - Express
+      X-Request-Id:
+      - b7813318-8e79-4b78-bb8f-592027b96016
+      Access-Control-Allow-Origin:
+      - "*"
+      Surrogate-Control:
+      - no-store
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, proxy-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Etag:
+      - W/"35b-Nw7iyKz2IwL4HAwQHjDn935Vi7A"
+      X-Response-Time:
+      - '1.019'
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Request-Id:
+      - 031f954a1300007554220b0200000001
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 59df8b235f717554-KUL
+    body:
+      encoding: UTF-8
+      string: '{"markets":{"ETH-DAI":{"symbol":"ETH-DAI","low":"235.7300","high":"246.0000","open":"236.4900","last":"242.0200","count":"362","baseVolume":"4066.1717","quoteVolume":"982509.5414","usdVolume":"982509.5414","type":"SPOT"},"ETH-USDC":{"symbol":"ETH-USDC","low":"236.9700","high":"246.5400","open":"237.0000","last":"243.2100","count":"430","baseVolume":"9164.8429","quoteVolume":"2212495.3949","usdVolume":"2212495.3949","type":"SPOT"},"DAI-USDC":{"symbol":"DAI-USDC","low":"1.0018","high":"1.0034","open":"1.0018","last":"1.0034","count":"24","baseVolume":"108072.9814","quoteVolume":"108285.1441","usdVolume":"108285.1441","type":"SPOT"},"PBTC-USDC":{"symbol":"PBTC-USDC","low":"9527.0000","high":"9674.0000","open":"9527.0000","last":"9640.0000","count":"104","baseVolume":"69.5195","quoteVolume":"668923.8477","usdVolume":"668923.8477","type":"PERPETUAL"}}}'
+    http_version: 
+  recorded_at: Thu, 04 Jun 2020 06:19:39 GMT
+recorded_with: VCR 4.0.0

--- a/spec/exchanges/dydx_perpetual/integration/market_spec.rb
+++ b/spec/exchanges/dydx_perpetual/integration/market_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe 'DydxPerpetual integration specs' do
   let(:client) { Cryptoexchange::Client.new }
   let(:market) { 'dydx_perpetual' }
-  let(:pbtc_usdc_pair) { Cryptoexchange::Models::MarketPair.new(base: 'PBTC', target: 'USDC', market: market, inst_id: "PBTC-USDC") }
+  let(:btc_usdc_pair) { Cryptoexchange::Models::MarketPair.new(base: 'BTC', target: 'USDC', market: market, inst_id: "PBTC-USDC", contract_interval: "perpetual") }
 
   it 'fetch pairs' do
     pairs = client.pairs(market)
@@ -13,24 +13,24 @@ RSpec.describe 'DydxPerpetual integration specs' do
     expect(pair.base).to_not be nil
     expect(pair.target).to_not be nil
     expect(pair.market).to eq market
-    expect(pair.inst_id).to eq "PBTC-USDC"
-    expect(pair.contract_interval).to eq "perpetual"
+    expect(pair.inst_id).to eq btc_usdc_pair.inst_id
+    expect(pair.contract_interval).to eq btc_usdc_pair.contract_interval
   end
 
   it 'give trade url' do
     trade_page_url = client.trade_page_url(market,
-      base: pbtc_usdc_pair.base,
-      target: pbtc_usdc_pair.target,
-      inst_id: "PBTC-USDC",
+      base: btc_usdc_pair.base,
+      target: btc_usdc_pair.target,
+      inst_id: btc_usdc_pair.inst_id,
     )
 
     expect(trade_page_url).to eq "https://trade.dydx.exchange/perpetual/PBTC-USDC"
   end
 
   it 'fetch ticker' do
-    ticker = client.ticker(pbtc_usdc_pair)
+    ticker = client.ticker(btc_usdc_pair)
 
-    expect(ticker.base).to eq 'PBTC'
+    expect(ticker.base).to eq 'BTC'
     expect(ticker.target).to eq 'USDC'
     expect(ticker.market).to eq market
     expect(ticker.last).to be_a Numeric
@@ -43,9 +43,9 @@ RSpec.describe 'DydxPerpetual integration specs' do
   end
 
   it 'fetch order book' do
-    order_book = client.order_book(pbtc_usdc_pair)
+    order_book = client.order_book(btc_usdc_pair)
 
-    expect(order_book.base).to eq 'PBTC'
+    expect(order_book.base).to eq 'BTC'
     expect(order_book.target).to eq 'USDC'
     expect(order_book.market).to eq market
     expect(order_book.asks).to_not be_empty
@@ -60,9 +60,9 @@ RSpec.describe 'DydxPerpetual integration specs' do
   end
 
   it 'fetch contract stat' do
-    contract_stat = client.contract_stat(pbtc_usdc_pair)
+    contract_stat = client.contract_stat(btc_usdc_pair)
 
-    expect(contract_stat.base).to eq 'PBTC'
+    expect(contract_stat.base).to eq 'BTC'
     expect(contract_stat.target).to eq 'USDC'
     expect(contract_stat.market).to eq market
     expect(contract_stat.index).to be nil

--- a/spec/exchanges/dydx_perpetual/integration/market_spec.rb
+++ b/spec/exchanges/dydx_perpetual/integration/market_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe 'DydxPerpetual integration specs' do
   let(:client) { Cryptoexchange::Client.new }
   let(:market) { 'dydx_perpetual' }
-  let(:pbtc_usdc_pair) { Cryptoexchange::Models::MarketPair.new(base: 'PBTC', target: 'USDC', market: market) }
+  let(:pbtc_usdc_pair) { Cryptoexchange::Models::MarketPair.new(base: 'PBTC', target: 'USDC', market: market, inst_id: "PBTC-USDC") }
 
   it 'fetch pairs' do
     pairs = client.pairs(market)
@@ -13,11 +13,18 @@ RSpec.describe 'DydxPerpetual integration specs' do
     expect(pair.base).to_not be nil
     expect(pair.target).to_not be nil
     expect(pair.market).to eq market
+    expect(pair.inst_id).to eq "PBTC-USDC"
+    expect(pair.contract_interval).to eq "perpetual"
   end
 
   it 'give trade url' do
-    trade_page_url = client.trade_page_url market, base: pbtc_usdc_pair.base, target: pbtc_usdc_pair.target
-    expect(trade_page_url).to eq "https://trade.dydx.exchange/perpetual/BTC-USDC"
+    trade_page_url = client.trade_page_url(market,
+      base: pbtc_usdc_pair.base,
+      target: pbtc_usdc_pair.target,
+      inst_id: "PBTC-USDC",
+    )
+
+    expect(trade_page_url).to eq "https://trade.dydx.exchange/perpetual/PBTC-USDC"
   end
 
   it 'fetch ticker' do


### PR DESCRIPTION
- What is the purpose of this Pull Request?
Add missing/required parameters for dydx perpetual market pairs.

- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [x] I have added Specs
- [x] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
