### PR TITLE
fix deversifi market pairs

### DIFF
--- a/lib/cryptoexchange/exchanges/deversifi/services/market.rb
+++ b/lib/cryptoexchange/exchanges/deversifi/services/market.rb
@@ -18,6 +18,7 @@ module Cryptoexchange::Exchanges
         def ticker_url(market_pair)
           base = market_pair.base.upcase
           target = market_pair.target.upcase
+          target = "USD" if market_pair.target.upcase == "USDT"
           "#{Cryptoexchange::Exchanges::Deversifi::Market::API_URL}/bfx/v2/tickers?symbols=t#{base}#{target}"
         end
 

--- a/lib/cryptoexchange/exchanges/deversifi/services/pairs.rb
+++ b/lib/cryptoexchange/exchanges/deversifi/services/pairs.rb
@@ -2,7 +2,7 @@ module Cryptoexchange::Exchanges
   module Deversifi
     module Services
       class Pairs < Cryptoexchange::Services::Pairs
-        PAIRS_URL = "#{Cryptoexchange::Exchanges::Deversifi::Market::API_URL}/v1/trading/r/get/conf"
+        PAIRS_URL = "#{Cryptoexchange::Exchanges::Deversifi::Market::API_URL}/v1/trading/r/last24HoursVolume"
 
         def fetch
           output = super
@@ -10,11 +10,11 @@ module Cryptoexchange::Exchanges
         end
 
         def adapt(output)
-          output["0x"]["exchangeSymbols"].map do |pair|
-            pair = pair[1..-1]
+          output["symbols"].map do |pair, ticker|
+            base, target = pair.split(":")
             Cryptoexchange::Models::MarketPair.new(
-              base: pair[0..2],
-              target: pair[3..5],
+              base: base,
+              target: target,
               market: Deversifi::Market::NAME
             )
           end

--- a/spec/cassettes/vcr_cassettes/deversifi/integration_specs_fetch_pairs.yml
+++ b/spec/cassettes/vcr_cassettes/deversifi/integration_specs_fetch_pairs.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.deversifi.com/v1/trading/r/get/conf
+    uri: https://api.deversifi.com/v1/trading/r/last24HoursVolume
     body:
       encoding: UTF-8
       string: ''
@@ -19,41 +19,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 12 Feb 2020 03:34:16 GMT
+      - Thu, 11 Jun 2020 07:49:29 GMT
       Content-Type:
-      - application/json; charset=utf-8
-      Content-Length:
-      - '3646'
+      - text/html; charset=utf-8
+      Transfer-Encoding:
+      - chunked
       Connection:
       - close
       Set-Cookie:
-      - __cfduid=d5a4526725ef1604e7d74a100fb68eeaf1581478456; expires=Fri, 13-Mar-20
-        03:34:16 GMT; path=/; domain=.deversifi.com; HttpOnly; SameSite=Lax; Secure
-      Access-Control-Allow-Origin:
-      - "*"
-      Etag:
-      - W/"e3e-FA5p8GplBY0pKgiR3x/D51BsF80"
-      Via:
-      - 1.1 google
-      Alt-Svc:
-      - clear
+      - __cfduid=d2ab5b26ab792728a48fbbdd7e83b45e01591861769; expires=Sat, 11-Jul-20
+        07:49:29 GMT; path=/; domain=.deversifi.com; HttpOnly; SameSite=Lax; Secure
+      Vary:
+      - origin,accept-encoding
+      Access-Control-Expose-Headers:
+      - WWW-Authenticate,Server-Authorization
       Cache-Control:
       - max-age=43200
+      Via:
+      - 1.1 google
       Cf-Cache-Status:
-      - HIT
-      Age:
-      - '2014'
-      Accept-Ranges:
-      - bytes
+      - EXPIRED
+      Cf-Request-Id:
+      - 0343f40c7e0000d9a87b877200000001
       Expect-Ct:
       - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
       Server:
       - cloudflare
       Cf-Ray:
-      - 563b817e39c9c10e-KUL
+      - 5a19bc5a6935d9a8-SIN
     body:
       encoding: UTF-8
-      string: '{"0x":{"protocol":"0x","minOrderTime":300,"tokenRegistry":{"ETH":{"decimals":18,"wrapperAddress":"0x50cb61afa3f023d17276dcfb35abf85c710d1cff","minOrderSize":0.02},"USD":{"decimals":6,"wrapperAddress":"0x33d019eb137b853f0cdf555a5d5bd2749135ac31","tokenAddress":"0xdac17f958d2ee523a2206206994597c13d831ec7","minOrderSize":10,"settleSpread":-0.0015},"WBT":{"decimals":8,"wrapperAddress":"0xff33b21bc54aee753891a15e72b7a152a5a782dc","tokenAddress":"0x2260fac5e5542a773aa44fbcfedf7c193bc2c599","minOrderSize":0.0087},"MKR":{"decimals":18,"wrapperAddress":"0x91cf769a44e9d09b8e249886d0de4dbe0aa998f9","tokenAddress":"0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2","minOrderSize":0.08},"DAI":{"decimals":18,"wrapperAddress":"0x2cd04bb68786834f199ce12074da7b8832129fe1","tokenAddress":"0x6b175474e89094c44da98b954eedeac495271d0f","minOrderSize":30},"UDC":{"decimals":6,"wrapperAddress":"0x0890fbf0f9b3d55a7e3f251b6afcbe691a29873b","tokenAddress":"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48","minOrderSize":50},"BAT":{"decimals":18,"wrapperAddress":"0x1c0f17436740bfb92c1070ee86322de890837c6a","tokenAddress":"0x0d8775f648430679a709e98d2b0cb6250d2887ef","minOrderSize":160},"NEC":{"decimals":18,"wrapperAddress":"0xfe65d1ba9a745b131dad1a066861bb5d9ce4767b","tokenAddress":"0xcc80c051057b774cd75067dc48f8987c4eb97a5e","minOrderSize":50},"OMG":{"decimals":18,"wrapperAddress":"0xb5dfdfb2a1c97b329361d261239c51e5f88d035d","tokenAddress":"0xd26114cd6EE289AccF82350c8d8487fedB8A0C07","minOrderSize":20},"ZRX":{"decimals":18,"wrapperAddress":"0x862916f9709e499a94fbca7a8f451eb443d34cad","tokenAddress":"0xe41d2489571d322189246dafa5ebde1f4699f498","minOrderSize":150},"SNT":{"decimals":18,"wrapperAddress":"0x7becbc91db4eb3c5e9a6cda1db391ee648e53779","tokenAddress":"0x744d70fdbe2ba4cf95131626614a1763df805b9e","minOrderSize":2000},"SAN":{"decimals":18,"wrapperAddress":"0x3bc26582062fd8aaa084ee874f6764718c398203","tokenAddress":"0x7c5a0ce9267ed19b22f8cae653f198e3e8daf098","minOrderSize":200},"EDO":{"decimals":18,"wrapperAddress":"0xf6d7e24ff16195a9f5c5df431ef4b3f78c23bf6d","tokenAddress":"0xced4e93198734ddaff8492d525bd258d49eb388e","minOrderSize":60},"FUN":{"decimals":8,"wrapperAddress":"0xbf06ea47c2cc300da596767024f87777d7e41d72","tokenAddress":"0x419d0d8bdd9af5e606ae2232ed285aff190e711b","minOrderSize":12000},"REP":{"decimals":18,"wrapperAddress":"0x5ee39beffcda53c5fa2890c2161247582e2210bb","tokenAddress":"0x1985365e9f78359a9b6ad760e32412f4a445e862","minOrderSize":3},"SPK":{"decimals":18,"wrapperAddress":"0xab0cd9fabcd3487cf22eb0b6a8c3ec1c0e00e643","tokenAddress":"0x42d6622dece394b54999fbd73d108123806f6a18","minOrderSize":4000},"ENJ":{"decimals":18,"wrapperAddress":"0x3f46e145dfcd84230c8e0684efb8bce3f0965fba","tokenAddress":"0xf629cbd94d3791c9250152bd8dfbdf380e2a3b9c","minOrderSize":400},"TKN":{"decimals":8,"wrapperAddress":"0xbf86f56cd4592fed0d7893e12461e19fcbbf0cd5","tokenAddress":"0xaaaf91d9b90df800df4f55c205fd6989c977e73a","minOrderSize":110},"TSD":{"decimals":18,"wrapperAddress":"0x243318cb80785ab92f2c39543cb58958320e64b2","tokenAddress":"0x0000000000085d4780b73119b644ae5ecd22b376","minOrderSize":50},"PNK":{"decimals":18,"wrapperAddress":"0x3ad9539c143b335794bac9211aa5491daeda85bf","tokenAddress":"0x93ed3fbe21207ec2e8f2d3c3de6e058cb73bc04d","minOrderSize":2000}},"feeApiUrl":"https://api.deversifi.com/v1/pub/feeRate/","ethfinexAddress":"0xaf8ae6955d07776ab690e565ba6fbc79b8de3a5d","deversifiAddress":"0xaf8ae6955d07776ab690e565ba6fbc79b8de3a5d","exchangeAddress":"0x080bf510fcbf18b91105470639e9561022937712","exchangeSymbols":["tETHUSD","tPNKETH","tPNKUSD","tMKRETH","tDAIETH","tDAIUSD","tUDCUSD","tMKRDAI","tNECUSD","tNECETH"]}}'
+      string: '{"totalUSDVolume":588726.4657404253,"tokens":{"ETH":{"tokenAmount":2277.438646105068,"USDVolume":560267.7204623692},"DAI":{"tokenAmount":4298.10854994,"USDVolume":4249.329431881099},"DUSK":{"tokenAmount":0,"USDVolume":0},"MKR":{"tokenAmount":3.996,"USDVolume":2637.36},"BTC":{"tokenAmount":1.87011404,"USDVolume":18349.79650130598},"ZRX":{"tokenAmount":18393.76266029,"USDVolume":7259.194338837513},"NEC":{"tokenAmount":2350.6,"USDVolume":234.19321980055673},"USDT":{"tokenAmount":584455.3375266562,"USDVolume":584455.3375266562},"OMG":{"tokenAmount":0,"USDVolume":0},"USDC":{"tokenAmount":0,"USDVolume":0},"FUN":{"tokenAmount":0,"USDVolume":0},"PNK":{"tokenAmount":0,"USDVolume":0}},"symbols":{"ETH:USDT":{"tokenAmount":2265.3381586,"USDVolume":557316.5922486001,"lastUSDPrice":247.15,"lastTrade":"2020-06-11T07:11:16.686Z"},"MKR:ETH":{"tokenAmount":0,"USDVolume":0},"MKR:USDT":{"tokenAmount":1.996,"USDVolume":1317.36,"lastUSDPrice":660,"lastTrade":"2020-06-11T01:14:06.950Z"},"MKR:DAI":{"tokenAmount":2,"USDVolume":1320,"lastUSDPrice":660,"lastTrade":"2020-06-10T23:57:22.183Z"},"PNK:ETH":{"tokenAmount":0,"USDVolume":0},"PNK:USDT":{"tokenAmount":0,"USDVolume":0},"DAI:ETH":{"tokenAmount":2978.10854994,"USDVolume":2929.329431881099,"lastUSDPrice":0.983292292,"lastTrade":"2020-06-10T18:45:43.388Z"},"DAI:USDT":{"tokenAmount":0,"USDVolume":0},"NEC:ETH":{"tokenAmount":197,"USDVolume":21.798781887943527,"lastUSDPrice":0.11065371516722601,"lastTrade":"2020-06-10T23:18:04.960Z"},"NEC:USDT":{"tokenAmount":2153.6,"USDVolume":212.3944379126132,"lastUSDPrice":0.10667,"lastTrade":"2020-06-10T23:51:43.148Z"},"BTC:USDT":{"tokenAmount":1.87011404,"USDVolume":18349.79650130598,"lastUSDPrice":9823.3891254,"lastTrade":"2020-06-11T06:51:39.128Z"},"ZRX:ETH":{"tokenAmount":0,"USDVolume":0},"ZRX:USDT":{"tokenAmount":18393.76266029,"USDVolume":7259.194338837513,"lastUSDPrice":0.3899,"lastTrade":"2020-06-10T20:50:16.587Z"},"DUSK:USDT":{"tokenAmount":0,"USDVolume":0}},"startDate":"2020-06-10T07:48:40.818Z"}'
     http_version: 
-  recorded_at: Wed, 12 Feb 2020 03:34:16 GMT
+  recorded_at: Thu, 11 Jun 2020 07:49:29 GMT
 recorded_with: VCR 4.0.0

--- a/spec/cassettes/vcr_cassettes/deversifi/integration_specs_fetch_ticker.yml
+++ b/spec/cassettes/vcr_cassettes/deversifi/integration_specs_fetch_ticker.yml
@@ -2,58 +2,6 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.deversifi.com/v1/trading/r/last24HoursVolume
-    body:
-      encoding: UTF-8
-      string: ''
-    headers:
-      Connection:
-      - close
-      Host:
-      - api.deversifi.com
-      User-Agent:
-      - http.rb/5.0.0.pre
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 09 Jun 2020 09:18:44 GMT
-      Content-Type:
-      - text/html; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - close
-      Set-Cookie:
-      - __cfduid=db5e6d073a2a180ff671ef85f455434ff1591694324; expires=Thu, 09-Jul-20
-        09:18:44 GMT; path=/; domain=.deversifi.com; HttpOnly; SameSite=Lax; Secure
-      Vary:
-      - origin,accept-encoding
-      Access-Control-Expose-Headers:
-      - WWW-Authenticate,Server-Authorization
-      Cache-Control:
-      - max-age=43200
-      Via:
-      - 1.1 google
-      Cf-Cache-Status:
-      - EXPIRED
-      Cf-Request-Id:
-      - '0339f90a42000073897201b200000001'
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
-      Server:
-      - cloudflare
-      Cf-Ray:
-      - 5a09c456dc397389-JHB
-    body:
-      encoding: UTF-8
-      string: '{"totalUSDVolume":140313.14677434333,"tokens":{"ETH":{"tokenAmount":561.7539645297319,"USDVolume":136921.24821328945},"DAI":{"tokenAmount":8243.01045006,"USDVolume":8294.425326783301},"DUSK":{"tokenAmount":0,"USDVolume":0},"MKR":{"tokenAmount":0.175,"USDVolume":98.175},"BTC":{"tokenAmount":0.00372748,"USDVolume":36.809237748},"ZRX":{"tokenAmount":71.73972307,"USDVolume":22.8659329396262},"NEC":{"tokenAmount":31586.41830275,"USDVolume":3234.0483903662507},"USDT":{"tokenAmount":132018.72144756003,"USDVolume":132018.72144756003},"OMG":{"tokenAmount":0,"USDVolume":0},"USDC":{"tokenAmount":0,"USDVolume":0},"FUN":{"tokenAmount":0,"USDVolume":0},"PNK":{"tokenAmount":0,"USDVolume":0}},"symbols":{"ETH:USDT":{"tokenAmount":528.35111721,"USDVolume":128626.82288650614,"lastUSDPrice":243.12,"lastTrade":"2020-06-09T08:50:37.783Z"},"MKR:ETH":{"tokenAmount":0,"USDVolume":0},"MKR:USDT":{"tokenAmount":0.175,"USDVolume":98.175,"lastUSDPrice":561,"lastTrade":"2020-06-09T07:02:24.661Z"},"MKR:DAI":{"tokenAmount":0,"USDVolume":0},"PNK:ETH":{"tokenAmount":0,"USDVolume":0},"PNK:USDT":{"tokenAmount":0,"USDVolume":0},"DAI:ETH":{"tokenAmount":8243.01045006,"USDVolume":8294.425326783301,"lastUSDPrice":0.994224862,"lastTrade":"2020-06-09T08:53:32.616Z"},"DAI:USDT":{"tokenAmount":0,"USDVolume":0},"NEC:ETH":{"tokenAmount":0,"USDVolume":0},"NEC:USDT":{"tokenAmount":31586.41830275,"USDVolume":3234.0483903662507,"lastUSDPrice":0.10611,"lastTrade":"2020-06-09T06:20:15.721Z"},"BTC:USDT":{"tokenAmount":0.00372748,"USDVolume":36.809237748,"lastUSDPrice":9875.1,"lastTrade":"2020-06-09T00:16:18.190Z"},"ZRX:ETH":{"tokenAmount":0,"USDVolume":0},"ZRX:USDT":{"tokenAmount":71.73972307,"USDVolume":22.8659329396262,"lastUSDPrice":0.3172,"lastTrade":"2020-06-08T21:00:22.329Z"},"DUSK:USDT":{"tokenAmount":0,"USDVolume":0}},"startDate":"2020-06-08T09:18:27.118Z"}'
-    http_version: 
-  recorded_at: Tue, 09 Jun 2020 09:18:44 GMT
-- request:
-    method: get
     uri: https://api.deversifi.com/bfx/v2/tickers?symbols=tETHUSD
     body:
       encoding: UTF-8
@@ -71,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 09 Jun 2020 09:18:44 GMT
+      - Thu, 11 Jun 2020 07:49:30 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -79,10 +27,10 @@ http_interactions:
       Connection:
       - close
       Set-Cookie:
-      - __cfduid=d164f47682c2d791ee2b739724e193cf51591694324; expires=Thu, 09-Jul-20
-        09:18:44 GMT; path=/; domain=.deversifi.com; HttpOnly; SameSite=Lax; Secure
-      Uwebsockets:
-      - v0.17
+      - __cfduid=dab150b1814213a80c0b112a0e2e349cf1591861769; expires=Sat, 11-Jul-20
+        07:49:29 GMT; path=/; domain=.deversifi.com; HttpOnly; SameSite=Lax; Secure
+      - __cfduid=db162c1efc02d3269e6a36cf950369a851591861770; expires=Sat, 11-Jul-20
+        07:49:30 GMT; path=/; domain=.bitfinex.com; HttpOnly; SameSite=Lax
       X-Frame-Options:
       - sameorigin
       X-Xss-Protection:
@@ -98,24 +46,20 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=31536000; includeSubdomains;
       Cf-Request-Id:
-      - '0339f90c550000738d35893200000001'
+      - 0343f40ed70000017a059db200000001
       Expect-Ct:
       - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
       Via:
       - 1.1 google
-      Cache-Control:
-      - max-age=43200
       Cf-Cache-Status:
-      - HIT
-      Age:
-      - '3848'
+      - BYPASS
       Server:
       - cloudflare
       Cf-Ray:
-      - 5a09c45a2aea738d-JHB
+      - 5a19bc5e2ba1017a-SIN
     body:
       encoding: UTF-8
-      string: '[["tETHUSD",243.73,597.17391604,243.76,1508.64367834,-0.45,-0.0018,243.7,51772.88926162,249.97,238.18]]'
+      string: '[["tETHUSD",246.71,851.22279976,246.72,880.2045623,3.0530679,0.0125,246.7230679,86007.55404605,250.53480726,241.57]]'
     http_version: 
-  recorded_at: Tue, 09 Jun 2020 09:18:44 GMT
+  recorded_at: Thu, 11 Jun 2020 07:49:30 GMT
 recorded_with: VCR 4.0.0


### PR DESCRIPTION
- What is the purpose of this Pull Request?
- What is the related issue for this Pull Request (if this PR fixes issue, prepend with "Fixes" or "Closes")?
- [ ] I have added Specs
- [ ] (If implementing Market Ticker) I have verified that the `volume` refers to BASE
- [ ] (If implementing Market Ticker) I have verified that the `base` and `target` is assigned correctly
- [ ] I have implemented the `trade_page_url` method that links to the exchange page with the `base` and `target` passed in. If not available, enter the root domain of the exchange website.
- [ ] I have verified at least **ONE** ticker volume matches volume shown on the trading page (use script below)

```
client = Cryptoexchange::Client.new
pairs = client.pairs 'exchange_name'
tickers = pairs.map do |p| client.ticker p end
sorted_tickers = tickers.sort_by do |t| t.volume end.reverse
```
